### PR TITLE
New release v1.1.0 of OCI Ansible Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2018-09-06
+
+### Added
+- Support for following services:
+  - [Oracle Container Engine for Kubernetes Service (OKE)](https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm)
+  - [Oracle Domain Name System (DNS) Service](https://docs.cloud.oracle.com/iaas/Content/DNS/Concepts/dnszonemanagement.htm)
+- Modules to manage [IAM dynamic groups](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingdynamicgroups.htm?tocpath=Services|IAM|_____12)
+- Support for [instance principal authorization](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm)
+- Support wait options in load balancer service modules
+- Support filtering of resources in facts modules using `display_name` or `name`
+- Support to automatically redirect IAM operations to home region of tenancy
+- Support for [Fault Domains](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/regions.htm#fault)
+- Added samples to demonstrate:
+  - the use of instance principal authorization
+  - setting up prerequisites for OKE, provisioning OKE cluster and deploying a sample application
+  - provisioning of a load balancer component in the Secure MongoDB deployment solution
+
+### Changed
+- Minimum supported OCI Python SDK to 2.0.2
+
 ## [1.0.0] - 2018-07-09
 
 ### Added
@@ -17,5 +37,4 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   - Identity and Access Management
 - Provides a dynamic inventory script `oci_inventory.py` that helps you fetch the latest set of OCI compute instances and make them available for your playbooks to be executed upon.
 - Includes a catalog of Oracle Cloud Infrastructure Ansible module samples, in the [samples](samples) directory, that illustrate using the modules to carry out common infrastructure provisioning and configuration tasks. 
-
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Oracle Cloud Infrastructure Ansible Modules provide an easy way to create and pr
 **Services supported**
 - Block Volume
 - Compute
+- Container Engine for Kubernetes Service (OKE)
+- Database
+- Domain Name System (DNS)
 - IAM
 - Load Balancing
 - Networking
 - Object Storage
-- Database
 
 The OCI Ansible modules are built using the [Oracle Cloud Infrastructure Python SDK](https://docs.us-phoenix-1.oraclecloud.com/Content/API/SDKDocs/pythonsdk.htm). The OCI Ansible modules honour the [SDK configuration](https://docs.us-phoenix-1.oraclecloud.com/Content/ToolsConfig.htm) when available.
 
@@ -24,6 +26,7 @@ See the [getting started guide](https://docs.cloud.oracle.com/iaas/Content/API/S
 This project includes a catalog of Oracle Cloud Infrastructure Ansible module samples that illustrate using the modules to carry out common infrastructure provisioning and configuration tasks in the `samples` directory. The samples are organized in groups associated with Oracle Cloud Infrastructure services:
 - Block Volume
 - Compute
+- Container Engine
 - Database
 - IAM
 - Load Balancing

--- a/docs/dynamic-inventory-script.md
+++ b/docs/dynamic-inventory-script.md
@@ -53,7 +53,7 @@ The `oci_inventory.py` script also accepts the following environment variables:
 | OCI_TENANCY | Specifies the OCID of the tenancy to use to fetch the inventory |
 | OCI_REGION |  Specifies the OCI Region to use to fetch the inventory |
 | OCI_USER_KEY_PASS_PHRASE | Specifies the passphrase of the key (if encrypted), to use to fetch the inventory. |
-| OCI_CACHE_DIR | Specifies the directory where cache files of the inventory script will reside. A file named "ansible-oci.cache" will be written to this directory. |
+| OCI_CACHE_DIR | Specifies the directory where cache files of the inventory script will reside. A file named "ansible-oci.cache" will be written to this directory. It is recommended that the directory pointed to by this environment variable be read-able and write-able (unix file permissions 600) only by the user running the inventory script. |
 | OCI_CACHE_MAX_AGE |  The number of seconds a cache file is considered valid. To disable caching and get the latest inventory from OCI, set this value to 0. |
 | OCI_HOSTNAME_FORMAT | Host naming format to use in the generated inventory. Use 'fqdn' to list hosts using the instance's Fully Qualified Domain Name (FQDN). Use 'public_ip' to list hosts using public IP address. Use 'private_ip' to list hosts using private IP address.|
 
@@ -172,4 +172,4 @@ The script would then return the following variables for the specified host:
   - GetVCN
   - GetVNIC
   - GetInstance
-- The default `OCI_HOSTNAME_FORMAT` is "public_ip" and so the generated inventory would only contain compute instances with public IP. This is useful when your ansible controller node is outside the OCI VCN (as Ansible can only reach instances with public IPs). However if you are running Ansible in a compute instance within your OCI VCN that has access to all subnets within yuor VCN and can reach compute instances with private ips, set `OCI_HOSTNAME_FORMAT` to "private_ip" to fetch nodes with private IPs as well.
+- The default `OCI_HOSTNAME_FORMAT` is "public_ip" and so the generated inventory would only contain compute instances with a public IP. This is useful when your ansible controller node is outside the OCI VCN (as Ansible can only reach instances with public IPs). However if you are running Ansible in a compute instance within your OCI VCN that has access to all subnets within yuor VCN and can reach compute instances with private ips, set `OCI_HOSTNAME_FORMAT` to "private_ip" to fetch nodes with private IPs as well.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -37,7 +37,7 @@ $ ansible-doc oci_bucket_facts
 **3. How do I enable `debug` mode for the OCI Ansible Cloud Modules?**
 
 -  Set the `log_requests` variable in your ~/.oci/config to `True` to enable Request logging in the OCI python SDK as described in https://github.com/oracle/oci-python-sdk/blob/master/docs/logging.rst
--  Export an environment variable to enable DEBUG mode for our Ansible modules
+-  Export an environment variable named `LOG_LEVEL` with the value `DEBUG` to enable DEBUG mode for the OCI Ansible modules
 ```sh
 $ export LOG_LEVEL="DEBUG"
 ```
@@ -46,7 +46,9 @@ All subsequent debug messages from an ansible playbook execution using the OCI A
 ```sh
 $ ansible-playbook ....
 ```
-would go to `/tmp/oci_ansible_module.log` (the default logging location for our modules).
+would go to `/tmp/oci_ansible_module.log` (the default logging location for the OCI Ansible modules).
+
+OCI Ansible Cloud Modules uses standard Python logging facilities for logging. To configure log messages, export an environment variable `LOG_CONFIG` pointing to a YAML file (as discussed in https://docs.python.org/3/howto/logging.html#configuring-logging) containing your logging configuration information Optionally, export an environment variable `LOG_PATH` to to your custom path where the logs must be placed.
 
 **4. In a Mac OSX controller node, I am seeing "ImportError: No module named yaml" when executing a playbook, in spite of observing that I have ansible and its requirements including PyYAML installed in my python setup.**
 
@@ -79,12 +81,16 @@ The documentation fragments shipped by an ansible module that is delivered by an
 
 **6. How do I use the `oci_inventory.py` dynamic inventory script?**
 
-In addition to the OCI Ansible Cloud Modules, this project also provide a [dynamic inventory](https://docs.ansible.com/ansible/latest/user_guide/intro_dynamic_inventory.html) script for OCI that you can use to construct a dynamic inventory of your OCI compute instances. For more details, see our how-to documentation at [using the dynamic inventory script](dynamic-inventory-script.md).
+In addition to the OCI Ansible Cloud Modules, this project also provide a [dynamic inventory](https://docs.ansible.com/ansible/latest/user_guide/intro_dynamic_inventory.html) script for OCI that you can use to construct a dynamic inventory of your OCI compute instances. For more details, see our how-to documentation at [using the dynamic inventory script](https://oracle-cloud-infrastructure-ansible-modules.readthedocs.io/en/latest/dynamic-inventory-script.html).
 
 **7. Any security guidelines or best practices?**
 
-The OCI Ansible Cloud Modules uses the authentication information specified in the standard OCI SDK configuration file (https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/installation.html#configuring-the-sdk) while creating and configuring OCI resources.
+1. The OCI Ansible Cloud Modules uses the authentication information specified in the standard OCI SDK configuration file (https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/installation.html#configuring-the-sdk) while creating and configuring OCI resources.
 
 > *Caution*: IAM credentials referenced in the OCI SDK configuration file, grants access to resources. It is important to secure these credentials to prevent unauthorized access to Oracle Cloud Infrastructure resources. Follow the guidelines in https://docs.us-phoenix-1.oraclecloud.com/Content/Security/Reference/iam_security.htm#IAMCredentials to secure the IAM credentials in the controller node where you run ansible playbooks that uses these modules.
 
 The OCI Ansible Cloud Modules allows the authentication information specified in the OCI SDK configuration file to be overridden using module options and environment variables. Please refer to the ansible module documentation of the OCI Ansible Cloud Modules for more details. Oracle recommends the use of OCI SDK configuration file to specify authentication information. Use the "profiles" feature in the OCI SDK configuration file to support different users. The use of environment variables and ansible module options to override Authentication information must be avoided in production scenarios. While distributing roles that use the OCI Ansible Cloud Modules, ensure that no IAM credentials are included with the roles.
+
+2. Logging of OCI Ansible Cloud Modules may be configured using the a file through the `LOG_CONFIG` environment variable, as discussed in FAQ #3 above. It is recommended that the file pointed to by `LOG_CONFIG` environment variable be only access-able (Unix file permissions 400 or 600) by the user running the `ansible-playbook` that uses OCI Ansible Cloud Modules.
+
+3. The [OCI Ansible Dynamic Inventory Script](https://oracle-cloud-infrastructure-ansible-modules.readthedocs.io/en/latest/dynamic-inventory-script.html) allows you to override the directory where cache files of the inventory script will reside using the `OCI_CACHE_DIR` environment variable. It is recommended that the directory pointed to by `OCI_CACHE_DIR` environment variable be only read-able and write-able (Unix file permissions 600) by the user running the inventory script.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Project URL: https://github.com/oracle/oci-ansible-modules
 .. toctree::
    :maxdepth: 1
    :caption: OCI Ansible Modules Development HOWTOs
+
    How to Run Developer Tests <tests-howto>
 
 .. toctree::

--- a/docs/modules/list_of_cloud_modules.rst
+++ b/docs/modules/list_of_cloud_modules.rst
@@ -1,116 +1,143 @@
+.. _cloud_modules:
+
 Cloud modules
 `````````````
 
-.. toctree:: :maxdepth: 1
+
+
+
+.. _oracle_cloud_modules:
 
 Oracle
 ------
 
-.. toctree:: :maxdepth: 1
 
-    oci_ad_facts Retrieve details of availability domains in your tenancy <oci_ad_facts_module>
-    oci_api_key Upload and delete API signing key of a user in OCI <oci_api_key_module>
-    oci_api_key_facts Retrieve details of api signing keys for a specified user <oci_api_key_facts_module>
-    oci_backup Create and Delete a Database Backup in OCI Database Cloud Service. <oci_backup_module>
-    oci_backup_facts Fetches details of one or more Database Backups <oci_backup_facts_module>
-    oci_boot_volume Manage boot volumes in OCI Block Volume service <oci_boot_volume_module>
-    oci_boot_volume_attachment Attach or detach a boot volume in OCI Block Volume service <oci_boot_volume_attachment_module>
-    oci_boot_volume_attachment_facts Retrieve facts of boot volume attachments in OCI <oci_boot_volume_attachment_facts_module>
-    oci_boot_volume_facts Retrieve facts of boot volumes in OCI Block Volume service <oci_boot_volume_facts_module>
-    oci_bucket Create,update and delete oci buckets <oci_bucket_module>
-    oci_bucket_facts Fetches details of a bucket or all available buckets within a namespace <oci_bucket_facts_module>
-    oci_compartment Manage compartments in OCI <oci_compartment_module>
-    oci_compartment_facts Retrieve details of a compartment or all the compartments in a tenancy in OCI <oci_compartment_facts_module>
-    oci_customer_secret_key Create, update and delete Customer Secret Keys for the specified user in OCI. <oci_customer_secret_key_module>
-    oci_customer_secret_key_facts Retrieve details of customer secret keys for a specified user <oci_customer_secret_key_facts_module>
-    oci_data_guard_association Create a Data Guard Association and, perform various Database role transitions of Databases associated with a Data Guard Association in OCI Database Cloud Service. <oci_data_guard_association_module>
-    oci_data_guard_association_facts Fetches details of an OCI Data Guard Association <oci_data_guard_association_facts_module>
-    oci_database Restore or Update a Database in OCI Database Cloud Service. <oci_database_module>
-    oci_database_facts Fetches details of one or more Databases <oci_database_facts_module>
-    oci_db_home Create,update and delete a DB Home in OCI Database Cloud Service. <oci_db_home_module>
-    oci_db_home_facts Fetches details of one or more OCI DB Homes <oci_db_home_facts_module>
-    oci_db_home_patch_facts Fetches details of one or more  DB Home Patches <oci_db_home_patch_facts_module>
-    oci_db_home_patch_history_entry_facts Fetches details of one or more DB Home Patch History Entries <oci_db_home_patch_history_entry_facts_module>
-    oci_db_node Control the lifecycle of a DB Node in OCI's Database Cloud Service. <oci_db_node_module>
-    oci_db_node_facts Fetches details of one or more OCI DB Nodes <oci_db_node_facts_module>
-    oci_db_system Launch,update and terminate a DB System in OCI Database Cloud Service. <oci_db_system_module>
-    oci_db_system_facts Fetches details of the OCI DB System <oci_db_system_facts_module>
-    oci_db_system_patch_facts Fetches details of one or more DB System Patches <oci_db_system_patch_facts_module>
-    oci_db_system_patch_history_entry_facts Fetches details of one or more DB System Patch History Entries <oci_db_system_patch_history_entry_facts_module>
-    oci_db_system_shape_facts Fetches details of all DB System Shapes <oci_db_system_shape_facts_module>
-    oci_db_version_facts Fetches details of all DB Versions <oci_db_version_facts_module>
-    oci_dhcp_options Create,update and delete OCI Dhcp Options <oci_dhcp_options_module>
-    oci_dhcp_options_facts Fetches details of a specific Dhcp Options or a list of Dhcp Optionss in the specified VCN and compartment <oci_dhcp_options_facts_module>
-    oci_group Create,update and delete OCI user groups and specified user associations <oci_group_module>
-    oci_group_facts Fetches details of all the OCI groups of a tenancy and the users associated <oci_group_facts_module>
-    oci_image Create, import, update and delete OCI Compute images <oci_image_module>
-    oci_image_facts Retrieve details about one or more Compute images in OCI Compute Service <oci_image_facts_module>
-    oci_instance Launch, terminate and control the lifecycle of OCI Compute instances <oci_instance_module>
-    oci_instance_facts Retrieve details about one or more Compute instances in OCI Compute Service <oci_instance_facts_module>
-    oci_internet_gateway Create,update and delete OCI Internet Gateway <oci_internet_gateway_module>
-    oci_internet_gateway_facts Fetches details of the OCI Internet Gateway under a Virtual Cloud Network <oci_internet_gateway_facts_module>
-    oci_load_balancer Create, update and delete load balancers in OCI Load Balancing Service <oci_load_balancer_module>
-    oci_load_balancer_backend Add, modify and remove a backend from a load balancer in OCI Load Balancing Service <oci_load_balancer_backend_module>
-    oci_load_balancer_backend_facts Fetch details of all Backends in a load balancer backend set of a load balancer <oci_load_balancer_backend_facts_module>
-    oci_load_balancer_backend_health_facts Fetch details of Backend Health in a load balancer backend set of a load balancer <oci_load_balancer_backend_health_facts_module>
-    oci_load_balancer_backend_set Create, update and delete a backend set of a load balancer. <oci_load_balancer_backend_set_module>
-    oci_load_balancer_backend_set_facts Fetches details of backend set(s) that are associated with a load balancer <oci_load_balancer_backend_set_facts_module>
-    oci_load_balancer_backend_set_health_facts Fetch details of a Backend Set's health in a load balancer <oci_load_balancer_backend_set_health_facts_module>
-    oci_load_balancer_certificate Add or remove a SSL certificate from a load balancer in OCI Load Balancing Service <oci_load_balancer_certificate_module>
-    oci_load_balancer_certificate_facts Fetch details of all certificates associated with a load balancer <oci_load_balancer_certificate_facts_module>
-    oci_load_balancer_facts Fetches details of the OCI Load Balancer <oci_load_balancer_facts_module>
-    oci_load_balancer_health_checker Update health checker details of a backend set in a load balancer in OCI Load Balancing Service <oci_load_balancer_health_checker_module>
-    oci_load_balancer_health_checker_facts Fetch details of all health checker details of load balancer backend sets of a load balancer <oci_load_balancer_health_checker_facts_module>
-    oci_load_balancer_health_facts Fetch details of a Load Balancer Health <oci_load_balancer_health_facts_module>
-    oci_load_balancer_health_summary_facts Fetches the summary health statuses for all load balancers in a given compartment. <oci_load_balancer_health_summary_facts_module>
-    oci_load_balancer_hostname Create, update and delete a hostname resource in the specified load balancer. <oci_load_balancer_hostname_module>
-    oci_load_balancer_hostname_facts Fetch details of all hostnames of a load balancer <oci_load_balancer_hostname_facts_module>
-    oci_load_balancer_listener Add, modify and remove a listener from a backend set of a load balancer in OCI Load Balancing Service <oci_load_balancer_listener_module>
-    oci_load_balancer_listener_facts Fetch details of all listeners of a load balancer <oci_load_balancer_listener_facts_module>
-    oci_load_balancer_path_route_set Create, update and delete a path route set of a load balancer. <oci_load_balancer_path_route_set_module>
-    oci_load_balancer_path_route_set_facts Fetches details of path route set(s) that are associated with a load balancer <oci_load_balancer_path_route_set_facts_module>
-    oci_load_balancer_policy_facts Fetches details of all load balancer policies supported in the OCI Load Balancer Service. <oci_load_balancer_policy_facts_module>
-    oci_load_balancer_protocol_facts Fetches details of all the traffic protocols supported in the OCI Load Balancer Service. <oci_load_balancer_protocol_facts_module>
-    oci_load_balancer_shape_facts Fetches details of all valid load balancer shapes supported in the OCI Load Balancer Service. <oci_load_balancer_shape_facts_module>
-    oci_load_balancer_work_request_facts Fetch details of all work_requests of a load balancer <oci_load_balancer_work_request_facts_module>
-    oci_object Manage objects in OCI Object Storage Service <oci_object_module>
-    oci_object_facts Retrieve details of an object or all the objects in a specific namespace and bucket in OCI Object                     Storage Service <oci_object_facts_module>
-    oci_policy Manage policies in OCI Identity and Access Management <oci_policy_module>
-    oci_policy_facts Retrieve details about a policy or policies attached to a compartment or tenancy in OCI Identity and Access Management service <oci_policy_facts_module>
-    oci_private_ip Manage private IPs in OCI <oci_private_ip_module>
-    oci_private_ip_facts Retrieve facts of private IPs <oci_private_ip_facts_module>
-    oci_public_ip Manage public IPs in OCI <oci_public_ip_module>
-    oci_public_ip_facts Retrieve facts of public IPs <oci_public_ip_facts_module>
-    oci_region_facts Retrieve details about all Regions offered by Oracle Cloud Infrastructure <oci_region_facts_module>
-    oci_region_subscription_facts Retrieve details of the region subscriptions for the specified tenancy. <oci_region_subscription_facts_module>
-    oci_route_table Create,update and delete OCI Route Table <oci_route_table_module>
-    oci_route_table_facts Fetches details of a specific Route Table or a list of Route tables in the specified VCN and compartment <oci_route_table_facts_module>
-    oci_security_list Create,update and delete OCI Security List <oci_security_list_module>
-    oci_security_list_facts Fetches details of a specific Security List or a list of Security Lists in the specified VCN and compartment <oci_security_list_facts_module>
-    oci_shape_facts Retrieve details about shapes that can be used to launch instances in OCI Compute Service <oci_shape_facts_module>
-    oci_subnet Manage subnets in a VCN in OCI <oci_subnet_module>
-    oci_subnet_facts Retrieve facts of subnets <oci_subnet_facts_module>
-    oci_swift_password Create, update and delete Swift (OpenStack Object Store Service) passwords in OCI <oci_swift_password_module>
-    oci_swift_password_facts Retrieve details of swift passwords for a specified user <oci_swift_password_facts_module>
-    oci_tag Create, retire and reactivate tag key definitions in OCI <oci_tag_module>
-    oci_tag_facts Retrieve details of tag key definitions for a specified tag namespace in OCI <oci_tag_facts_module>
-    oci_tag_namespace Create, retire and reactivate tag namespaces in OCI <oci_tag_namespace_module>
-    oci_tag_namespace_facts Retrieve details of tag namespaces for a specified compartment or tenancy in OCI <oci_tag_namespace_facts_module>
-    oci_tenancy_facts Retrieve details about a tenancy in Oracle Cloud Infrastructure <oci_tenancy_facts_module>
-    oci_user Create,update and delete OCI user with specified group associations <oci_user_module>
-    oci_user_facts Fetches details of all the OCI users of a tenancy and their group memberships <oci_user_facts_module>
-    oci_vcn Manage Virtual Cloud Networks(VCN) in OCI <oci_vcn_module>
-    oci_vcn_facts Retrieve facts of Virtual Cloud Networks(VCNs) <oci_vcn_facts_module>
-    oci_vnic Update a VNIC <oci_vnic_module>
-    oci_vnic_attachment Create a secondary VNIC and attach it to a compute instance, detach or delete VNIC attachments from a compute instance. <oci_vnic_attachment_module>
-    oci_vnic_attachment_facts Retrieve details about one or more VNIC attachments in the specified compartment <oci_vnic_attachment_facts_module>
-    oci_vnic_facts Retrieve details about a specific VNIC <oci_vnic_facts_module>
-    oci_volume Manage volumes in OCI Block Volume service <oci_volume_module>
-    oci_volume_attachment Attach or detach a volume in OCI Block Volume service <oci_volume_attachment_module>
-    oci_volume_attachment_facts Retrieve facts of volume attachments in OCI <oci_volume_attachment_facts_module>
-    oci_volume_backup Manage volume backups in OCI Block Volume service <oci_volume_backup_module>
-    oci_volume_backup_facts Retrieve facts of volume backups in OCI Block Volume service <oci_volume_backup_facts_module>
-    oci_volume_facts Retrieve facts of volumes in OCI Block Volume service <oci_volume_facts_module>
+
+  * :ref:`oci_ad_facts_module` 
+  * :ref:`oci_api_key_module` 
+  * :ref:`oci_api_key_facts_module` 
+  * :ref:`oci_backup_module` 
+  * :ref:`oci_backup_facts_module` 
+  * :ref:`oci_boot_volume_module` 
+  * :ref:`oci_boot_volume_attachment_module` 
+  * :ref:`oci_boot_volume_attachment_facts_module` 
+  * :ref:`oci_boot_volume_facts_module` 
+  * :ref:`oci_bucket_module` 
+  * :ref:`oci_bucket_facts_module` 
+  * :ref:`oci_cluster_module` 
+  * :ref:`oci_cluster_facts_module` 
+  * :ref:`oci_cluster_options_facts_module` 
+  * :ref:`oci_compartment_module` 
+  * :ref:`oci_compartment_facts_module` 
+  * :ref:`oci_customer_secret_key_module` 
+  * :ref:`oci_customer_secret_key_facts_module` 
+  * :ref:`oci_data_guard_association_module` 
+  * :ref:`oci_data_guard_association_facts_module` 
+  * :ref:`oci_database_module` 
+  * :ref:`oci_database_facts_module` 
+  * :ref:`oci_db_home_module` 
+  * :ref:`oci_db_home_facts_module` 
+  * :ref:`oci_db_home_patch_facts_module` 
+  * :ref:`oci_db_home_patch_history_entry_facts_module` 
+  * :ref:`oci_db_node_module` 
+  * :ref:`oci_db_node_facts_module` 
+  * :ref:`oci_db_system_module` 
+  * :ref:`oci_db_system_facts_module` 
+  * :ref:`oci_db_system_patch_facts_module` 
+  * :ref:`oci_db_system_patch_history_entry_facts_module` 
+  * :ref:`oci_db_system_shape_facts_module` 
+  * :ref:`oci_db_version_facts_module` 
+  * :ref:`oci_dhcp_options_module` 
+  * :ref:`oci_dhcp_options_facts_module` 
+  * :ref:`oci_domain_records_module` 
+  * :ref:`oci_domain_records_facts_module` 
+  * :ref:`oci_dynamic_group_module` 
+  * :ref:`oci_dynamic_group_facts_module` 
+  * :ref:`oci_fault_domain_facts_module` 
+  * :ref:`oci_group_module` 
+  * :ref:`oci_group_facts_module` 
+  * :ref:`oci_image_module` 
+  * :ref:`oci_image_facts_module` 
+  * :ref:`oci_instance_module` 
+  * :ref:`oci_instance_facts_module` 
+  * :ref:`oci_internet_gateway_module` 
+  * :ref:`oci_internet_gateway_facts_module` 
+  * :ref:`oci_kubeconfig_module` 
+  * :ref:`oci_load_balancer_module` 
+  * :ref:`oci_load_balancer_backend_module` 
+  * :ref:`oci_load_balancer_backend_facts_module` 
+  * :ref:`oci_load_balancer_backend_health_facts_module` 
+  * :ref:`oci_load_balancer_backend_set_module` 
+  * :ref:`oci_load_balancer_backend_set_facts_module` 
+  * :ref:`oci_load_balancer_backend_set_health_facts_module` 
+  * :ref:`oci_load_balancer_certificate_module` 
+  * :ref:`oci_load_balancer_certificate_facts_module` 
+  * :ref:`oci_load_balancer_facts_module` 
+  * :ref:`oci_load_balancer_health_checker_module` 
+  * :ref:`oci_load_balancer_health_checker_facts_module` 
+  * :ref:`oci_load_balancer_health_facts_module` 
+  * :ref:`oci_load_balancer_health_summary_facts_module` 
+  * :ref:`oci_load_balancer_hostname_module` 
+  * :ref:`oci_load_balancer_hostname_facts_module` 
+  * :ref:`oci_load_balancer_listener_module` 
+  * :ref:`oci_load_balancer_listener_facts_module` 
+  * :ref:`oci_load_balancer_path_route_set_module` 
+  * :ref:`oci_load_balancer_path_route_set_facts_module` 
+  * :ref:`oci_load_balancer_policy_facts_module` 
+  * :ref:`oci_load_balancer_protocol_facts_module` 
+  * :ref:`oci_load_balancer_shape_facts_module` 
+  * :ref:`oci_load_balancer_work_request_facts_module` 
+  * :ref:`oci_node_pool_module` 
+  * :ref:`oci_node_pool_facts_module` 
+  * :ref:`oci_node_pool_options_facts_module` 
+  * :ref:`oci_object_module` 
+  * :ref:`oci_object_facts_module` 
+  * :ref:`oci_oke_work_request_module` 
+  * :ref:`oci_oke_work_request_error_facts_module` 
+  * :ref:`oci_oke_work_request_facts_module` 
+  * :ref:`oci_oke_work_request_log_entry_facts_module` 
+  * :ref:`oci_policy_module` 
+  * :ref:`oci_policy_facts_module` 
+  * :ref:`oci_private_ip_module` 
+  * :ref:`oci_private_ip_facts_module` 
+  * :ref:`oci_public_ip_module` 
+  * :ref:`oci_public_ip_facts_module` 
+  * :ref:`oci_region_facts_module` 
+  * :ref:`oci_region_subscription_facts_module` 
+  * :ref:`oci_route_table_module` 
+  * :ref:`oci_route_table_facts_module` 
+  * :ref:`oci_rrset_module` 
+  * :ref:`oci_rrset_facts_module` 
+  * :ref:`oci_security_list_module` 
+  * :ref:`oci_security_list_facts_module` 
+  * :ref:`oci_shape_facts_module` 
+  * :ref:`oci_subnet_module` 
+  * :ref:`oci_subnet_facts_module` 
+  * :ref:`oci_swift_password_module` 
+  * :ref:`oci_swift_password_facts_module` 
+  * :ref:`oci_tag_module` 
+  * :ref:`oci_tag_facts_module` 
+  * :ref:`oci_tag_namespace_module` 
+  * :ref:`oci_tag_namespace_facts_module` 
+  * :ref:`oci_tenancy_facts_module` 
+  * :ref:`oci_user_module` 
+  * :ref:`oci_user_facts_module` 
+  * :ref:`oci_vcn_module` 
+  * :ref:`oci_vcn_facts_module` 
+  * :ref:`oci_vnic_module` 
+  * :ref:`oci_vnic_attachment_module` 
+  * :ref:`oci_vnic_attachment_facts_module` 
+  * :ref:`oci_vnic_facts_module` 
+  * :ref:`oci_volume_module` 
+  * :ref:`oci_volume_attachment_module` 
+  * :ref:`oci_volume_attachment_facts_module` 
+  * :ref:`oci_volume_backup_module` 
+  * :ref:`oci_volume_backup_facts_module` 
+  * :ref:`oci_volume_facts_module` 
+  * :ref:`oci_zone_module` 
+  * :ref:`oci_zone_facts_module` 
+  * :ref:`oci_zone_records_module` 
+  * :ref:`oci_zone_records_facts_module` 
 
 
 .. note::

--- a/docs/modules/oci_ad_facts_module.rst
+++ b/docs/modules/oci_ad_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_ad_facts:
+:source: cloud/oracle/oci_ad_facts.py
+
+:orphan:
+
+.. _oci_ad_facts_module:
 
 
 oci_ad_facts - Retrieve details of availability domains in your tenancy
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,207 +17,137 @@ oci_ad_facts - Retrieve details of availability domains in your tenancy
 
 Synopsis
 --------
-
-
-* This module retrieves details of all availability domains in your tenancy.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details of all availability domains in your tenancy.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy).</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    - name: Get details of all the availability domains in your tenancy
-      oci_ad_facts:
-        compartment_id: 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...vm62xq'
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>availability_domains</td>
-    <td>
-        <div>Information about one or more availability domains in your tenancy</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>{'availability_domains': [{'name': 'IwGV:US-ASHBURN-AD-1', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq'}, {'name': 'IwGV:US-ASHBURN-AD-2', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq'}, {'name': 'IwGV:US-ASHBURN-AD-3', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq'}]}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name of the Availability Domain.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BnQb:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy).</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -226,19 +157,94 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Sivakumar Thyagarajan (@sivakumart)
+.. code-block:: yaml+jinja
+
+    
+    - name: Get details of all the availability domains in your tenancy
+      oci_ad_facts:
+        compartment_id: 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...vm62xq'
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>availability_domains</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more availability domains in your tenancy</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'availability_domains': [{'name': 'IwGV:US-ASHBURN-AD-1', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq'}, {'name': 'IwGV:US-ASHBURN-AD-2', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq'}, {'name': 'IwGV:US-ASHBURN-AD-3', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq'}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the Availability Domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_ad_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_api_key_facts_module.rst
+++ b/docs/modules/oci_api_key_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_api_key_facts:
+:source: cloud/oracle/oci_api_key_facts.py
+
+:orphan:
+
+.. _oci_api_key_facts_module:
 
 
 oci_api_key_facts - Retrieve details of api signing keys for a specified user
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,160 @@ oci_api_key_facts - Retrieve details of api signing keys for a specified user
 
 Synopsis
 --------
-
-
-* This module retrieves details of api signing keys of a specified user. Note that this is not the SSH key for accessing compute instances. This is the credential for securing requests to the Oracle Cloud Infrastructure REST API.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details of api signing keys of a specified user. Note that this is not the SSH key for accessing compute instances. This is the credential for securing requests to the Oracle Cloud Infrastructure REST API.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_key_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the api signing key. Required when facts about a specific api signing key for the specified user needs to be obtained.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>user_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user whose API signing keys must be retrieved</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_key_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the api signing key. Required when facts about a specific api signing key for the specified user needs to be obtained.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>user_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user whose API signing keys must be retrieved</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the api signing keys of the specified user
@@ -165,135 +183,137 @@ Examples
         id: "ocid1.credential.oc1..xxxxxEXAMPLExxxxx"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>api_keys</td>
-    <td>
-        <div>Information about one or more api signing keys of the specified user</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>{'api_keys': [{'lifecycle_state': 'ACTIVE', 'key_value': '-----BEGIN PUBLIC KEY-----...urt/fN8jNz2nZwIDAQAB-----END PUBLIC KEY-----', 'inactive_status': None, 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'fingerprint': '08:07:a6:7d:06:b4:73:91:e9:2c:da:42:c8:cb:df:02', 'key_id': 'ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx/ocid1.user.oc1..xxxxxEXAMPLExxxxx/08:07:a6:7d:06:b4:73:91:e9:2c:da', 'time_created': '2018-01-08T09:33:59.705000+00:00'}]}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>key_value</td>
-        <td>
-            <div>The key's value.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>-----BEGIN PUBLIC KEY-----...urt/fN8jNz2nZwIDAQAB-----END PUBLIC KEY-----</td>
-        </tr>
-
-        <tr>
-        <td>inactive_status</td>
-        <td>
-            <div>The detailed status of INACTIVE lifecycleState.</div>
-        </td>
-        <td align=center>Only when the I(lifecycle_state) is 'INACTIVE'</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>user_id</td>
-        <td>
-            <div>Date and time the ApiKey object was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>fingerprint</td>
-        <td>
-            <div>The key's fingerprint</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>12:34:56:78:90:ab:cd:ef:12:34:56:78:90:ab:cd:ef</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_status</td>
-        <td>
-            <div>The API key's current state.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>key_id</td>
-        <td>
-            <div>The OCID of the API signing key. An Oracle-assigned identifier for the key, in this format TENANCY_OCID/USER_OCID/KEY_FINGERPRINT.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx/ocid1.user.oc1..xxxxxEXAMPLExxxxx/08:07:a6:7d:06:b4:73:91:e9:2c:da</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>api_keys</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more api signing keys of the specified user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'api_keys': [{'lifecycle_state': 'ACTIVE', 'key_value': '-----BEGIN PUBLIC KEY-----...urt/fN8jNz2nZwIDAQAB-----END PUBLIC KEY-----', 'inactive_status': None, 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'fingerprint': '08:07:a6:7d:06:b4:73:91:e9:2c:da:42:c8:cb:df:02', 'key_id': 'ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx/ocid1.user.oc1..xxxxxEXAMPLExxxxx/08:07:a6:7d:06:b4:73:91:e9:2c:da', 'time_created': '2018-01-08T09:33:59.705000+00:00'}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>key_value</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The key's value.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">-----BEGIN PUBLIC KEY-----...urt/fN8jNz2nZwIDAQAB-----END PUBLIC KEY-----</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>Only when the <em>lifecycle_state</em> is 'INACTIVE'</td>
+                <td>
+                                            <div>The detailed status of INACTIVE lifecycleState.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>user_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time the ApiKey object was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>fingerprint</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The key's fingerprint</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">12:34:56:78:90:ab:cd:ef:12:34:56:78:90:ab:cd:ef</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The API key's current state.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>key_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the API signing key. An Oracle-assigned identifier for the key, in this format TENANCY_OCID/USER_OCID/KEY_FINGERPRINT.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx/ocid1.user.oc1..xxxxxEXAMPLExxxxx/08:07:a6:7d:06:b4:73:91:e9:2c:da</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_api_key_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_api_key_module.rst
+++ b/docs/modules/oci_api_key_module.rst
@@ -1,13 +1,14 @@
-.. _oci_api_key:
+:source: cloud/oracle/oci_api_key.py
+
+:orphan:
+
+.. _oci_api_key_module:
 
 
 oci_api_key - Upload and delete API signing key of a user in OCI
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,214 +17,244 @@ oci_api_key - Upload and delete API signing key of a user in OCI
 
 Synopsis
 --------
-
-
-* This module allows the user upload and delete API signing keys of a user in OCI. A PEM-format RSA credential for securing requests to the Oracle Cloud Infrastructure REST API. Also known as an API signing key. Specifically, this is the public key from the key pair. The private key remains with the user calling the API. For information about generating a key pair in the required PEM format, see Required Keys and OCIDs. Note that this is not the SSH key for accessing compute instances. Each user can have a maximum of three API signing keys. For more information about user credentials, see https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user upload and delete API signing keys of a user in OCI. A PEM-format RSA credential for securing requests to the Oracle Cloud Infrastructure REST API. Also known as an API signing key. Specifically, this is the public key from the key pair. The private key remains with the user calling the API. For information about generating a key pair in the required PEM format, see Required Keys and OCIDs. Note that this is not the SSH key for accessing compute instances. Each user can have a maximum of three API signing keys. For more information about user credentials, see https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_key_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The API signing key's id. The Id must be of the format TENANCY_OCID/USER_OCID/KEY_FINGERPRINT.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_signing_key</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The public key. Must be an RSA key in PEM format. Required when the API signing key is uploaded with <em>state=present</em></div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: key</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The state of the api signing key that must be asserted to. When <em>state=present</em>, and the api key doesn't exist, the api key is created with the provided <code>api_signing_key</code>. When <em>state=absent</em>, the api signing key corresponding to the provided <code>fingerprint</code> is deleted.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>user_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user whose API signing key needs to be created or deleted.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_key_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The API signing key's id. The Id must be of the format TENANCY_OCID/USER_OCID/KEY_FINGERPRINT.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_signing_key<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The public key. Must be an RSA key in PEM format. Required when the API signing key is uploaded with <em>state=present</em></div>
-        </br><div style="font-size: small;">aliases: key</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>The state of the api signing key that must be asserted to. When <em>state=present</em>, and the api key doesn't exist, the api key is created with the provided <code>api_signing_key</code>. When <em>state=absent</em>, the api signing key corresponding to the provided <code>fingerprint</code> is deleted.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>user_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user whose API signing key needs to be created or deleted.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Upload a new api signing key for the specified user
@@ -238,58 +269,54 @@ Examples
             state: "absent"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>oci_api_key</td>
-    <td>
-        <div>Details of the API signing key</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>dict</td>
-    <td align=center>{'lifecycle_state': 'ACTIVE', 'key_value': '-----BEGIN PUBLIC KEY-----...urt/fN8jNz2nZwIDAQAB-----END PUBLIC KEY-----', 'inactive_status': None, 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'fingerprint': '08:07:a6:7d:06:b4:73:91:e9:2c:da:42:c8:cb:df:02', 'key_id': 'ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx/ocid1.user.oc1..xxxxxEXAMPLExxxxx/08:07:a6:7d:06:b4:73:91:e9:2c:da', 'time_created': '2018-01-08T09:33:59.705000+00:00'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>oci_api_key</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>Details of the API signing key</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'ACTIVE', 'key_value': '-----BEGIN PUBLIC KEY-----...urt/fN8jNz2nZwIDAQAB-----END PUBLIC KEY-----', 'inactive_status': None, 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'fingerprint': '08:07:a6:7d:06:b4:73:91:e9:2c:da:42:c8:cb:df:02', 'key_id': 'ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx/ocid1.user.oc1..xxxxxEXAMPLExxxxx/08:07:a6:7d:06:b4:73:91:e9:2c:da', 'time_created': '2018-01-08T09:33:59.705000+00:00'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_api_key.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_backup_facts_module.rst
+++ b/docs/modules/oci_backup_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_backup_facts:
+:source: cloud/oracle/oci_backup_facts.py
+
+:orphan:
+
+.. _oci_backup_facts_module:
 
 
 oci_backup_facts - Fetches details of one or more Database Backups
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,153 +17,180 @@ oci_backup_facts - Fetches details of one or more Database Backups
 
 Synopsis
 --------
-
-
-* Fetches details of the Database Backups.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of the Database Backups.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>backup_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Database Backup whose details needs to be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment from which the details of the Database Backups should be fetched</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>database_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Database whose Backups should be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>backup_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Database Backup whose details needs to be fetched.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment from which the details of the Database Backups should be fetched</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>database_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Database whose Backups should be fetched.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch Database Backup for a Compartment
@@ -179,175 +207,195 @@ Examples
           backup_id: 'ocid1.backup..xcds'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>backups</td>
-    <td>
-        <div>Attributes of the Fetched Database Backup.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ABC-AD-1', 'display_name': 'ansible-backup-one', 'time_started': '2018-02-23T06:37:58.669000+00:00', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_ended': '2018-02-23T13:50:57.211000+00:00', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_details': 'The backup operation  run successfully.', 'type': 'FULL', 'id': 'ocid1.dbbackup.oc1.iad.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ABC-AD-1', 'display_name': 'ansible-backup-two', 'time_started': '2018-02-24T06:37:58.669000+00:00', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_ended': '2018-02-24T13:50:57.211000+00:00', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_details': 'The backup operation  run successfully.', 'type': 'FULL', 'id': 'ocid1.dbbackup.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Database Backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The name of the Availability Domain that the backup is located in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IwGV:US-ABC-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>The user-friendly name for the Database Backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-backup</td>
-        </tr>
-
-        <tr>
-        <td>time_started</td>
-        <td>
-            <div>The date and time the Database Backup starts.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-02-23 06:37:58.669000</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the DB System where the Database resides, whose backup has to be created.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>time_ended</td>
-        <td>
-            <div>The date and time the Database Backup was completed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-02-23 13:50:57.211000</td>
-        </tr>
-
-        <tr>
-        <td>database_id</td>
-        <td>
-            <div>The identifier of the Database whose backup has to be created.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>Additional information about the current lifecycle_state of the Database Backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>The backup operation cannot run successfully because the node is STOPPING or STOPPED</td>
-        </tr>
-
-        <tr>
-        <td>type</td>
-        <td>
-            <div>The type of Database Backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>FULL</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Database Backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.backup.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>backups</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Fetched Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ABC-AD-1', 'display_name': 'ansible-backup-one', 'time_started': '2018-02-23T06:37:58.669000+00:00', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_ended': '2018-02-23T13:50:57.211000+00:00', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_details': 'The backup operation  run successfully.', 'type': 'FULL', 'id': 'ocid1.dbbackup.oc1.iad.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ABC-AD-1', 'display_name': 'ansible-backup-two', 'time_started': '2018-02-24T06:37:58.669000+00:00', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_ended': '2018-02-24T13:50:57.211000+00:00', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_details': 'The backup operation  run successfully.', 'type': 'FULL', 'id': 'ocid1.dbbackup.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the Availability Domain that the backup is located in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ABC-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The user-friendly name for the Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-backup</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_started</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the Database Backup starts.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-02-23 06:37:58.669000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the DB System where the Database resides, whose backup has to be created.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_ended</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the Database Backup was completed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-02-23 13:50:57.211000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>database_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the Database whose backup has to be created.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional information about the current lifecycle_state of the Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The backup operation cannot run successfully because the node is STOPPING or STOPPED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">FULL</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.backup.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_backup_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_backup_module.rst
+++ b/docs/modules/oci_backup_module.rst
@@ -1,13 +1,14 @@
-.. _oci_backup:
+:source: cloud/oracle/oci_backup.py
+
+:orphan:
+
+.. _oci_backup_module:
 
 
 oci_backup - Create and Delete a Database Backup in OCI Database Cloud Service.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,214 +17,244 @@ oci_backup - Create and Delete a Database Backup in OCI Database Cloud Service.
 
 Synopsis
 --------
-
-
-* Create and Delete a Database Backup in OCI Database Cloud Service.
-* Since all the operations of this module takes a long time, it is recommended to set the ``wait`` parameter to False. Use :ref:`oci_backup_facts <oci_backup_facts>` to check the status of the operation as a separate task.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Create and Delete a Database Backup in OCI Database Cloud Service.
+- Since all the operations of this module takes a long time, it is recommended to set the ``wait`` parameter to False. Use :ref:`oci_backup_facts <oci_backup_facts_module>` to check the status of the operation as a separate task.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>backup_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the  Database Backup. Mandatory for delete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>database_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the  Database whose backup has to be created. Mandatory for create.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The user-friendly name for the Database Backup. It does not have to be unique. Mandatory for create.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Decides whether to create or delete Database Backup. For <em>state=present</em>, if the backup does not exists, it gets created.For <em>state=absent</em>, backup gets deleted.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>backup_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the  Database Backup. Mandatory for delete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>database_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the  Database whose backup has to be created. Mandatory for create.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The user-friendly name for the Database Backup. It does not have to be unique. Mandatory for create.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Decides whether to create or delete Database Backup. For <em>state=present</em>, if the backup does not exists, it gets created.For <em>state=absent</em>, backup gets deleted.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -241,175 +272,195 @@ Examples
           state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>backup</td>
-    <td>
-        <div>Attributes of the Database Backup.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ABC-AD-1', 'display_name': 'ansible-backup', 'time_started': '2018-02-23T06:37:58.669000+00:00', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_ended': '2018-02-23T13:50:57.211000+00:00', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_details': 'The backup operation  run successfully.', 'type': 'FULL', 'id': 'ocid1.dbbackup.oc1.iad.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Database Backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The name of the Availability Domain that the Database Backup is located in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IwGV:US-ABC-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>The user-friendly name for the Database Backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-backup</td>
-        </tr>
-
-        <tr>
-        <td>time_started</td>
-        <td>
-            <div>The date and time the Database Backup starts.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-02-23 06:37:58.669000</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the DB System where the Database resides, whose backup has to be created.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>time_ended</td>
-        <td>
-            <div>The date and time the Database Backup was completed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-02-23 13:50:57.211000</td>
-        </tr>
-
-        <tr>
-        <td>database_id</td>
-        <td>
-            <div>The identifier of the Database whose backup has to be created.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>Additional information about the current lifecycle_state of the Database Backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>The backup operation cannot run successfully because the node is STOPPING or STOPPED</td>
-        </tr>
-
-        <tr>
-        <td>type</td>
-        <td>
-            <div>The type of Database Backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>FULL</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Database Backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.backup.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>backup</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ABC-AD-1', 'display_name': 'ansible-backup', 'time_started': '2018-02-23T06:37:58.669000+00:00', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_ended': '2018-02-23T13:50:57.211000+00:00', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_details': 'The backup operation  run successfully.', 'type': 'FULL', 'id': 'ocid1.dbbackup.oc1.iad.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the Availability Domain that the Database Backup is located in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ABC-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The user-friendly name for the Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-backup</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_started</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the Database Backup starts.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-02-23 06:37:58.669000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the DB System where the Database resides, whose backup has to be created.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_ended</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the Database Backup was completed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-02-23 13:50:57.211000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>database_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the Database whose backup has to be created.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional information about the current lifecycle_state of the Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">The backup operation cannot run successfully because the node is STOPPING or STOPPED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">FULL</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Database Backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.backup.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_backup.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_boot_volume_attachment_facts_module.rst
+++ b/docs/modules/oci_boot_volume_attachment_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_boot_volume_attachment_facts:
+:source: cloud/oracle/oci_boot_volume_attachment_facts.py
+
+:orphan:
+
+.. _oci_boot_volume_attachment_facts_module:
 
 
 oci_boot_volume_attachment_facts - Retrieve facts of boot volume attachments in OCI
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,173 +17,200 @@ oci_boot_volume_attachment_facts - Retrieve facts of boot volume attachments in 
 
 Synopsis
 --------
-
-
-* This module retrieves information of a specified boot volume attachment or all the boot volume attachments in the specified compartment and availability domain.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves information of a specified boot volume attachment or all the boot volume attachments in the specified compartment and availability domain.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the Availability Domain. Required to get information of all the boot volume attachments in the specified <em>compartment_id</em> and <em>availability_domain</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>boot_volume_attachment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the boot volume attachment. Required to get information of a specific boot volume attachment.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the boot volume. Use <em>boot_volume_id</em> with <em>compartment_id</em> and <em>availability_domain</em> to get boot volume attachment information related to <em>boot_volume_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. Required to get information of all the boot volume attachments in the specified <em>compartment_id</em> and <em>availability_domain</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>instance_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the instance. Use <em>instance_id</em> with <em>compartment_id</em> and <em>availability_domain</em> to get boot volume attachment information related to <em>instance_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the Availability Domain. Required to get information of all the boot volume attachments in the specified <em>compartment_id</em> and <em>availability_domain</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>boot_volume_attachment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the boot volume attachment. Required to get information of a specific boot volume attachment.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>boot_volume_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the boot volume. Use <em>boot_volume_id</em> with <em>compartment_id</em> and <em>availability_domain</em> to get boot volume attachment information related to <em>boot_volume_id</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment. Required to get information of all the boot volume attachments in the specified <em>compartment_id</em> and <em>availability_domain</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instance_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the instance. Use <em>instance_id</em> with <em>compartment_id</em> and <em>availability_domain</em> to get boot volume attachment information related to <em>instance_id</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get information of all boot volume attachments in a compartment and availability domain
@@ -195,155 +223,165 @@ Examples
         id: ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>boot_volume_attachments</td>
-    <td>
-        <div>List of information about boot volume attachments</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-15T07:23:10.838000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>boot_volume_id</td>
-        <td>
-            <div>The OCID of the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BnQb:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>My boot volume attachment</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the boot volume attachment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ATTACHED</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>instance_id</td>
-        <td>
-            <div>The OCID of the instance the boot volume is attached to.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the boot volume attachment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>boot_volume_attachments</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>List of information about boot volume attachments</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-15T07:23:10.838000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My boot volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_boot_volume_attachment_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_boot_volume_attachment_module.rst
+++ b/docs/modules/oci_boot_volume_attachment_module.rst
@@ -1,13 +1,14 @@
-.. _oci_boot_volume_attachment:
+:source: cloud/oracle/oci_boot_volume_attachment.py
+
+:orphan:
+
+.. _oci_boot_volume_attachment_module:
 
 
 oci_boot_volume_attachment - Attach or detach a boot volume in OCI Block Volume service
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,204 +17,230 @@ oci_boot_volume_attachment - Attach or detach a boot volume in OCI Block Volume 
 
 Synopsis
 --------
-
-
-* This module allows the user to attach a boot volume to an instance or detach a boot volume from an instance in OCI.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to attach a boot volume to an instance or detach a boot volume from an instance in OCI.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>boot_volume_attachment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the boot volume attachment. Required to detach a boot volume from an instance with <em>state=absent</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the boot volume. Required to attach a boot volume to an instance with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it cannot be changed. Avoid entering confidential information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>instance_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the instance. Required to attach a boot volume to an instance with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>state=present</em> to attach a boot volume to an instance. Use <em>state=absent</em> to detach a boot volume from an instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>boot_volume_attachment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the boot volume attachment. Required to detach a boot volume from an instance with <em>state=absent</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>boot_volume_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the boot volume. Required to attach a boot volume to an instance with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name. Does not have to be unique, and it cannot be changed. Avoid entering confidential information.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instance_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the instance. Required to attach a boot volume to an instance with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Use <em>state=present</em> to attach a boot volume to an instance. Use <em>state=absent</em> to detach a boot volume from an instance.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Attach a boot volume to an instance
@@ -226,155 +253,165 @@ Examples
         boot_volume_attachment_id: ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>boot_volume_attachment</td>
-    <td>
-        <div>Information about the boot volume attachment</div>
-    </td>
-    <td align=center>On successful attach & detach operation</td>
-    <td align=center>complex</td>
-    <td align=center>{'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-15T07:23:10.838000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>boot_volume_id</td>
-        <td>
-            <div>The OCID of the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BnQb:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>My boot volume attachment</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the boot volume attachment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ATTACHED</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>instance_id</td>
-        <td>
-            <div>The OCID of the instance the boot volume is attached to.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the boot volume attachment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>boot_volume_attachment</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful attach &amp; detach operation</td>
+                <td>
+                                            <div>Information about the boot volume attachment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-15T07:23:10.838000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My boot volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_boot_volume_attachment.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_boot_volume_facts_module.rst
+++ b/docs/modules/oci_boot_volume_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_boot_volume_facts:
+:source: cloud/oracle/oci_boot_volume_facts.py
+
+:orphan:
+
+.. _oci_boot_volume_facts_module:
 
 
 oci_boot_volume_facts - Retrieve facts of boot volumes in OCI Block Volume service
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,164 +17,195 @@ oci_boot_volume_facts - Retrieve facts of boot volumes in OCI Block Volume servi
 
 Synopsis
 --------
-
-
-* This module retrieves information of a specified boot volume or all the boot volumes in a specified compartment and availability domain.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves information of a specified boot volume or all the boot volumes in a specified compartment and availability domain.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the Availability Domain. Required to get information of all the boot volumes in the specified <em>compartment_id</em> and <em>availability_domain</em>. This option is mutually exclusive with <em>boot_volume_id</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>boot_volume_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the boot volume. Required to get information of a specific boot volume. This option is mutually exclusive with <em>availability_domain</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment. Required to get information of all the boot volumes in the specified <em>compartment_id</em> and <em>availability_domain</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>lookup_attached_instance<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to fetch information of the compute instance attached to this boot volume from all the compartments in the tenancy.Fetching this information requires traversing through all the compartments in the  Tenancy and therefore can potentially take a long time. This option is only supported in experimental mode.
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the Availability Domain. Required to get information of all the boot volumes in the specified <em>compartment_id</em> and <em>availability_domain</em>. This option is mutually exclusive with <em>boot_volume_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the boot volume. Required to get information of a specific boot volume. This option is mutually exclusive with <em>availability_domain</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. Required to get information of all the boot volumes in the specified <em>compartment_id</em> and <em>availability_domain</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>lookup_attached_instance</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to fetch information of the compute instance attached to this boot volume from all the compartments in the tenancy.Fetching this information requires traversing through all the compartments in the  Tenancy and therefore can potentially take a long time. This option is only supported in experimental mode.
     When <em>lookup_all_attached_instances=False</em>, only an attached compute instance belonging to this boot volume's compartment, is returned. This is useful when the boot volume is used within a single compartment. When <em>lookup_all_attached_instances=True</em>, all the compartments in the tenancy are searched to find out the compute instance that is attached to this boot volume. Fetching information about compute instances attached to this boot volume is an experimental feature (ie, this may or may not be supported in future releases). To use such experimental features, set the environment variable OCI_ANSIBLE_EXPERIMENTAL to True.</div>
-    </td>
-    </tr>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
 
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
+Notes
+-----
 
-    </table>
-    </br>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get information of all the boot volumes for a specific availability domain & compartment_id
@@ -186,175 +218,314 @@ Examples
         boot_volume_id: ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>boot_volumes</td>
-    <td>
-        <div>List of boot volume information</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'demo-20171214-100_bastion_instance (Boot Volume)', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'attached_instance_information': {'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-14T19:02:49.085000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}, 'size_in_mbs': 47694, 'time_created': '2018-01-14T19:02:49.042000+00:00', 'image_id': 'ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx', 'size_in_gbs': 46, 'id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="3">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of a boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>PROVISIONING</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain of the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IwGV:US-ASHBURN-AD-2</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name of the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_boot_volume</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>attached_instance_information</td>
-        <td>
-            <div>Information of the instance the boot volume is attached to.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>size_in_mbs</td>
-        <td>
-            <div>The size of the boot volume in MBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>51200</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the boot volume was created. Format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2017-11-22 19:40:08.871000</td>
-        </tr>
-
-        <tr>
-        <td>image_id</td>
-        <td>
-            <div>The image OCID used to create the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>size_in_gbs</td>
-        <td>
-            <div>The size of the boot volume in GBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>50</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="3">
+                    <b>boot_volumes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>List of boot volume information</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'demo-20171214-100_bastion_instance (Boot Volume)', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'attached_instance_information': {'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-14T19:02:49.085000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}, 'size_in_mbs': 47694, 'time_created': '2018-01-14T19:02:49.042000+00:00', 'image_id': 'ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx', 'size_in_gbs': 46, 'id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of a boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PROVISIONING</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ASHBURN-AD-2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_boot_volume</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>attached_instance_information</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Information of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The Availability Domain of an instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My boot volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The current state of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>size_in_mbs</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the boot volume in MBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">51200</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the boot volume was created. Format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-22 19:40:08.871000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>image_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The image OCID used to create the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>size_in_gbs</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the boot volume in GBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">50</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_boot_volume_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_boot_volume_module.rst
+++ b/docs/modules/oci_boot_volume_module.rst
@@ -1,13 +1,14 @@
-.. _oci_boot_volume:
+:source: cloud/oracle/oci_boot_volume.py
+
+:orphan:
+
+.. _oci_boot_volume_module:
 
 
 oci_boot_volume - Manage boot volumes in OCI Block Volume service
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,195 +17,225 @@ oci_boot_volume - Manage boot volumes in OCI Block Volume service
 
 Synopsis
 --------
-
-
-* This module allows the user to perform delete & update operations on boot volumes in OCI Block Volume service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to perform delete & update operations on boot volumes in OCI Block Volume service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>boot_volume_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the boot volume.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>lookup_attached_instance<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to fetch information of the compute instance attached to this boot volume from all the compartments in the tenancy.Fetching this information requires traversing through all the compartments in the  Tenancy and therefore can potentially take a long time. This option is only supported in experimental mode.
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the boot volume.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>lookup_attached_instance</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to fetch information of the compute instance attached to this boot volume from all the compartments in the tenancy.Fetching this information requires traversing through all the compartments in the  Tenancy and therefore can potentially take a long time. This option is only supported in experimental mode.
     When <em>lookup_all_attached_instances=False</em>, only an attached compute instance belonging to this boot volume's compartment, is returned. This is useful when the boot volume is used within a single compartment. When <em>lookup_all_attached_instances=True</em>, all the compartments in the tenancy are searched to find out the compute instance that is attached to this boot volume. Fetching information about compute instances attached to this boot volume is an experimental feature (ie, this may or may not be supported in future releases). To use such experimental features, set the environment variable OCI_ANSIBLE_EXPERIMENTAL to True.</div>
-    </td>
-    </tr>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Update a boot volume with <em>state=present</em>. Delete a boot volume with <em>state=absent</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
 
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Update a boot volume with <em>state=present</em>. Delete a boot volume with <em>state=absent</em>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Update name of a boot volume
@@ -218,175 +249,314 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>boot_volume</td>
-    <td>
-        <div>Information about the boot volume</div>
-    </td>
-    <td align=center>On successful update and delete operation</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'demo-20171214-100_bastion_instance (Boot Volume)', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'attached_instance_information': {'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-14T19:02:49.085000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}, 'size_in_mbs': 47694, 'time_created': '2018-01-14T19:02:49.042000+00:00', 'image_id': 'ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx', 'size_in_gbs': 46, 'id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="3">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of a boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>PROVISIONING</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain of the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IwGV:US-ASHBURN-AD-2</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name of the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_boot_volume</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>attached_instance_information</td>
-        <td>
-            <div>Information of the instance the boot volume is attached to.</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>dict</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>size_in_mbs</td>
-        <td>
-            <div>The size of the boot volume in MBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>51200</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the boot volume was created. Format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2017-11-22 19:40:08.871000</td>
-        </tr>
-
-        <tr>
-        <td>image_id</td>
-        <td>
-            <div>The image OCID used to create the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>size_in_gbs</td>
-        <td>
-            <div>The size of the boot volume in GBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>50</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the boot volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="3">
+                    <b>boot_volume</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful update and delete operation</td>
+                <td>
+                                            <div>Information about the boot volume</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'demo-20171214-100_bastion_instance (Boot Volume)', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'attached_instance_information': {'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-14T19:02:49.085000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}, 'size_in_mbs': 47694, 'time_created': '2018-01-14T19:02:49.042000+00:00', 'image_id': 'ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx', 'size_in_gbs': 46, 'id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of a boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PROVISIONING</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ASHBURN-AD-2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_boot_volume</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>attached_instance_information</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>Information of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The Availability Domain of an instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My boot volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The current state of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this boot volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>size_in_mbs</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the boot volume in MBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">51200</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the boot volume was created. Format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-22 19:40:08.871000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>image_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The image OCID used to create the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>size_in_gbs</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the boot volume in GBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">50</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_boot_volume.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_bucket_facts_module.rst
+++ b/docs/modules/oci_bucket_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_bucket_facts:
+:source: cloud/oracle/oci_bucket_facts.py
+
+:orphan:
+
+.. _oci_bucket_facts_module:
 
 
 oci_bucket_facts - Fetches details of a bucket or all available buckets within a namespace
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,153 +17,170 @@ oci_bucket_facts - Fetches details of a bucket or all available buckets within a
 
 Synopsis
 --------
-
-
-* This module retrieves details of a bucket or all the buckets available for specified namespace and compartment identifier.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details of a bucket or all the buckets available for specified namespace and compartment identifier.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment from which facts of constituent buckets needs to be fetched.                     Required to get details of all buckets in a specified namespace and compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the bucket. Required to fetch details of a specific bucket.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: bucket</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>namespace_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the namespace from which facts of constituent buckets needs to be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment from which facts of constituent buckets needs to be fetched.                     Required to get details of all buckets in a specified namespace and compartment.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the bucket. Required to fetch details of a specific bucket.</div>
-        </br><div style="font-size: small;">aliases: bucket</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>namespace_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the namespace from which facts of constituent buckets needs to be fetched.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Note: These examples do not set authentication details.
@@ -181,155 +199,167 @@ Examples
         name: 'Bucket1'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>buckets</td>
-    <td>
-        <div>The specified bucket or a list of all available buckets in the specified namespace and compartment.</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'etag': '7d48fea5-ghfc', 'name': 'Bucket1', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'created_by': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'namespace': 'mynamespace', 'time_created': '2017-10-07T16:20:33.933000+00:00'}, {'etag': '3f0158f2-68ea', 'name': 'Bucket2', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'created_by': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'namespace': 'mynamespace', 'time_created': '2017-10-06T13:47:38.544000+00:00'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name of the bucket</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>my-new-bucket1</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The ID of the compartment in which the bucket is authorized</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>namespace</td>
-        <td>
-            <div>The namespace in which the bucket lives</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>mynamespace</td>
-        </tr>
-
-        <tr>
-        <td>created_by</td>
-        <td>
-            <div>The OCID of the user who created the bucket.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.user.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>etag</td>
-        <td>
-            <div>The entity tag for the bucket.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>7d48fea5-ghfc</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the bucket was created, as described in RFC 2616, section 14.29</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-10-07 16:20:33.933000</td>
-        </tr>
-
-        <tr>
-        <td>public_access_type</td>
-        <td>
-            <div>The type of public access enabled on this bucket. A bucket is set to NoPublicAccess by                         default, which only allows an authenticated caller to access the bucket and its contents. When                         ObjectRead is enabled on the bucket, public access is allowed for the GetObject, HeadObject,                         and ListObjects operations.</div>
-        </td>
-        <td align=center>On retrieving a specific bucket</td>
-        <td align=center>string</td>
-        <td align=center>NoPublicAccess</td>
-        </tr>
-
-        <tr>
-        <td>metadata</td>
-        <td>
-            <div>Arbitrary string keys and values for user-defined metadata.</div>
-        </td>
-        <td align=center>On retrieving a specific bucket</td>
-        <td align=center>dict(str,str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>buckets</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>The specified bucket or a list of all available buckets in the specified namespace and compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'etag': '7d48fea5-ghfc', 'name': 'Bucket1', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'created_by': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'namespace': 'mynamespace', 'time_created': '2017-10-07T16:20:33.933000+00:00'}, {'etag': '3f0158f2-68ea', 'name': 'Bucket2', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'created_by': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'namespace': 'mynamespace', 'time_created': '2017-10-06T13:47:38.544000+00:00'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the bucket</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">my-new-bucket1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The ID of the compartment in which the bucket is authorized</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>namespace</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The namespace in which the bucket lives</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">mynamespace</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>created_by</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the user who created the bucket.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.user.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>etag</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The entity tag for the bucket.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">7d48fea5-ghfc</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the bucket was created, as described in RFC 2616, section 14.29</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-10-07 16:20:33.933000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>public_access_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>On retrieving a specific bucket</td>
+                <td>
+                                            <div>The type of public access enabled on this bucket. A bucket is set to NoPublicAccess by                         default, which only allows an authenticated caller to access the bucket and its contents. When                         ObjectRead is enabled on the bucket, public access is allowed for the GetObject, HeadObject,                         and ListObjects operations.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NoPublicAccess</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str,str)</div>
+                                    </td>
+                <td>On retrieving a specific bucket</td>
+                <td>
+                                            <div>Arbitrary string keys and values for user-defined metadata.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_bucket_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_bucket_module.rst
+++ b/docs/modules/oci_bucket_module.rst
@@ -1,13 +1,14 @@
-.. _oci_bucket:
+:source: cloud/oracle/oci_bucket.py
+
+:orphan:
+
+.. _oci_bucket_module:
 
 
 oci_bucket - Create,update and delete oci buckets
 +++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,194 +17,223 @@ oci_bucket - Create,update and delete oci buckets
 
 Synopsis
 --------
-
-
-* Creates OCI bucket if not present.
-* Update OCI bucket, if present.
-* Delete OCI bucket, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Creates OCI bucket if not present.
+- Update OCI bucket, if present.
+- Delete OCI bucket, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment in which the bucket is available or should be available. Mandatory for <em>state=present</em>. Not required for <em>state=absent</em></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>If <em>force='no'</em> and the bucket contains objects, bucket will not be deleted. To delete a bucket which has objects, <em>force='yes'</em> should be specified.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>metadata</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use defined metadata dict(str,str) for the bucket. Limit is 4KB.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the bucket. Bucket name must be unique within a namespace. For naming conventions, refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingbuckets.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingbuckets.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>namespace_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the namespace in which the bucket is available or should be available</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>public_access_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>ObjectRead</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>NoPublicAccess</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of public access  of the bucket. By default, no public access is allowed on the bucket. If <em>public_access_type=ObjectRead</em>, user can perform read operation on the bucket.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Decides whether to create,update or delete bucket. For <em>state=present</em>, if the bucket does not exist, it gets created. If it exists, it gets updated. For <em>state=absent</em>, the bucket gets deleted.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment in which the bucket is available or should be available. Mandatory for <em>state=present</em>. Not required for <em>state=absent</em></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>no</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>If <em>force='no'</em> and the bucket contains objects, bucket will not be deleted. To delete a bucket which has objects, <em>force='yes'</em> should be specified.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>metadata<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Use defined metadata dict(str,str) for the bucket. Limit is 4KB.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the bucket. Bucket name must be unique within a namespace. For naming conventions, refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingbuckets.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingbuckets.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>namespace_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the namespace in which the bucket is available or should be available</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>public_access_type<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>NoPublicAccess</td>
-    <td><ul><li>ObjectRead</li><li>NoPublicAccess</li></ul></td>
-    <td>
-        <div>The type of public access  of the bucket. By default, no public access is allowed on the bucket. If <em>public_access_type=ObjectRead</em>, user can perform read operation on the bucket.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Decides whether to create,update or delete bucket. For <em>state=present</em>, if the bucket does not exist, it gets created. If it exists, it gets updated. For <em>state=absent</em>, the bucket gets deleted.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Note: These examples do not set authentication details.
@@ -230,58 +260,54 @@ Examples
 
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>bucket</td>
-    <td>
-        <div>Attributes of the created/updated bucket. Applicable only for create and update.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>string</td>
-    <td align=center>{'name': 'AnsibleTestBucket', 'compartment_id': 'ocid1....62xq', 'namespace': 'ansibletestspace', 'created_by': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx..qndq', 'etag': 'cb734ffe-da3a-48f4-....-161fd4604cf1', 'time_created': '2017-10-01T11:30:33.655000+00:00', 'public_access_type': 'ObjectRead', 'metadata': {}}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>bucket</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated bucket. Applicable only for create and update.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'name': 'AnsibleTestBucket', 'compartment_id': 'ocid1....62xq', 'namespace': 'ansibletestspace', 'created_by': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx..qndq', 'etag': 'cb734ffe-da3a-48f4-....-161fd4604cf1', 'time_created': '2017-10-01T11:30:33.655000+00:00', 'public_access_type': 'ObjectRead', 'metadata': {}}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_bucket.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_cluster_facts_module.rst
+++ b/docs/modules/oci_cluster_facts_module.rst
@@ -1,0 +1,397 @@
+:source: cloud/oracle/oci_cluster_facts.py
+
+:orphan:
+
+.. _oci_cluster_facts_module:
+
+
+oci_cluster_facts - Retrieve facts of clusters in OCI Container Engine for Kubernetes Service
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves information of a specific cluster or of all the clusters in OCI Container Engine for Kubernetes Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cluster_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the cluster. <em>cluster_id</em> is required to get the details of a cluster.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. <em>compartment_id</em> is required to list all the cluster objects in a compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get all the clusters
+      oci_cluster_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Get a specific cluster
+      oci_cluster_facts:
+        cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Get clusters in a compartment having the specified name
+      oci_cluster_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        name: test_cluster
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>clusters</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of cluster details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'available_kubernetes_upgrades': ['v1.10.3'], 'endpoints': {'kubernetes': 'xxxxxEXAMPLExxxxx.clusters.oci.oraclecloud.com:xxxx'}, 'name': 'test', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ACTIVE', 'id': 'ocid1.cluster.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_details': '', 'kubernetes_version': 'v1.9.7', 'options': {'add_ons': {'is_tiller_enabled': True, 'is_kubernetes_dashboard_enabled': True}, 'service_lb_subnet_ids': [], 'kubernetes_network_config': {'services_cidr': '10.96.0.0/16', 'pods_cidr': '10.244.0.0/16'}}, 'metadata': {'created_by_user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'deleted_by_work_request_id': None, 'time_updated': None, 'deleted_by_user_id': None, 'updated_by_user_id': None, 'time_created': '2018-07-26T18:42:25+00:00', 'time_deleted': None, 'created_by_work_request_id': 'ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx', 'updated_by_work_request_id': None}}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>available_kubernetes_upgrades</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Available Kubernetes versions to which the clusters masters may be upgraded.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['v1.10.3']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>endpoints</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Endpoints served up by the cluster masters.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'kubernetes': 'xxxEXAMPLExxx.us-ashburn-1.clusters.oci.oraclecloud.com:6443'}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the cluster.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">sample_cluster</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment in which the cluster exists.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The state of the cluster masters.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the cluster.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.cluster.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the virtual cloud network (VCN) in which the cluster exists.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Details about the state of the cluster masters.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>kubernetes_version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The version of Kubernetes running on the cluster masters.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">v1.9.7</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>options</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Optional attributes for the cluster.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>metadata</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Metadata about the cluster.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_cluster_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_cluster_module.rst
+++ b/docs/modules/oci_cluster_module.rst
@@ -1,0 +1,703 @@
+:source: cloud/oracle/oci_cluster.py
+
+:orphan:
+
+.. _oci_cluster_module:
+
+
+oci_cluster - Manage Kubernetes clusters in OCI Container Engine for Kubernetes Service
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module allows the user to create, delete and update Kubernetes clusters in OCI Container Engine for Kubernetes Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="3">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="3">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>cluster_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the cluster. Required to update/delete a cluster.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment in which to create the cluster. Required to create a cluster.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>kubernetes_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The version of Kubernetes to install into the cluster masters. Required to create a cluster.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the cluster. Avoid entering confidential information. Required to create a cluster.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>options</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Optional attributes for the cluster.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>add_ons</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Configurable cluster add-ons.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>is_tiller_enabled</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Whether or not to enable the Tiller add-on.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>is_kubernetes_dashboard_enabled</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Whether or not to enable the Kubernetes Dashboard add-on.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>service_lb_subnet_ids</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCIDs of the subnets used for Kubernetes services load balancers.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>kubernetes_network_config</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Network configuration for Kubernetes.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>services_cidr</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The CIDR block for Kubernetes services.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>pods_cidr</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The CIDR block for Kubernetes pods.</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                                <td colspan="3">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a cluster with <em>state=present</em>. Use <em>state=absent</em> to delete a cluster.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the virtual cloud network (VCN) in which to create the cluster. Required to create a cluster.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create a cluster
+      oci_cluster:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        name: test_cluster
+        vcn_id: ocid1.vcn.oc1..xxxxxEXAMPLExxxxx
+        kubernetes_version: "v1.9.7"
+        options:
+          service_lb_subnet_ids:
+            - ocid1.subnet.oc1..xxxxxEXAMPLExxxxx
+            - ocid1.subnet.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Update name and version of Kubernetes master
+      oci_cluster:
+        id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+        name: ansible_cluster
+        kubernetes_version: "v1.10.3"
+
+    - name: Delete a cluster
+      oci_cluster:
+        id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>cluster</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful create, delete &amp; update operations on cluster</td>
+                <td>
+                                            <div>Information about the cluster</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'available_kubernetes_upgrades': [], 'endpoints': {'kubernetes': 'xxxxxEXAMPLExxxxx.clusters.oci.oraclecloud.com:xxxx'}, 'name': 'test', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ACTIVE', 'id': 'ocid1.cluster.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_details': '', 'kubernetes_version': 'v1.10.3', 'options': {'add_ons': {'is_tiller_enabled': True, 'is_kubernetes_dashboard_enabled': True}, 'service_lb_subnet_ids': [], 'kubernetes_network_config': {'services_cidr': '10.96.0.0/16', 'pods_cidr': '10.244.0.0/16'}}, 'metadata': {'created_by_user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'deleted_by_work_request_id': None, 'time_updated': None, 'deleted_by_user_id': None, 'updated_by_user_id': None, 'time_created': '2018-07-26T18:42:25+00:00', 'time_deleted': None, 'created_by_work_request_id': 'ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx', 'updated_by_work_request_id': None}}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>available_kubernetes_upgrades</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Available Kubernetes versions to which the clusters masters may be upgraded.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['v1.10.3']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>endpoints</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Endpoints served up by the cluster masters.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'kubernetes': 'xxxEXAMPLExxx.us-ashburn-1.clusters.oci.oraclecloud.com:6443'}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the cluster.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">sample_cluster</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment in which the cluster exists.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The state of the cluster masters.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the cluster.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.cluster.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the virtual cloud network (VCN) in which the cluster exists.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Details about the state of the cluster masters.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>kubernetes_version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The version of Kubernetes running on the cluster masters.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">v1.9.7</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>options</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Optional attributes for the cluster.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>metadata</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Metadata about the cluster.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                <td colspan="2">
+                    <b>work_request</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>When a new work request is created</td>
+                <td>
+                                            <div>Information of work request</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'status': 'ACCEPTED', 'time_finished': '2018-07-26T18:44:13+00:00', 'time_started': '2018-07-26T18:43:26+00:00', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'operation_type': 'CLUSTER_CREATE', 'time_accepted': '2018-07-26T18:42:26+00:00', 'id': 'ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx', 'resources': [{'entity_uri': '/clusters/ocid1.cluster.oc1..xxxxxEXAMPLExxxxx', 'identifier': 'ocid1.cluster.oc1..xxxxxEXAMPLExxxxx', 'action_type': 'IN_PROGRESS', 'entity_type': 'cluster'}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current status of the work request.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_finished</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was finished.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_started</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was started.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment in which the work request exists.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>operation_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of work the work request is doing.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_accepted</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was accepted.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the work request.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>resources</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The resources this work request affects.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_cluster.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_cluster_options_facts_module.rst
+++ b/docs/modules/oci_cluster_options_facts_module.rst
@@ -1,0 +1,237 @@
+:source: cloud/oracle/oci_cluster_options_facts.py
+
+:orphan:
+
+.. _oci_cluster_options_facts_module:
+
+
+oci_cluster_options_facts - Retrieve options available for clusters in OCI Container Engine for Kubernetes Service
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves options available for clusters in OCI Container Engine for Kubernetes Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cluster_option_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>all</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The id of the option set to retrieve. Only &quot;all&quot; is supported.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get all options available for clusters
+      oci_cluster_options_facts:
+        cluster_option_id: all
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>cluster_options</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Options available for clusters</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'kubernetes_versions': ['v1.8.11', 'v1.9.7', 'v1.10.3', 'v1.11.1']}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>kubernetes_versions</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Available Kubernetes versions.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_cluster_options_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_compartment_facts_module.rst
+++ b/docs/modules/oci_compartment_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_compartment_facts:
+:source: cloud/oracle/oci_compartment_facts.py
+
+:orphan:
+
+.. _oci_compartment_facts_module:
 
 
 oci_compartment_facts - Retrieve details of a compartment or all the compartments in a tenancy in OCI
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,132 +17,159 @@ oci_compartment_facts - Retrieve details of a compartment or all the compartment
 
 Synopsis
 --------
-
-
-* This module allows the user to retrieve details of a specific compartment in a tenancy or all the compartments in a tenancy in OCI.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to retrieve details of a specific compartment in a tenancy or all the compartments in a tenancy in OCI.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of a compartment. Use OCID of a tenancy to get details of all the compartments in the tenancy. Use OCID of a compartment in a tenancy to get details of the compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of a compartment. Use OCID of a tenancy to get details of all the compartments in the tenancy. Use OCID of a compartment in a tenancy to get details of the compartment.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the compartments in a tenancy by specifying OCID of the tenancy
@@ -152,146 +180,157 @@ Examples
       oci_compartment_facts:
         compartment_id: 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx'
 
+    - name: Get details of a compartment in a tenancy using the compartment's name
+      oci_compartment_facts:
+        compartment_id: 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx:aaaaaaaamx5hilztihors5wfsn2akuyty4'
+        name: test_compartment
+
+
+
 
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>compartments</td>
-    <td>
-        <div>List of compartment details</div>
-    </td>
-    <td align=center>always</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'Project-Ansible', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx:aaaabcaamx5hilzhdwvds5wfsn2akuyty4', 'id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-02-01T03:20:22.160000+00:00', 'description': 'Compartment for Project-Ansible'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The compartment's current state</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>inactive_status</td>
-        <td>
-            <div>The detailed status of INACTIVE lifecycleState</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name assigned to the compartment</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Project-A</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the tenancy containing the compartment</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx:aaaabcaamx5hilzhdwvds5wfsn2akuyty4</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the compartment</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time the compartment was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-02-01T03:20:22.160000+00:00</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The description assigned to the compartment</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Compartment for Project-A</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>compartments</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of compartment details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'Project-Ansible', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx:aaaabcaamx5hilzhdwvds5wfsn2akuyty4', 'id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-02-01T03:20:22.160000+00:00', 'description': 'Compartment for Project-Ansible'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The compartment's current state</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The detailed status of INACTIVE lifecycleState</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name assigned to the compartment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Project-A</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the tenancy containing the compartment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx:aaaabcaamx5hilzhdwvds5wfsn2akuyty4</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time the compartment was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-02-01T03:20:22.160000+00:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description assigned to the compartment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Compartment for Project-A</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_compartment_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_compartment_module.rst
+++ b/docs/modules/oci_compartment_module.rst
@@ -1,13 +1,14 @@
-.. _oci_compartment:
+:source: cloud/oracle/oci_compartment.py
+
+:orphan:
+
+.. _oci_compartment_module:
 
 
 oci_compartment - Manage compartments in OCI
 ++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,212 +17,237 @@ oci_compartment - Manage compartments in OCI
 
 Synopsis
 --------
-
-
-* This module allows the user to create and update a compartment in OCI.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create and update a compartment in OCI.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the tenancy in which the compartment has to be created or the OCID of the compartment to be updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>description</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The description to be assigned to the compartment. Required when creating a compartment with <em>state=present</em>. <em>description</em> should be minimum 1 character and maximum 100 characters long. Does not have to be unique, and it's changeable.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the compartment. The name must be unique across all compartments in the tenancy. Required when creating a compartment with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a compartment with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the tenancy in which the compartment has to be created or the OCID of the compartment to be updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>description<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The description to be assigned to the compartment. Required when creating a compartment with <em>state=present</em>. <em>description</em> should be minimum 1 character and maximum 100 characters long. Does not have to be unique, and it's changeable.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the compartment. The name must be unique across all compartments in the tenancy. Required when creating a compartment with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li></ul></td>
-    <td>
-        <div>Create or update a compartment with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a compartment
@@ -237,58 +263,54 @@ Examples
         description: Compartment for Project-Ansible
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>compartment</td>
-    <td>
-        <div>Information about the compartment</div>
-    </td>
-    <td align=center>On successful operation</td>
-    <td align=center>dict</td>
-    <td align=center>{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'Project-Ansible', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx:aaaabcaamx5hilzhdwvds5wfsn2akuyty4', 'id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-02-01T03:20:22.160000+00:00', 'description': 'Compartment for Project-Ansible'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>compartment</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful operation</td>
+                <td>
+                                            <div>Information about the compartment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'Project-Ansible', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx:aaaabcaamx5hilzhdwvds5wfsn2akuyty4', 'id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-02-01T03:20:22.160000+00:00', 'description': 'Compartment for Project-Ansible'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_compartment.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_customer_secret_key_facts_module.rst
+++ b/docs/modules/oci_customer_secret_key_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_customer_secret_key_facts:
+:source: cloud/oracle/oci_customer_secret_key_facts.py
+
+:orphan:
+
+.. _oci_customer_secret_key_facts_module:
 
 
 oci_customer_secret_key_facts - Retrieve details of customer secret keys for a specified user
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,170 @@ oci_customer_secret_key_facts - Retrieve details of customer secret keys for a s
 
 Synopsis
 --------
-
-
-* This module retrieves details of customer secret keys of a specified user. The returned object contains the customer secret key's OCID, but not the password itself. The actual password is returned only upon creation of a customer secret key using the :ref:`oci_customer_secret_key <oci_customer_secret_key>` module.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details of customer secret keys of a specified user. The returned object contains the customer secret key's OCID, but not the password itself. The actual password is returned only upon creation of a customer secret key using the :ref:`oci_customer_secret_key <oci_customer_secret_key_module>` module.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>customer_secret_key_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the customer secret key. Required when facts about a specific customer secret key for the specified user needs to be obtained.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>user_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>customer_secret_key_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the customer secret key. Required when facts about a specific customer secret key for the specified user needs to be obtained.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>user_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the customer secret keys of the specified user
@@ -165,145 +193,151 @@ Examples
         id: "ocid1.credential.oc1..xxxxxEXAMPLExxxxx"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>customer_secret_keys</td>
-    <td>
-        <div>Information about one or more customer secret keys in the specified user</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>{'customer_secret_keys': [{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'display_name': 'My first customer secret key description', 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'time_expires': 'None', 'id': 'ocid1.credential.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2018-01-08T04:44:17.784000+00:00'}]}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The password's current state.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>inactive_status</td>
-        <td>
-            <div>The detailed status of INACTIVE lifecycleState.</div>
-        </td>
-        <td align=center>only when the I(lifecycle_state) is 'INACTIVE'</td>
-        <td align=center>string</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>user_id</td>
-        <td>
-            <div>The OCID of the user the customer secret key belongs to.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.user.oc1..xxxxxEXAMPLExxxxx'</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The description that was assigned to the Customer secret key.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>My first customer secret key description'</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the Customer secret key:.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.credential.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time the Customer secret key object was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>expires_on</td>
-        <td>
-            <div>Date and time when this secret key will expire, in the format defined by RFC3339. Null if it never expires.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>customer_secret_keys</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more customer secret keys in the specified user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'customer_secret_keys': [{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'display_name': 'My first customer secret key description', 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'time_expires': 'None', 'id': 'ocid1.credential.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2018-01-08T04:44:17.784000+00:00'}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The password's current state.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>only when the <em>lifecycle_state</em> is 'INACTIVE'</td>
+                <td>
+                                            <div>The detailed status of INACTIVE lifecycleState.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>user_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the user the customer secret key belongs to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.user.oc1..xxxxxEXAMPLExxxxx'</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description that was assigned to the Customer secret key.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My first customer secret key description'</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the Customer secret key:.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.credential.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time the Customer secret key object was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>expires_on</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when this secret key will expire, in the format defined by RFC3339. Null if it never expires.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_customer_secret_key_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_customer_secret_key_module.rst
+++ b/docs/modules/oci_customer_secret_key_module.rst
@@ -1,13 +1,14 @@
-.. _oci_customer_secret_key:
+:source: cloud/oracle/oci_customer_secret_key.py
+
+:orphan:
+
+.. _oci_customer_secret_key_module:
 
 
 oci_customer_secret_key - Create, update and delete Customer Secret Keys for the specified user in OCI.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,184 +17,209 @@ oci_customer_secret_key - Create, update and delete Customer Secret Keys for the
 
 Synopsis
 --------
-
-
-* This module allows the user to create, update and delete Customer Secret Keys in OCI. A CustomerSecretKey is an Oracle-provided key for using the Object Storage Service's Amazon S3 compatible API. A user can have up to two secret keys at a time. Note: The secret key is always an Oracle-generated string; you can't change it to a string of your choice.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create, update and delete Customer Secret Keys in OCI. A CustomerSecretKey is an Oracle-provided key for using the Object Storage Service's Amazon S3 compatible API. A user can have up to two secret keys at a time. Note: The secret key is always an Oracle-generated string; you can't change it to a string of your choice.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>customer_secret_key_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the Customer Secret Key. Required when the secret keys's description needs to be updated with <em>state=present</em> and for deleting a secret key with <em>state=absent</em></div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The display name you assign to the secret key. Does not have to be unique, and it's changeable. Required when creating a customer secret key. The length of the description must be between 1 and 200 characters.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The state of the customer secret key that must be asserted to. When <em>state=present</em>, and the secret key doesn't exist, the secret key is created. When <em>state=absent</em>, the secret key is deleted.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>user_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>customer_secret_key_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the Customer Secret Key. Required when the secret keys's description needs to be updated with <em>state=present</em> and for deleting a secret key with <em>state=absent</em></div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The display name you assign to the secret key. Does not have to be unique, and it's changeable. Required when creating a customer secret key. The length of the description must be between 1 and 200 characters.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>The state of the customer secret key that must be asserted to. When <em>state=present</em>, and the secret key doesn't exist, the secret key is created. When <em>state=absent</em>, the secret key is deleted.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>user_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a new customer secret key
@@ -214,58 +240,54 @@ Examples
         state: "absent"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>oci_customer_secret_key</td>
-    <td>
-        <div>Details of the Customer Secret Key. The &quot;key&quot; attribute is returned only during creation of the customer secret key.</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>dict</td>
-    <td align=center>{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'display_name': 'My first customer secret key description 900', 'time_created': '2018-01-08T05:20:23.353000+00:00', 'key': 'wtUboLOGc3p8t0LG6d/wVJF+fwj0R700bW87LK41+kU=', 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'time_expires': 'None', 'id': 'ocid1.credential.oc1..xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>oci_customer_secret_key</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>Details of the Customer Secret Key. The &quot;key&quot; attribute is returned only during creation of the customer secret key.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'display_name': 'My first customer secret key description 900', 'time_created': '2018-01-08T05:20:23.353000+00:00', 'key': 'wtUboLOGc3p8t0LG6d/wVJF+fwj0R700bW87LK41+kU=', 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'time_expires': 'None', 'id': 'ocid1.credential.oc1..xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_customer_secret_key.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_data_guard_association_facts_module.rst
+++ b/docs/modules/oci_data_guard_association_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_data_guard_association_facts:
+:source: cloud/oracle/oci_data_guard_association_facts.py
+
+:orphan:
+
+.. _oci_data_guard_association_facts_module:
 
 
 oci_data_guard_association_facts - Fetches details of an OCI Data Guard Association
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,160 @@ oci_data_guard_association_facts - Fetches details of an OCI Data Guard Associat
 
 Synopsis
 --------
-
-
-* Fetches details of an OCI Data Guard Association
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of an OCI Data Guard Association
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>data_guard_association_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Data Guard Association whose details needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>database_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the database whose Data Guard Association details needs to be fetched</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>data_guard_association_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Data Guard Association whose details needs to be fetched.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>database_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the database whose Data Guard Association details needs to be fetched</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -168,215 +186,251 @@ Examples
           data_guard_association_id: 'ocid1.dgassociation.abuw'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>data_guard_association</td>
-    <td>
-        <div>Attributes of the Data Guard Association.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'peer_db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_state': 'PROVISIONING', 'peer_data_guard_association_id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'peer_role': 'STANDBY', 'time_created': '2018-03-03T06:55:49.463000+00:00', 'id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'role': 'PRIMARY', 'peer_database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'transport_type': 'ASYNC', 'lifecycle_details': None, 'apply_rate': '15 KByte/s', 'apply_lag': '7 seconds', 'peer_db_system_id': 'ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx', 'protection_mode': 'MAXIMUM_PERFORMANCE'}, {'peer_db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_state': 'PROVISIONING', 'peer_data_guard_association_id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'peer_role': 'STANDBY', 'time_created': '2018-03-03T06:55:49.463000+00:00', 'id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'role': 'PRIMARY', 'peer_database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'transport_type': 'ASYNC', 'lifecycle_details': None, 'apply_rate': '15 KByte/s', 'apply_lag': '7 seconds', 'peer_db_system_id': 'ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx', 'protection_mode': 'MAXIMUM_PERFORMANCE'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Data Guard Association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>peer_data_guard_association_id</td>
-        <td>
-            <div>Identifier of the peer database's Data Guard association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>peer_role</td>
-        <td>
-            <div>The role of the peer database in this Data Guard association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>STANDBY</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Data Guard Association was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Data Guard Association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>database_id</td>
-        <td>
-            <div>Identifier of the  reporting Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>role</td>
-        <td>
-            <div>The role of the reporting database in this Data Guard Association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>PRIMARY</td>
-        </tr>
-
-        <tr>
-        <td>peer_database_id</td>
-        <td>
-            <div>Identifier of the associated peer database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>transport_type</td>
-        <td>
-            <div>The redo transport type used by this Data Guard Association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ASYNC</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>Additional information about the current lifecycle_state, if available.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Details of lifecycle state</td>
-        </tr>
-
-        <tr>
-        <td>apply_rate</td>
-        <td>
-            <div>The rate at which redo logs are synced between the associated databases.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>17.00 KByte/s</td>
-        </tr>
-
-        <tr>
-        <td>apply_lag</td>
-        <td>
-            <div>The lag time between updates to the primary database and application of the redo data on the standby database, as computed by the reporting database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>9 seconds</td>
-        </tr>
-
-        <tr>
-        <td>peer_db_system_id</td>
-        <td>
-            <div>Identifier of the  DB System containing the associated peer database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>protection_mode</td>
-        <td>
-            <div>The protection mode of this Data Guard association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>MAXIMUM_PERFORMANCE</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>data_guard_association</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Data Guard Association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'peer_db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_state': 'PROVISIONING', 'peer_data_guard_association_id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'peer_role': 'STANDBY', 'time_created': '2018-03-03T06:55:49.463000+00:00', 'id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'role': 'PRIMARY', 'peer_database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'transport_type': 'ASYNC', 'lifecycle_details': None, 'apply_rate': '15 KByte/s', 'apply_lag': '7 seconds', 'peer_db_system_id': 'ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx', 'protection_mode': 'MAXIMUM_PERFORMANCE'}, {'peer_db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_state': 'PROVISIONING', 'peer_data_guard_association_id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'peer_role': 'STANDBY', 'time_created': '2018-03-03T06:55:49.463000+00:00', 'id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'role': 'PRIMARY', 'peer_database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'transport_type': 'ASYNC', 'lifecycle_details': None, 'apply_rate': '15 KByte/s', 'apply_lag': '7 seconds', 'peer_db_system_id': 'ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx', 'protection_mode': 'MAXIMUM_PERFORMANCE'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Data Guard Association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>peer_data_guard_association_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the peer database's Data Guard association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>peer_role</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The role of the peer database in this Data Guard association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">STANDBY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Data Guard Association was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Data Guard Association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>database_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the  reporting Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>role</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The role of the reporting database in this Data Guard Association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PRIMARY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>peer_database_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the associated peer database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>transport_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The redo transport type used by this Data Guard Association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ASYNC</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional information about the current lifecycle_state, if available.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Details of lifecycle state</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>apply_rate</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The rate at which redo logs are synced between the associated databases.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">17.00 KByte/s</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>apply_lag</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The lag time between updates to the primary database and application of the redo data on the standby database, as computed by the reporting database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">9 seconds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>peer_db_system_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the  DB System containing the associated peer database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>protection_mode</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The protection mode of this Data Guard association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">MAXIMUM_PERFORMANCE</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_data_guard_association_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_data_guard_association_module.rst
+++ b/docs/modules/oci_data_guard_association_module.rst
@@ -1,13 +1,14 @@
-.. _oci_data_guard_association:
+:source: cloud/oracle/oci_data_guard_association.py
+
+:orphan:
+
+.. _oci_data_guard_association_module:
 
 
 oci_data_guard_association - Create a Data Guard Association and, perform various Database role transitions of Databases associated with a Data Guard Association in OCI Database Cloud Service.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,257 +17,302 @@ oci_data_guard_association - Create a Data Guard Association and, perform variou
 
 Synopsis
 --------
-
-
-* Create an OCI Data Guard Association
-* Perform a switchover between Databases associated in a Data Guard Association
-* Perform a failover on standby Database associated in a Data Guard Association
-* Perform a reinstate on a disabled standby Database associated in a Data Guard Association
-* Since all operations of this module takes a long time, it is recommended to set the ``wait`` to False. Use :ref:`oci_data_guard_association_facts <oci_data_guard_association_facts>` to check the status of the operation as a separate task.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Create an OCI Data Guard Association
+- Perform a switchover between Databases associated in a Data Guard Association
+- Perform a failover on standby Database associated in a Data Guard Association
+- Perform a reinstate on a disabled standby Database associated in a Data Guard Association
+- Since all operations of this module takes a long time, it is recommended to set the ``wait`` to False. Use :ref:`oci_data_guard_association_facts <oci_data_guard_association_facts_module>` to check the status of the operation as a separate task.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>creation_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>ExistingDbSystem</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Specifies where to create the associated database ExistingDbSystem is the only supported  value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>data_guard_association_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The identifier of the Data Guard Association. Mandatory for role transition of the Databases associated with a specified Data Guard Association.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>database_admin_password</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A strong password for SYS, SYSTEM, and PDB Admin. The password must be at least nine characters and contain at least two uppercase,two lowercase, two numbers, and two special characters.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>database_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Database to which the Data Guard should be Associated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>peer_db_system_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the DB System to create the standby database on.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>protection_mode</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>MAXIMUM_AVAILABILITY</li>
+                                                                                                                                                                                                <li>MAXIMUM_PERFORMANCE</li>
+                                                                                                                                                                                                <li>MAXIMUM_PROTECTION</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The protection mode to set up between the primary and standby databases. The only protection mode currently supported by the Database Service is MAXIMUM_PERFORMANCE. Allowed values are MAXIMUM_AVAILABILITY, MAXIMUM_PERFORMANCE, MAXIMUM_PROTECTION</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>switchover</li>
+                                                                                                                                                                                                <li>failover</li>
+                                                                                                                                                                                                <li>reinstate</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create a new dataguard association or perform role transitions within associated databases of a dataguard association. For <em>state=present</em>, it gets created. For <em>state=switchover</em>, <em>state=failover</em>, <em>state=reinstate</em>, switchover, failover and reinstate on databases gets performed respectively.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>transport_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>SYNC</li>
+                                                                                                                                                                                                <li>ASYNC</li>
+                                                                                                                                                                                                <li>FASTSYNC</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The redo transport type to use for this Data Guard association. The only transport type currently supported by the Database Service is ASYNC. Allowed values are SYNC, ASYNC, FASTSYNC.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>creation_type<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>ExistingDbSystem</td>
-    <td><ul><li>ExistingDbSystem</li></ul></td>
-    <td>
-        <div>Specifies where to create the associated database ExistingDbSystem is the only supported  value.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>data_guard_association_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The identifier of the Data Guard Association. Mandatory for role transition of the Databases associated with a specified Data Guard Association.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>database_admin_password<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A strong password for SYS, SYSTEM, and PDB Admin. The password must be at least nine characters and contain at least two uppercase,two lowercase, two numbers, and two special characters.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>database_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Database to which the Data Guard should be Associated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>peer_db_system_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the DB System to create the standby database on.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>protection_mode<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>MAXIMUM_AVAILABILITY</li><li>MAXIMUM_PERFORMANCE</li><li>MAXIMUM_PROTECTION</li></ul></td>
-    <td>
-        <div>The protection mode to set up between the primary and standby databases. The only protection mode currently supported by the Database Service is MAXIMUM_PERFORMANCE. Allowed values are MAXIMUM_AVAILABILITY, MAXIMUM_PERFORMANCE, MAXIMUM_PROTECTION</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>switchover</li><li>failover</li><li>reinstate</li></ul></td>
-    <td>
-        <div>Create a new dataguard association or perform role transitions within associated databases of a dataguard association. For <em>state=present</em>, it gets created. For <em>state=switchover</em>, <em>state=failover</em>, <em>state=reinstate</em>, switchover, failover and reinstate on databases gets performed respectively.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>transport_type<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>SYNC</li><li>ASYNC</li><li>FASTSYNC</li></ul></td>
-    <td>
-        <div>The redo transport type to use for this Data Guard association. The only transport type currently supported by the Database Service is ASYNC. Allowed values are SYNC, ASYNC, FASTSYNC.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -307,215 +353,251 @@ Examples
           state: 'reinstate'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>data_guard_association</td>
-    <td>
-        <div>Attributes of the Data Guard Association.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'peer_db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_state': 'PROVISIONING', 'peer_data_guard_association_id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'peer_role': 'STANDBY', 'time_created': '2018-03-03T06:55:49.463000+00:00', 'id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'role': 'PRIMARY', 'peer_database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'transport_type': 'ASYNC', 'lifecycle_details': None, 'apply_rate': '15 KByte/s', 'apply_lag': '7 seconds', 'peer_db_system_id': 'ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx', 'protection_mode': 'MAXIMUM_PERFORMANCE'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Data Guard Association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>peer_data_guard_association_id</td>
-        <td>
-            <div>Identifier of the peer database's Data Guard association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>peer_role</td>
-        <td>
-            <div>The role of the peer database in this Data Guard association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>STANDBY</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Data Guard Association was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Data Guard Association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>database_id</td>
-        <td>
-            <div>Identifier of the  reporting Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>role</td>
-        <td>
-            <div>The role of the reporting database in this Data Guard Association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>PRIMARY</td>
-        </tr>
-
-        <tr>
-        <td>peer_database_id</td>
-        <td>
-            <div>Identifier of the associated peer database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>transport_type</td>
-        <td>
-            <div>The redo transport type used by this Data Guard Association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ASYNC</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>Additional information about the current lifecycle_state, if available.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Details of lifecycle state</td>
-        </tr>
-
-        <tr>
-        <td>apply_rate</td>
-        <td>
-            <div>The rate at which redo logs are synced between the associated databases.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>17.00 KByte/s</td>
-        </tr>
-
-        <tr>
-        <td>apply_lag</td>
-        <td>
-            <div>The lag time between updates to the primary database and application of the redo data on the standby database, as computed by the reporting database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>9 seconds</td>
-        </tr>
-
-        <tr>
-        <td>peer_db_system_id</td>
-        <td>
-            <div>Identifier of the  DB System containing the associated peer database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>protection_mode</td>
-        <td>
-            <div>The protection mode of this Data Guard association.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>MAXIMUM_PERFORMANCE</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>data_guard_association</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Data Guard Association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'peer_db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'lifecycle_state': 'PROVISIONING', 'peer_data_guard_association_id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'peer_role': 'STANDBY', 'time_created': '2018-03-03T06:55:49.463000+00:00', 'id': 'ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx', 'database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'role': 'PRIMARY', 'peer_database_id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx', 'transport_type': 'ASYNC', 'lifecycle_details': None, 'apply_rate': '15 KByte/s', 'apply_lag': '7 seconds', 'peer_db_system_id': 'ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx', 'protection_mode': 'MAXIMUM_PERFORMANCE'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Data Guard Association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>peer_data_guard_association_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the peer database's Data Guard association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>peer_role</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The role of the peer database in this Data Guard association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">STANDBY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Data Guard Association was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Data Guard Association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>database_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the  reporting Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>role</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The role of the reporting database in this Data Guard Association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PRIMARY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>peer_database_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the associated peer database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>transport_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The redo transport type used by this Data Guard Association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ASYNC</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional information about the current lifecycle_state, if available.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Details of lifecycle state</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>apply_rate</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The rate at which redo logs are synced between the associated databases.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">17.00 KByte/s</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>apply_lag</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The lag time between updates to the primary database and application of the redo data on the standby database, as computed by the reporting database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">9 seconds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>peer_db_system_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the  DB System containing the associated peer database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dgassociation.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>protection_mode</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The protection mode of this Data Guard association.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">MAXIMUM_PERFORMANCE</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_data_guard_association.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_database_facts_module.rst
+++ b/docs/modules/oci_database_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_database_facts:
+:source: cloud/oracle/oci_database_facts.py
+
+:orphan:
+
+.. _oci_database_facts_module:
 
 
 oci_database_facts - Fetches details of one or more Databases
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,153 +17,170 @@ oci_database_facts - Fetches details of one or more Databases
 
 Synopsis
 --------
-
-
-* Fetches details of one or more OCI Databases.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of one or more OCI Databases.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment in which the specified Database exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>database_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Database whose details needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_home_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the DB Home under which the Database is available.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment in which the specified Database exists</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>database_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Database whose details needs to be fetched.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_home_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the DB Home under which the Database is available.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch Databases
@@ -176,215 +194,251 @@ Examples
           database_id: 'ocid1.database..xcds'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>databases</td>
-    <td>
-        <div>Attributes of the Database.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'BACKUP_IN_PROGRESS', 'ncharacter_set': 'AL16UTF16', 'compartment_id': 'ocid1.compartment.aaaa', 'defined_tags': {'target_users': {'division': 'design'}}, 'pdb_name': None, 'freeform_tags': {'deployment': 'test'}, 'time_created': '2018-02-22T08:42:26.060000+00:00', 'db_workload': 'OLTP', 'db_backup_config': {'auto_backup_enabled': False}, 'db_name': 'ansibledbone', 'db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'db_unique_name': 'ansibledbone_iad2cj', 'lifecycle_details': None, 'character_set': 'AL32UTF8', 'id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'AVAILABLE', 'ncharacter_set': 'AL16UTF16', 'compartment_id': 'ocid1.compartment.aaaa', 'defined_tags': {'target_users': {'division': 'development'}}, 'pdb_name': None, 'freeform_tags': {'deployment': 'production'}, 'time_created': '2018-02-20T08:42:26.060000+00:00', 'db_workload': 'OLTP', 'db_backup_config': {'auto_backup_enabled': True}, 'db_name': 'ansibledbtwo', 'db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'db_unique_name': 'ansibledbtwo_iad2cj', 'lifecycle_details': None, 'character_set': 'AL32UTF8', 'id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>ncharacter_set</td>
-        <td>
-            <div>The national character set for the database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AL16UTF16</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the DB System where the Database resides.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>pdb_name</td>
-        <td>
-            <div>Pluggable database name. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>db_workload</td>
-        <td>
-            <div>Database workload type.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>OLTP</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the DB Node was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>character_set</td>
-        <td>
-            <div>The character set for the database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AL32UTF8</td>
-        </tr>
-
-        <tr>
-        <td>db_backup_config</td>
-        <td>
-            <div>Determines whether to configure automatic backup of the Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>db_backup_config:{ auto_backup_enabled:false }</td>
-        </tr>
-
-        <tr>
-        <td>db_name</td>
-        <td>
-            <div>The database name.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansibledb</td>
-        </tr>
-
-        <tr>
-        <td>db_home_id</td>
-        <td>
-            <div>The identifier of the DB Home containing the Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>db_unique_name</td>
-        <td>
-            <div>A system-generated name for the database to ensure uniqueness within an Oracle Data Guard group (a primary database and its standby databases). The unique name cannot be changed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansibledb_iad7b</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>Additional information about the current lifecycle_state of the Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>software_storage_size_in_gb</td>
-        <td>
-            <div>Storage size, in GBs, of the software volume that is allocated to the DB system. This is applicable only for VM-based DBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>1024</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>databases</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'BACKUP_IN_PROGRESS', 'ncharacter_set': 'AL16UTF16', 'compartment_id': 'ocid1.compartment.aaaa', 'defined_tags': {'target_users': {'division': 'design'}}, 'pdb_name': None, 'freeform_tags': {'deployment': 'test'}, 'time_created': '2018-02-22T08:42:26.060000+00:00', 'db_workload': 'OLTP', 'db_backup_config': {'auto_backup_enabled': False}, 'db_name': 'ansibledbone', 'db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'db_unique_name': 'ansibledbone_iad2cj', 'lifecycle_details': None, 'character_set': 'AL32UTF8', 'id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'AVAILABLE', 'ncharacter_set': 'AL16UTF16', 'compartment_id': 'ocid1.compartment.aaaa', 'defined_tags': {'target_users': {'division': 'development'}}, 'pdb_name': None, 'freeform_tags': {'deployment': 'production'}, 'time_created': '2018-02-20T08:42:26.060000+00:00', 'db_workload': 'OLTP', 'db_backup_config': {'auto_backup_enabled': True}, 'db_name': 'ansibledbtwo', 'db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'db_unique_name': 'ansibledbtwo_iad2cj', 'lifecycle_details': None, 'character_set': 'AL32UTF8', 'id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ncharacter_set</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The national character set for the database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AL16UTF16</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the DB System where the Database resides.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>pdb_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Pluggable database name. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_workload</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Database workload type.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">OLTP</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the DB Node was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>character_set</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The character set for the database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AL32UTF8</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_backup_config</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Determines whether to configure automatic backup of the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">db_backup_config:{ auto_backup_enabled:false }</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The database name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansibledb</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_home_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the DB Home containing the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_unique_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A system-generated name for the database to ensure uniqueness within an Oracle Data Guard group (a primary database and its standby databases). The unique name cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansibledb_iad7b</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional information about the current lifecycle_state of the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>software_storage_size_in_gb</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Storage size, in GBs, of the software volume that is allocated to the DB system. This is applicable only for VM-based DBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1024</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_database_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_database_module.rst
+++ b/docs/modules/oci_database_module.rst
@@ -1,13 +1,14 @@
-.. _oci_database:
+:source: cloud/oracle/oci_database.py
+
+:orphan:
+
+.. _oci_database_module:
 
 
 oci_database - Restore or Update a Database in OCI Database Cloud Service.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,264 +17,273 @@ oci_database - Restore or Update a Database in OCI Database Cloud Service.
 
 Synopsis
 --------
-
-
-* Restore a Database. Note that this operation is not idempotent and any existing data in the database would be overwritten by this operation.
-* Update a Database.
-* Since all operations of this module takes a long time, it is recommended to set the ``wait`` to False. Use :ref:`oci_database_facts <oci_database_facts>` to check the status of the operation as a separate task.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Restore a Database. Note that this operation is not idempotent and any existing data in the database would be overwritten by this operation.
+- Update a Database.
+- Since all operations of this module takes a long time, it is recommended to set the ``wait`` to False. Use :ref:`oci_database_facts <oci_database_facts_module>` to check the status of the operation as a separate task.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>database_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the  Database that is required to be restored or updated.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>database_scn<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>System Change Number of the backup which should be used to restore the Database.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">db_backup_config<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Determines whether to configure automatic backups for the Database.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object db_backup_config</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>database_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the  Database that is required to be restored or updated.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>database_scn</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>System Change Number of the backup which should be used to restore the Database.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>db_backup_config</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Determines whether to configure automatic backups for the Database.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>auto_backup_enabled</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Configures automatic backup if <em>auto_backup_enabled=True</em></div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>latest</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>If <em>latest=True</em>, the Database is restored to the last known good state with the least possible data loss.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>restore</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>update</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Desired action to be performed on Database</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>timestamp</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The timestamp to which Database gets restored.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>auto_backup_enabled<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Configures automatic backup if <em>auto_backup_enabled=True</em></div>
-        </td>
-        </tr>
 
-        </table>
+Notes
+-----
 
-    </td>
-    </tr>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>latest<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>If <em>latest=True</em>, the Database is restored to the last known good state with the least possible data loss.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td>update</td>
-    <td><ul><li>restore</li><li>update</li></ul></td>
-    <td>
-        <div>Desired action to be performed on Database</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>timestamp<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The timestamp to which Database gets restored.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -293,215 +303,251 @@ Examples
           state: 'restore'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>database</td>
-    <td>
-        <div>Attributes of the Database.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'BACKUP_IN_PROGRESS', 'ncharacter_set': 'AL16UTF16', 'compartment_id': 'ocid1.compartment.aaaa', 'defined_tags': {'target_users': {'division': 'design'}}, 'pdb_name': None, 'freeform_tags': {'deployment': 'test'}, 'time_created': '2018-02-22T08:42:26.060000+00:00', 'db_workload': 'OLTP', 'db_backup_config': {'auto_backup_enabled': False}, 'db_name': 'ansibledb', 'db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'db_unique_name': 'ansibledb_iad2cj', 'lifecycle_details': None, 'character_set': 'AL32UTF8', 'id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>ncharacter_set</td>
-        <td>
-            <div>The national character set for the database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AL16UTF16</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the DB System where the Database resides.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>pdb_name</td>
-        <td>
-            <div>Pluggable database name. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>db_workload</td>
-        <td>
-            <div>Database workload type.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>OLTP</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the DB Node was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>character_set</td>
-        <td>
-            <div>The character set for the database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AL32UTF8</td>
-        </tr>
-
-        <tr>
-        <td>db_backup_config</td>
-        <td>
-            <div>Determines whether to configure automatic backup of the Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>db_backup_config:{ auto_backup_enabled:false }</td>
-        </tr>
-
-        <tr>
-        <td>db_name</td>
-        <td>
-            <div>The database name.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansibledb</td>
-        </tr>
-
-        <tr>
-        <td>db_home_id</td>
-        <td>
-            <div>The identifier of the DB Home containing the Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>db_unique_name</td>
-        <td>
-            <div>A system-generated name for the database to ensure uniqueness within an Oracle Data Guard group (a primary database and its standby databases). The unique name cannot be changed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansibledb_iad7b</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>Additional information about the current lifecycle_state of the Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>software_storage_size_in_gb</td>
-        <td>
-            <div>Storage size, in GBs, of the software volume that is allocated to the DB system. This is applicable only for VM-based DBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>1024</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>database</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'BACKUP_IN_PROGRESS', 'ncharacter_set': 'AL16UTF16', 'compartment_id': 'ocid1.compartment.aaaa', 'defined_tags': {'target_users': {'division': 'design'}}, 'pdb_name': None, 'freeform_tags': {'deployment': 'test'}, 'time_created': '2018-02-22T08:42:26.060000+00:00', 'db_workload': 'OLTP', 'db_backup_config': {'auto_backup_enabled': False}, 'db_name': 'ansibledb', 'db_home_id': 'ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx', 'db_unique_name': 'ansibledb_iad2cj', 'lifecycle_details': None, 'character_set': 'AL32UTF8', 'id': 'ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ncharacter_set</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The national character set for the database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AL16UTF16</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the DB System where the Database resides.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>pdb_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Pluggable database name. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_workload</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Database workload type.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">OLTP</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the DB Node was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>character_set</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The character set for the database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AL32UTF8</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_backup_config</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Determines whether to configure automatic backup of the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">db_backup_config:{ auto_backup_enabled:false }</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The database name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansibledb</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_home_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the DB Home containing the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_unique_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A system-generated name for the database to ensure uniqueness within an Oracle Data Guard group (a primary database and its standby databases). The unique name cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansibledb_iad7b</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional information about the current lifecycle_state of the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.database.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>software_storage_size_in_gb</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Storage size, in GBs, of the software volume that is allocated to the DB system. This is applicable only for VM-based DBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1024</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_database.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_home_facts_module.rst
+++ b/docs/modules/oci_db_home_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_home_facts:
+:source: cloud/oracle/oci_db_home_facts.py
+
+:orphan:
+
+.. _oci_db_home_facts_module:
 
 
 oci_db_home_facts - Fetches details of one or more OCI DB Homes
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,153 +17,180 @@ oci_db_home_facts - Fetches details of one or more OCI DB Homes
 
 Synopsis
 --------
-
-
-* Fetches details of the OCI DB Home.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of the OCI DB Home.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment in which the specified DB System exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_home_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the DB Home whose details needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_system_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the DB System under which the DB Home is available.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment in which the specified DB System exists</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_home_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the DB Home whose details needs to be fetched.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_system_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the DB System under which the DB Home is available.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch DB Home
@@ -176,155 +204,167 @@ Examples
           db_home_id: 'ocid1.dbhome..xcds'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_homes</td>
-    <td>
-        <div>Attributes of the Fetched DB Homes</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'db_version': '12.2.0.1.1', 'display_name': 'ansible-db-one', 'compartment_id': 'ocid1.compartment.aaaa', 'lifecycle_state': 'AVAILABLE', 'last_patch_history_entry_id': 'ocid1.dbpatchhistory.aaaa', 'time_created': '2018-02-16T08:44:32.779000+00:00', 'db_system_id': 'ocid1.dbsystem.aaaa', 'id': 'ocid1.dbhome.aaaa'}, {'db_version': '12.2.0.1.1', 'display_name': 'ansible-db-two', 'compartment_id': 'ocid1.compartment.aaaa', 'lifecycle_state': 'AVAILABLE', 'last_patch_history_entry_id': 'ocid1.dbpatchhistory.aaaa', 'time_created': '2018-02-16T08:44:32.779000+00:00', 'db_system_id': 'ocid1.dbsystem.aaaa', 'id': 'ocid1.dbhome.aaaa'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>db_version</td>
-        <td>
-            <div>Oracle database version.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>12.2.0.1.1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>The user-friendly name for the DB Home.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-db-home</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the DB Home</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the DB System was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>last_patch_history_entry_id</td>
-        <td>
-            <div>The OCID of the last patch history. This is updated as soon as a patch operation is started.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.lastpatchhistory.aaaa</td>
-        </tr>
-
-        <tr>
-        <td>db_system_id</td>
-        <td>
-            <div>Identifier of the  DB System under which the DB Home should exists.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the DB Home.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_homes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Fetched DB Homes</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'db_version': '12.2.0.1.1', 'display_name': 'ansible-db-one', 'compartment_id': 'ocid1.compartment.aaaa', 'lifecycle_state': 'AVAILABLE', 'last_patch_history_entry_id': 'ocid1.dbpatchhistory.aaaa', 'time_created': '2018-02-16T08:44:32.779000+00:00', 'db_system_id': 'ocid1.dbsystem.aaaa', 'id': 'ocid1.dbhome.aaaa'}, {'db_version': '12.2.0.1.1', 'display_name': 'ansible-db-two', 'compartment_id': 'ocid1.compartment.aaaa', 'lifecycle_state': 'AVAILABLE', 'last_patch_history_entry_id': 'ocid1.dbpatchhistory.aaaa', 'time_created': '2018-02-16T08:44:32.779000+00:00', 'db_system_id': 'ocid1.dbsystem.aaaa', 'id': 'ocid1.dbhome.aaaa'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Oracle database version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">12.2.0.1.1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The user-friendly name for the DB Home.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-db-home</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the DB Home</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the DB System was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>last_patch_history_entry_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the last patch history. This is updated as soon as a patch operation is started.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.lastpatchhistory.aaaa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_system_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the  DB System under which the DB Home should exists.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the DB Home.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_home_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_home_module.rst
+++ b/docs/modules/oci_db_home_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_home:
+:source: cloud/oracle/oci_db_home.py
+
+:orphan:
+
+.. _oci_db_home_module:
 
 
 oci_db_home - Create,update and delete a DB Home in OCI Database Cloud Service.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,404 +17,417 @@ oci_db_home - Create,update and delete a DB Home in OCI Database Cloud Service.
 
 Synopsis
 --------
-
-
-* Create an OCI DB Home
-* Update an OCI DB Home, if present
-* Delete an OCI DB Home, if present.
-* Since all operations of this module takes a long time, it is recommended to set the ``wait`` to False. Use :ref:`oci_db_home_facts <oci_db_home_facts>` to check the status of the operation as a separate task.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Create an OCI DB Home
+- Update an OCI DB Home, if present
+- Delete an OCI DB Home, if present.
+- Since all operations of this module takes a long time, it is recommended to set the ``wait`` to False. Use :ref:`oci_db_home_facts <oci_db_home_facts_module>` to check the status of the operation as a separate task.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">database<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The details of the databse to be created under the db home. Mandatory for create operation.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object database</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>database</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The details of the databse to be created under the db home. Mandatory for create operation.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>backup_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The backup OCID. This parameter only valid for <em>source=DB_BACKUP</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ncharacter_set</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>National character set for the database.The default is AL16UTF16. Allowed values are AL16UTF16 or UTF8. This parameter only valid for <em>source=NONE</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>backup_tde_password</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password to open the TDE wallet. This parameter only valid for <em>source=DB_BACKUP</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>pdb_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>pluggable database name.It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name. This parameter only valid for <em>source=NONE</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>db_workload</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Database workload type with allowed values OLTP and DSS. This parameter only valid for <em>source=NONE</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>db_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The name of the database name. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. This parameter only valid for <em>source=NONE</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>admin_password</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A strong password for SYS, SYSTEM, and PDB Admin. The password must be at least nine characters and contain at least two uppercase,two lowercase, two numbers, and two special characters. This parameter valid for <em>source=NONE</em> and <em>source=DB_BACKUP</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>db_backup_config</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Consists of the option 'auto_backup_enabled' to determine whether to configures automatic backups of the databse. This parameter only valid for <em>source=NONE</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>character_set</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The character set for the database. The default is AL32UTF8. This parameter only valid for <em>source=NONE</em>.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>db_home_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The identifier of the db home. Mandatory for update and delete.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>db_system_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the  DB System under which the DB Home should exist. Mandatory for create.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>db_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A valid Oracle database version. Mandatory for create.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The user-provided name of the database home.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>patch_details</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The patch version and what actions to perform with that, on specified DB Home. This is required only for the update use case.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>action</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>APPLY</li>
+                                                                                                                                                                                                <li>PRECHECK</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The action to perform on the patch.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>patch_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCID of the patch.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>source</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>NONE</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>DB_BACKUP</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Source of database. <em>source=NONE</em> for creating a new database <em>source=DB_BACKUP</em> for creating a new database by restoring a backup.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete DB Home. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>backup_id<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The backup OCID. This parameter only valid for <em>source=DB_BACKUP</em>.</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>ncharacter_set<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>National character set for the database.The default is AL16UTF16. Allowed values are AL16UTF16 or UTF8. This parameter only valid for <em>source=NONE</em>.</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        <tr>
-        <td>backup_tde_password<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The password to open the TDE wallet. This parameter only valid for <em>source=DB_BACKUP</em>.</div>
-        </td>
-        </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-        <tr>
-        <td>pdb_name<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>pluggable database name.It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name. This parameter only valid for <em>source=NONE</em>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>db_workload<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Database workload type with allowed values OLTP and DSS. This parameter only valid for <em>source=NONE</em>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>db_name<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The name of the database name. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. This parameter only valid for <em>source=NONE</em>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>admin_password<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A strong password for SYS, SYSTEM, and PDB Admin. The password must be at least nine characters and contain at least two uppercase,two lowercase, two numbers, and two special characters. This parameter valid for <em>source=NONE</em> and <em>source=DB_BACKUP</em>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>db_backup_config<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Consists of the option 'auto_backup_enabled' to determine whether to configures automatic backups of the databse. This parameter only valid for <em>source=NONE</em>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>character_set<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The character set for the database. The default is AL32UTF8. This parameter only valid for <em>source=NONE</em>.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_home_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The identifier of the db home. Mandatory for update and delete.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_system_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the  DB System under which the DB Home should exist. Mandatory for create.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_version<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A valid Oracle database version. Mandatory for create.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The user-provided name of the database home.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">patch_details<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The patch version and what actions to perform with that, on specified DB Home. This is required only for the update use case.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object patch_details</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>action<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td><ul><li>APPLY</li><li>PRECHECK</li></ul></td>
-        <td>
-        <div>The action to perform on the patch.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>patch_id<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The OCID of the patch.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>source<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>NONE</td>
-    <td><ul><li>NONE</li><li>DB_BACKUP</li></ul></td>
-    <td>
-        <div>Source of database. <em>source=NONE</em> for creating a new database <em>source=DB_BACKUP</em> for creating a new database by restoring a backup.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete DB Home. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -467,155 +481,167 @@ Examples
         state: 'absense'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_home</td>
-    <td>
-        <div>Attributes of the created/updated DB Home. For delete, deleted DB Home description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'db_version': '12.2.0.1.1', 'display_name': 'ansible-db', 'compartment_id': 'ocid1.compartment.aaaa', 'lifecycle_state': 'AVAILABLE', 'last_patch_history_entry_id': 'ocid1.dbpatchhistory.aaaa', 'time_created': '2018-02-16T08:44:32.779000+00:00', 'db_system_id': 'ocid1.dbsystem.aaaa', 'id': 'ocid1.dbhome.aaaa'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>db_version</td>
-        <td>
-            <div>Oracle database version.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>12.2.0.1.1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>The user-friendly name for the DB Home.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-db-home</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the DB Home</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the DB System was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>last_patch_history_entry_id</td>
-        <td>
-            <div>The OCID of the last patch history. This is updated as soon as a patch operation is started.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.lastpatchhistory.aaaa</td>
-        </tr>
-
-        <tr>
-        <td>db_system_id</td>
-        <td>
-            <div>Identifier of the  DB System under which the DB Home should exists.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the DB Home.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_home</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated DB Home. For delete, deleted DB Home description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'db_version': '12.2.0.1.1', 'display_name': 'ansible-db', 'compartment_id': 'ocid1.compartment.aaaa', 'lifecycle_state': 'AVAILABLE', 'last_patch_history_entry_id': 'ocid1.dbpatchhistory.aaaa', 'time_created': '2018-02-16T08:44:32.779000+00:00', 'db_system_id': 'ocid1.dbsystem.aaaa', 'id': 'ocid1.dbhome.aaaa'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Oracle database version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">12.2.0.1.1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The user-friendly name for the DB Home.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-db-home</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the DB Home</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the DB System was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>last_patch_history_entry_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the last patch history. This is updated as soon as a patch operation is started.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.lastpatchhistory.aaaa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_system_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the  DB System under which the DB Home should exists.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the DB Home.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbhome.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_home.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_home_patch_facts_module.rst
+++ b/docs/modules/oci_db_home_patch_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_home_patch_facts:
+:source: cloud/oracle/oci_db_home_patch_facts.py
+
+:orphan:
+
+.. _oci_db_home_patch_facts_module:
 
 
 oci_db_home_patch_facts - Fetches details of one or more  DB Home Patches
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,142 +17,159 @@ oci_db_home_patch_facts - Fetches details of one or more  DB Home Patches
 
 Synopsis
 --------
-
-
-* Fetches details of one or more  DB Home Patches.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of one or more  DB Home Patches.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_home_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the  DB Home for which the Patches are supported.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>patch_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of a Patch whose details needs to be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_home_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the  DB Home for which the Patches are supported.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>patch_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of a Patch whose details needs to be fetched.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch all DB Home Patches
@@ -165,155 +183,167 @@ Examples
         patch_id: "ocid1.dbpatch.aaaa"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_home_patches</td>
-    <td>
-        <div>Attributes of the DB Home Patch.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'PRECHECK', 'description': 'Oct 2017 12.2 Database patch', 'last_action': 'PRECHECK', 'id': 'ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx', 'version': '12.2.0.1.171017', 'time_released': '2018-01-29T01:00:00+00:00', 'available_actions': ['APPLY', 'PRECHECK'], 'lifecycle_details': 'Operation was successful'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the patch as a result of last_action.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The  text describing this patch package.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Oct 2017 12.2 Database patch</td>
-        </tr>
-
-        <tr>
-        <td>last_action</td>
-        <td>
-            <div>Action that is currently being performed or was completed last.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>PRECHECK</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the DB Home Patch.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>version</td>
-        <td>
-            <div>The version of this patch package.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>12.2.0.1.171017</td>
-        </tr>
-
-        <tr>
-        <td>time_released</td>
-        <td>
-            <div>The date and time that the patch was released.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-01-29 01:00:00</td>
-        </tr>
-
-        <tr>
-        <td>available_actions</td>
-        <td>
-            <div>Actions that can possibly be performed using this patch.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>APPLY</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>A descriptive text associated with the lifecycle_state. Typically can contain additional displayable text.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>DCS-10001:Internal error encountered</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_home_patches</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the DB Home Patch.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'PRECHECK', 'description': 'Oct 2017 12.2 Database patch', 'last_action': 'PRECHECK', 'id': 'ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx', 'version': '12.2.0.1.171017', 'time_released': '2018-01-29T01:00:00+00:00', 'available_actions': ['APPLY', 'PRECHECK'], 'lifecycle_details': 'Operation was successful'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the patch as a result of last_action.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The  text describing this patch package.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Oct 2017 12.2 Database patch</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>last_action</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Action that is currently being performed or was completed last.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PRECHECK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the DB Home Patch.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The version of this patch package.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">12.2.0.1.171017</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_released</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time that the patch was released.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-01-29 01:00:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>available_actions</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Actions that can possibly be performed using this patch.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">APPLY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A descriptive text associated with the lifecycle_state. Typically can contain additional displayable text.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">DCS-10001:Internal error encountered</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_home_patch_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_home_patch_history_entry_facts_module.rst
+++ b/docs/modules/oci_db_home_patch_history_entry_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_home_patch_history_entry_facts:
+:source: cloud/oracle/oci_db_home_patch_history_entry_facts.py
+
+:orphan:
+
+.. _oci_db_home_patch_history_entry_facts_module:
 
 
 oci_db_home_patch_history_entry_facts - Fetches details of one or more DB Home Patch History Entries
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,142 +17,159 @@ oci_db_home_patch_history_entry_facts - Fetches details of one or more DB Home P
 
 Synopsis
 --------
-
-
-* Fetches details of one or more  DB Home Patch History Entries.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of one or more  DB Home Patch History Entries.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_home_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the  DB Home whose Patch History Entries needs to be fetched</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>patch_history_entry_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of a Patch History Entry whose details needs to be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_home_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the  DB Home whose Patch History Entries needs to be fetched</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>patch_history_entry_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of a Patch History Entry whose details needs to be fetched.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch all DB Home Patch History Entries
@@ -165,145 +183,153 @@ Examples
         patch_history_entry_id: 'ocid1.dbpatchhistory.oc1.ad.abu'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_home_patch_history_entries</td>
-    <td>
-        <div>Attributes of the DB Home Patch History Entry</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'time_ended': '2018-02-24T18:28:52.198000+00:00', 'lifecycle_state': 'SUCCEEDED', 'patch_id': 'ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx', 'time_started': '2018-02-24T18:25:06.151000+00:00', 'action': 'PRECHECK', 'lifecycle_details': 'Action was successful', 'id': 'ocid1.dbpatchhistory.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>time_ended</td>
-        <td>
-            <div>The date and time when the patch action completed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-01-29 01:00:00</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the action.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>SUCCEEDED</td>
-        </tr>
-
-        <tr>
-        <td>patch_id</td>
-        <td>
-            <div>Identifier of the Patch whose history is fetched</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_started</td>
-        <td>
-            <div>The date and time when the patch action started.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-01-29 12:30:00</td>
-        </tr>
-
-        <tr>
-        <td>action</td>
-        <td>
-            <div>The action being performed or was completed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>APPLY</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>A descriptive text associated with the lifecycle_state. Typically can contain additional displayable text.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>DCS-10001:Internal error encountered</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the DB Home Patch History Entry.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbpatchhistory.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_home_patch_history_entries</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the DB Home Patch History Entry</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'time_ended': '2018-02-24T18:28:52.198000+00:00', 'lifecycle_state': 'SUCCEEDED', 'patch_id': 'ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx', 'time_started': '2018-02-24T18:25:06.151000+00:00', 'action': 'PRECHECK', 'lifecycle_details': 'Action was successful', 'id': 'ocid1.dbpatchhistory.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_ended</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time when the patch action completed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-01-29 01:00:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the action.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">SUCCEEDED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>patch_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Patch whose history is fetched</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_started</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time when the patch action started.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-01-29 12:30:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>action</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The action being performed or was completed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">APPLY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A descriptive text associated with the lifecycle_state. Typically can contain additional displayable text.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">DCS-10001:Internal error encountered</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the DB Home Patch History Entry.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbpatchhistory.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_home_patch_history_entry_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_node_facts_module.rst
+++ b/docs/modules/oci_db_node_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_node_facts:
+:source: cloud/oracle/oci_db_node_facts.py
+
+:orphan:
+
+.. _oci_db_node_facts_module:
 
 
 oci_db_node_facts - Fetches details of one or more OCI DB Nodes
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,153 +17,170 @@ oci_db_node_facts - Fetches details of one or more OCI DB Nodes
 
 Synopsis
 --------
-
-
-* Fetches details of the OCI DB Home.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of the OCI DB Home.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment in which the specified DB System exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_node_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the DB Node whose details needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_system_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the DB System under which the DB Node is available.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment in which the specified DB System exists</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_node_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the DB Node whose details needs to be fetched.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_system_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the DB System under which the DB Node is available.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch Db Nodes
@@ -176,155 +194,167 @@ Examples
           db_node_id: 'ocid1.dbnode..xcds'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_nodes</td>
-    <td>
-        <div>Attributes of the fetched DB Nodes.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'hostname': 'db-system-one', 'time_created': '2018-02-17T07:59:04.715000+00:00', 'vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'db_system_id': 'ocid1.dbsystem.oc1.ia', 'backup_vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.dbnode.oc1.iad.xxxxxEXAMPLExxxxx', 'software_storage_size_in_gb': '1024'}, {'lifecycle_state': 'AVAILABLE', 'hostname': 'db-system-two', 'time_created': '2018-02-17T07:59:04.715000+00:00', 'vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'db_system_id': 'ocid1.dbsystem.oc1.xvf', 'backup_vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.dbnode.oc1.iad.xxxxxEXAMPLExxxxx', 'software_storage_size_in_gb': '1024'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the DB Node.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>hostname</td>
-        <td>
-            <div>The host name for the DB Node.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-db-node</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the DB Node was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>vnic_id</td>
-        <td>
-            <div>The OCID of the VNIC of this DB Node</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>db_system_id</td>
-        <td>
-            <div>Identifier of the  DB System under which the DB Node exists.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>backup_vnic_id</td>
-        <td>
-            <div>The OCID of the backup VNIC of this DB Node</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the DB Node.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbnode.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>software_storage_size_in_gb</td>
-        <td>
-            <div>Storage size, in GBs, of the software volume that is allocated to the DB system. This is applicable only for VM-based DBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>1024</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_nodes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the fetched DB Nodes.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'hostname': 'db-system-one', 'time_created': '2018-02-17T07:59:04.715000+00:00', 'vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'db_system_id': 'ocid1.dbsystem.oc1.ia', 'backup_vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.dbnode.oc1.iad.xxxxxEXAMPLExxxxx', 'software_storage_size_in_gb': '1024'}, {'lifecycle_state': 'AVAILABLE', 'hostname': 'db-system-two', 'time_created': '2018-02-17T07:59:04.715000+00:00', 'vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'db_system_id': 'ocid1.dbsystem.oc1.xvf', 'backup_vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.dbnode.oc1.iad.xxxxxEXAMPLExxxxx', 'software_storage_size_in_gb': '1024'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the DB Node.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostname</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The host name for the DB Node.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-db-node</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the DB Node was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vnic_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VNIC of this DB Node</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_system_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the  DB System under which the DB Node exists.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>backup_vnic_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the backup VNIC of this DB Node</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the DB Node.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbnode.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>software_storage_size_in_gb</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Storage size, in GBs, of the software volume that is allocated to the DB system. This is applicable only for VM-based DBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1024</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_node_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_node_module.rst
+++ b/docs/modules/oci_db_node_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_node:
+:source: cloud/oracle/oci_db_node.py
+
+:orphan:
+
+.. _oci_db_node_module:
 
 
 oci_db_node - Control the lifecycle of a DB Node in OCI's Database Cloud Service.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,176 +17,204 @@ oci_db_node - Control the lifecycle of a DB Node in OCI's Database Cloud Service
 
 Synopsis
 --------
-
-
-* Stop/start a DB Node
-* Reset a DB Node
-* Soft-reset a DB Node
-* All operations of this module returns after triggering the lifecycle operation. Use :ref:`oci_db_node_facts <oci_db_node_facts>` to check the status of the operation.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Stop/start a DB Node
+- Reset a DB Node
+- Soft-reset a DB Node
+- All operations of this module returns after triggering the lifecycle operation. Use :ref:`oci_db_node_facts <oci_db_node_facts_module>` to check the status of the operation.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_node_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the DB Node whose lifecycle state is to be controlled.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>stop</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>start</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>reset</li>
+                                                                                                                                                                                                <li>softreset</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The state of the DB Node that must be asserted to. When <em>state=stop</em>, specified DB Node is powered off. When <em>state=start</em>, the specified DB Node is powered on. When <em>state=softreset</em>, an ACPI shutdown is initiated and specified DB Node is powered on. When <em>state=reset</em>, specified DB Node is powered off and then powered on. Note that <em>state=softreset</em> and <em>state=reset</em> states are not idempotent. Every time a play is executed with these <code>state</code> options, a shutdown and a power-on sequence is executed against the DB node.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_node_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the DB Node whose lifecycle state is to be controlled.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td>start</td>
-    <td><ul><li>stop</li><li>start</li><li>reset</li><li>softreset</li></ul></td>
-    <td>
-        <div>The state of the DB Node that must be asserted to. When <em>state=stop</em>, specified DB Node is powered off. When <em>state=start</em>, the specified DB Node is powered on. When <em>state=softreset</em>, an ACPI shutdown is initiated and specified DB Node is powered on. When <em>state=reset</em>, specified DB Node is powered off and then powered on. Note that <em>state=softreset</em> and <em>state=reset</em> states are not idempotent. Every time a play is executed with these <code>state</code> options, a shutdown and a power-on sequence is executed against the DB node.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -196,155 +225,167 @@ Examples
         state: 'stop'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_node</td>
-    <td>
-        <div>Attributes of the Db Node.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'hostname': 'db-system-one', 'time_created': '2018-02-17T07:59:04.715000+00:00', 'vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'db_system_id': 'ocid1.dbsystem.oc1.ia', 'backup_vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.dbnode.oc1.iad.xxxxxEXAMPLExxxxx', 'software_storage_size_in_gb': '1024'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the DB Node.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>hostname</td>
-        <td>
-            <div>The host name for the DB Node.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-db-node</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the DB Node was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>vnic_id</td>
-        <td>
-            <div>The OCID of the VNIC of this DB Node</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>db_system_id</td>
-        <td>
-            <div>Identifier of the  DB System under which the DB Node exists.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>backup_vnic_id</td>
-        <td>
-            <div>The OCID of the backup VNIC of this DB Node</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the DB Node.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbnode.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>software_storage_size_in_gb</td>
-        <td>
-            <div>Storage size, in GBs, of the software volume that is allocated to the DB system. This is applicable only for VM-based DBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>1024</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_node</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Db Node.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'hostname': 'db-system-one', 'time_created': '2018-02-17T07:59:04.715000+00:00', 'vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'db_system_id': 'ocid1.dbsystem.oc1.ia', 'backup_vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.dbnode.oc1.iad.xxxxxEXAMPLExxxxx', 'software_storage_size_in_gb': '1024'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the DB Node.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostname</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The host name for the DB Node.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-db-node</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the DB Node was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vnic_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VNIC of this DB Node</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_system_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the  DB System under which the DB Node exists.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>backup_vnic_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the backup VNIC of this DB Node</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the DB Node.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbnode.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>software_storage_size_in_gb</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Storage size, in GBs, of the software volume that is allocated to the DB system. This is applicable only for VM-based DBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1024</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_node.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_system_facts_module.rst
+++ b/docs/modules/oci_db_system_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_system_facts:
+:source: cloud/oracle/oci_db_system_facts.py
+
+:orphan:
+
+.. _oci_db_system_facts_module:
 
 
 oci_db_system_facts - Fetches details of the OCI DB System
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,170 @@ oci_db_system_facts - Fetches details of the OCI DB System
 
 Synopsis
 --------
-
-
-* Fetches details of the OCI DB System.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of the OCI DB System.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment in which this DB System exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_system_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the DB System whose details needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment in which this DB System exists</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_system_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the DB System whose details needs to be fetched.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch DB System
@@ -166,345 +194,433 @@ Examples
           db_system_id: 'ocid1.dbsystem..xcds'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_system</td>
-    <td>
-        <div>Attributes of the Fetched DB System.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'domain': 'ansiblevcn955.ansiblevcn955.oraclevcn.com', 'backup_subnet_id': None, 'reco_storage_size_in_gb': None, 'database_edition': 'STANDARD_EDITION', 'time_created': '2018-02-10T19:21:44.171000+00:00', 'shape': 'BM.DenseIO1.36', 'disk_redundancy': 'NORMAL', 'last_patch_history_entry_id': None, 'license_model': 'LICENSE_INCLUDED', 'lifecycle_details': None, 'data_storage_size_in_gbs': None, 'id': 'ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx', 'listener_port': 1521, 'lifecycle_state': 'PROVISIONING', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'ansible-db-system-955', 'data_storage_percentage': 80, 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'subnet_id': 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'defined_tags': {'target_users': {'division': 'accounts'}}, 'hostname': 'db-system-955', 'freeform_tags': {'deployment': 'production'}, 'ssh_public_keys': ['ssh-rsa AAA'], 'vip_ids': None, 'cluster_name': 'db-clus-955', 'scan_ip_ids': None, 'version': None, 'cpu_core_count': 2, 'scan_dns_record_id': None, 'node_count': None}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>domain</td>
-        <td>
-            <div>The domain name for the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansiblevcn955.ansiblevcn955.oraclevcn.com</td>
-        </tr>
-
-        <tr>
-        <td>data_storage_percentage</td>
-        <td>
-            <div>The percentage assigned to DATA storage</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>80</td>
-        </tr>
-
-        <tr>
-        <td>reco_storage_size_in_gb</td>
-        <td>
-            <div>RECO/REDO storage size, in GBs, that is currently allocated to the DB system. This is applicable only for VM-based DBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>1024</td>
-        </tr>
-
-        <tr>
-        <td>database_edition</td>
-        <td>
-            <div>The Oracle Database Edition that applies to all the databases on the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>STANDARD_EDITION</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the DB System was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>shape</td>
-        <td>
-            <div>The shape of the DB System</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BM.DenseIO1.36</td>
-        </tr>
-
-        <tr>
-        <td>disk_redundancy</td>
-        <td>
-            <div>The type of redundancy configured for the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>NORMAL</td>
-        </tr>
-
-        <tr>
-        <td>last_patch_history_entry_id</td>
-        <td>
-            <div>The OCID of the last patch history. This is updated as soon as a patch operation is started.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.lastpatchhistory.aaaa</td>
-        </tr>
-
-        <tr>
-        <td>license_model</td>
-        <td>
-            <div>The Oracle license model that applies to all the databases on the DB System</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>LICENSE_INCLUDED</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>Additional information about the current lifecycle state.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>details</td>
-        </tr>
-
-        <tr>
-        <td>data_storage_size_in_gbs</td>
-        <td>
-            <div>Data storage size, in GBs, that is currently available to the DB system. This is applicable only for VM-based DBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2048</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The identifier of the DB System</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbsystem.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>listener_port</td>
-        <td>
-            <div>The port number configured for the listener on the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>1521</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain where the DB System is located.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IwGV:US-ASHBURN-AD-2</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>The user-friendly name for the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-db-system</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the DB System</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>subnet_id</td>
-        <td>
-            <div>The OCID of the subnet the DB System is associated with.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.subnet.aaaa</td>
-        </tr>
-
-        <tr>
-        <td>scan_dns_record_id</td>
-        <td>
-            <div>The OCID of the DNS record for the SCAN IP addresses that are associated with the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid.dnsrecord.aaaa</td>
-        </tr>
-
-        <tr>
-        <td>hostname</td>
-        <td>
-            <div>The user-friendly name for the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>db-system</td>
-        </tr>
-
-        <tr>
-        <td>ssh_public_keys</td>
-        <td>
-            <div>The public key portion of one or more key pairs used for SSH access to the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>['ssh-rsa 3NzaC1y']</td>
-        </tr>
-
-        <tr>
-        <td>vip_ids</td>
-        <td>
-            <div>The OCID of the virtual IP (VIP) addresses associated with the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>['159.28.0.1']</td>
-        </tr>
-
-        <tr>
-        <td>cluster_name</td>
-        <td>
-            <div>Cluster name for Exadata and 2-node RAC DB Systems</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>db-cluster</td>
-        </tr>
-
-        <tr>
-        <td>scan_ip_ids</td>
-        <td>
-            <div>The OCID of the Single Client Access Name (SCAN) IP addresses associated with the DB System. SCAN IP addresses are typically used for load balancing and are not assigned to any interface. Clusterware directs the requests to the appropriate nodes in the cluster. For a single-node DB System, this list is empty.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.scanip.aaaa</td>
-        </tr>
-
-        <tr>
-        <td>version</td>
-        <td>
-            <div>The version of the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>12.2.0.1</td>
-        </tr>
-
-        <tr>
-        <td>cpu_core_count</td>
-        <td>
-            <div>The number of CPU cores to enable.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2</td>
-        </tr>
-
-        <tr>
-        <td>node_count</td>
-        <td>
-            <div>Number of nodes in this DB system. For RAC DBs, this will be greater than 1.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_system</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Fetched DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'domain': 'ansiblevcn955.ansiblevcn955.oraclevcn.com', 'backup_subnet_id': None, 'reco_storage_size_in_gb': None, 'database_edition': 'STANDARD_EDITION', 'time_created': '2018-02-10T19:21:44.171000+00:00', 'shape': 'BM.DenseIO1.36', 'disk_redundancy': 'NORMAL', 'last_patch_history_entry_id': None, 'license_model': 'LICENSE_INCLUDED', 'lifecycle_details': None, 'data_storage_size_in_gbs': None, 'id': 'ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx', 'listener_port': 1521, 'lifecycle_state': 'PROVISIONING', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'ansible-db-system-955', 'data_storage_percentage': 80, 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'subnet_id': 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'defined_tags': {'target_users': {'division': 'accounts'}}, 'hostname': 'db-system-955', 'freeform_tags': {'deployment': 'production'}, 'ssh_public_keys': ['ssh-rsa AAA'], 'vip_ids': None, 'cluster_name': 'db-clus-955', 'scan_ip_ids': None, 'version': None, 'cpu_core_count': 2, 'scan_dns_record_id': None, 'node_count': None}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The domain name for the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansiblevcn955.ansiblevcn955.oraclevcn.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>data_storage_percentage</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The percentage assigned to DATA storage</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">80</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>reco_storage_size_in_gb</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>RECO/REDO storage size, in GBs, that is currently allocated to the DB system. This is applicable only for VM-based DBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1024</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>database_edition</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Oracle Database Edition that applies to all the databases on the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">STANDARD_EDITION</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the DB System was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The shape of the DB System</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BM.DenseIO1.36</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>disk_redundancy</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of redundancy configured for the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NORMAL</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>last_patch_history_entry_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the last patch history. This is updated as soon as a patch operation is started.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.lastpatchhistory.aaaa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>license_model</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Oracle license model that applies to all the databases on the DB System</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">LICENSE_INCLUDED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional information about the current lifecycle state.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">details</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>data_storage_size_in_gbs</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Data storage size, in GBs, that is currently available to the DB system. This is applicable only for VM-based DBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2048</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the DB System</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbsystem.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>listener_port</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The port number configured for the listener on the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1521</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain where the DB System is located.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ASHBURN-AD-2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The user-friendly name for the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-db-system</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the DB System</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the subnet the DB System is associated with.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.subnet.aaaa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>scan_dns_record_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the DNS record for the SCAN IP addresses that are associated with the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid.dnsrecord.aaaa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostname</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The user-friendly name for the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">db-system</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ssh_public_keys</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The public key portion of one or more key pairs used for SSH access to the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['ssh-rsa 3NzaC1y']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vip_ids</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the virtual IP (VIP) addresses associated with the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['159.28.0.1']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cluster_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Cluster name for Exadata and 2-node RAC DB Systems</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">db-cluster</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>scan_ip_ids</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the Single Client Access Name (SCAN) IP addresses associated with the DB System. SCAN IP addresses are typically used for load balancing and are not assigned to any interface. Clusterware directs the requests to the appropriate nodes in the cluster. For a single-node DB System, this list is empty.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.scanip.aaaa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The version of the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">12.2.0.1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cpu_core_count</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The number of CPU cores to enable.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>node_count</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Number of nodes in this DB system. For RAC DBs, this will be greater than 1.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_system_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_system_module.rst
+++ b/docs/modules/oci_db_system_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_system:
+:source: cloud/oracle/oci_db_system.py
+
+:orphan:
+
+.. _oci_db_system_module:
 
 
 oci_db_system - Launch,update and terminate a DB System in OCI Database Cloud Service.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,514 +17,536 @@ oci_db_system - Launch,update and terminate a DB System in OCI Database Cloud Se
 
 Synopsis
 --------
-
-
-* Launch an OCI DB System
-* Update an OCI DB System, if present, with a new display name
-* Terminate an OCI DB System, if present.
-* Since all operations of this module takes a long time, it is recommended to set the ``wait`` to False. Use :ref:`oci_db_system_facts <oci_db_system_facts>` to check the status of the operation as a separate task.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Launch an OCI DB System
+- Update an OCI DB System, if present, with a new display name
+- Terminate an OCI DB System, if present.
+- Since all operations of this module takes a long time, it is recommended to set the ``wait`` to False. Use :ref:`oci_db_system_facts <oci_db_system_facts_module>` to check the status of the operation as a separate task.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Availability Domain where the DB System is located.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>backup_subnet_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the backup network subnet the DB System is associated with. Applicable only to Exadata.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>cluster_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Cluster name for Exadata and 2-node RAC DB Systems. The cluster name must begin with an an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment under which this DB System would be created. Mandatory for create operation.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>cpu_core_count<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The number of CPU cores to enable. For VM DB systems, the core count is inferred from the specific VM shape chosen, so this parameter is not used.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>data_storage_percentage<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The percentage assigned to DATA storage (user data and database files). The remaining percentage is assigned to RECO storage (database redo logs, archive logs, and recovery manager backups). Specify 80 or 40. The default is 80 percent assigned to DATA storage. This is not applicable for VM based DB systems.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>data_storage_size_in_gbs<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Size, in GBs, to which the currently attached storage needs to be scaled up to for VM based DB system. This must be greater than current storage size. Note that the total storage size attached will be more than what is requested, to account for REDO/RECO space and software volume. This option required only for update operation.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>database_edition<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>STANDARD_EDITION</li><li>ENTERPRISE_EDITION</li><li>ENTERPRISE_EDITION_EXTREME_PERFORMANCE</li><li>ENTERPRISE_EDITION_HIGH_PERFORMANCE</li></ul></td>
-    <td>
-        <div>The Oracle Database Edition that applies to all the databases on the DB System. Exadata DB Systems and 2-node RAC DB Systems require ENTERPRISE_EDITION_EXTREME_PERFORMANCE.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">db_home<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Details of the DB home to use for this database. DB home is a directory where Oracle database software is installed.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object db_home</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Availability Domain where the DB System is located.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>backup_subnet_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the backup network subnet the DB System is associated with. Applicable only to Exadata.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>cluster_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Cluster name for Exadata and 2-node RAC DB Systems. The cluster name must begin with an an alphabetic character, and may contain hyphens (-). Underscores (_) are not permitted. The cluster name can be no longer than 11 characters and is not case sensitive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which this DB System would be created. Mandatory for create operation.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>cpu_core_count</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The number of CPU cores to enable. For VM DB systems, the core count is inferred from the specific VM shape chosen, so this parameter is not used.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>data_storage_percentage</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The percentage assigned to DATA storage (user data and database files). The remaining percentage is assigned to RECO storage (database redo logs, archive logs, and recovery manager backups). Specify 80 or 40. The default is 80 percent assigned to DATA storage. This is not applicable for VM based DB systems.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>data_storage_size_in_gbs</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Size, in GBs, to which the currently attached storage needs to be scaled up to for VM based DB system. This must be greater than current storage size. Note that the total storage size attached will be more than what is requested, to account for REDO/RECO space and software volume. This option required only for update operation.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>database_edition</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>STANDARD_EDITION</li>
+                                                                                                                                                                                                <li>ENTERPRISE_EDITION</li>
+                                                                                                                                                                                                <li>ENTERPRISE_EDITION_EXTREME_PERFORMANCE</li>
+                                                                                                                                                                                                <li>ENTERPRISE_EDITION_HIGH_PERFORMANCE</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Database Edition that applies to all the databases on the DB System. Exadata DB Systems and 2-node RAC DB Systems require ENTERPRISE_EDITION_EXTREME_PERFORMANCE.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>db_home</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Details of the DB home to use for this database. DB home is a directory where Oracle database software is installed.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>db_version</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A valid Oracle database version.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The user-provided name of the database home.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>database</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The details of the database to be created under the db home. Consists of the following options, ['admin_password' describes A strong password for SYS, SYSTEM, and PDB Admin. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. required - true], ['character_set' describes the character set for the database. The default is AL32UTF8. required - false],['freeform_tags' describes Free-form tags for this database. Each tag is a simple key-value pair with no predefined name, type, or namespace. required - false], ['defined_tags' describes Defined tags for this database. Each key is predefined and scoped to a namespace. required - false] ['db_backup_config' consists of the option 'auto_backup_enabled' to determine whether to configures automatic backups of the databse. required - false], ['db_name' describes the name of the database name. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. required - true],['db_workload' describes database workload type with allowed values OLTP and DSS.required - false], ['ncharacter_set' describes National character set for the database.The default is AL16UTF16. Allowed values are AL16UTF16 or UTF8. required - false],['pdb_name' describes pluggable database name.It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are notpermitted. Pluggable database should not be same as database name. required - false]</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>db_system_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the existing DB System which required to be updated or terminated. Mandatory for terminate and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>disk_redundancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>HIGH</li>
+                                                                                                                                                                                                <li>NORMAL</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of redundancy configured for the DB System. Normal is 2-way redundancy, recommended for test and development systems. High is 3-way redundancy, recommended for production systems.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The user-friendly name for the DB System. It does not have to be unique.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A domain name used for the DB System. If the Oracle-provided Internet and VCN Resolver is enabled for the specified subnet, the domain name for the subnet is used. Hyphens (-) are not permitted.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>hostname</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The host name for the DB System. The host name must begin with an alphabetic character and can contain a maximum of 30 alphanumeric characters, including hyphens (-).The maximum length of the combined hostname and domain is 63 characters. The hostname must be unique within the subnet. If it is not unique, the DB System will fail to provision.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>initial_data_storage_size_in_gb</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Size, in GBs, of the initial data volume that will be created and attached to VM-shape based DB system. This storage can later be scaled up if needed. Note that the total storage size attached will be more than what is requested, to account for REDO/RECO space and software volume.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>license_model</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>LICENSE_INCLUDED</li>
+                                                                                                                                                                                                <li>BRING_YOUR_OWN_LICENSE</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle license model that applies to all the databases on the DB System. The default is LICENSE_INCLUDED.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>node_count</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Number of nodes to launch for a VM-shape based RAC DB system.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>purge_ssh_public_keys</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                                                                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                                                                                    <li>no</li>
+                                                                                    </ul>
+                                                                                    <b>Default:</b><br/><div style="color: blue">yes</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Purge ssh public keys  from DB System which are not present in the provided ssh public keys. If <em>purge_ssh_public_keys=no</em>, provided ssh public keys would be appended to existing ssh public keys.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>shape</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The shape of the DB System. The shape determines resources allocated to the DB System - CPU cores and memory for VM shapes; CPU cores, memory and storage for non-VM (or bare metal) shapes.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>ssh_public_keys</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The public key portion of the key pair to use for SSH access to the DB System. Multiple public keys can be provided. The length of the combined keys cannot exceed 10,000 characters.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Launch,update or terminate DB System. For <em>state=present</em>, if it does not exist, it gets created. If it exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>subnet_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the subnet the DB System is associated with.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>This attribute describes the patch version and what actions to perform with that on specified DB system. This is required only for update use case.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>action</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>APPLY</li>
+                                                                                                                                                                                                <li>PRECHECK</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The action to perform on the patch.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>patch_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCID of the patch.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>db_version<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A valid Oracle database version.</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>display_name<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The user-provided name of the database home.</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        <tr>
-        <td>database<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The details of the database to be created under the db home. Consists of the following options, ['admin_password' describes A strong password for SYS, SYSTEM, and PDB Admin. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numbers, and two special characters. required - true], ['character_set' describes the character set for the database. The default is AL32UTF8. required - false],['freeform_tags' describes Free-form tags for this database. Each tag is a simple key-value pair with no predefined name, type, or namespace. required - false], ['defined_tags' describes Defined tags for this database. Each key is predefined and scoped to a namespace. required - false] ['db_backup_config' consists of the option 'auto_backup_enabled' to determine whether to configures automatic backups of the databse. required - false], ['db_name' describes the name of the database name. It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. required - true],['db_workload' describes database workload type with allowed values OLTP and DSS.required - false], ['ncharacter_set' describes National character set for the database.The default is AL16UTF16. Allowed values are AL16UTF16 or UTF8. required - false],['pdb_name' describes pluggable database name.It must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are notpermitted. Pluggable database should not be same as database name. required - false]</div>
-        </td>
-        </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_system_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the existing DB System which required to be updated or terminated. Mandatory for terminate and update.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>disk_redundancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>HIGH</li><li>NORMAL</li></ul></td>
-    <td>
-        <div>The type of redundancy configured for the DB System. Normal is 2-way redundancy, recommended for test and development systems. High is 3-way redundancy, recommended for production systems.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The user-friendly name for the DB System. It does not have to be unique.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A domain name used for the DB System. If the Oracle-provided Internet and VCN Resolver is enabled for the specified subnet, the domain name for the subnet is used. Hyphens (-) are not permitted.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>hostname<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The host name for the DB System. The host name must begin with an alphabetic character and can contain a maximum of 30 alphanumeric characters, including hyphens (-).The maximum length of the combined hostname and domain is 63 characters. The hostname must be unique within the subnet. If it is not unique, the DB System will fail to provision.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>initial_data_storage_size_in_gb<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Size, in GBs, of the initial data volume that will be created and attached to VM-shape based DB system. This storage can later be scaled up if needed. Note that the total storage size attached will be more than what is requested, to account for REDO/RECO space and software volume.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>license_model<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>LICENSE_INCLUDED</li><li>BRING_YOUR_OWN_LICENSE</li></ul></td>
-    <td>
-        <div>The Oracle license model that applies to all the databases on the DB System. The default is LICENSE_INCLUDED.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>node_count<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Number of nodes to launch for a VM-shape based RAC DB system.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>purge_ssh_public_keys<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>True</li><li>False</li></ul></td>
-    <td>
-        <div>Purge ssh public keys  from DB System which are not present in the provided ssh public keys. If <em>purge_ssh_public_keys=no</em>, provided ssh public keys would be appended to existing ssh public keys.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>shape<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The shape of the DB System. The shape determines resources allocated to the DB System - CPU cores and memory for VM shapes; CPU cores, memory and storage for non-VM (or bare metal) shapes.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>ssh_public_keys<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The public key portion of the key pair to use for SSH access to the DB System. Multiple public keys can be provided. The length of the combined keys cannot exceed 10,000 characters.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Launch,update or terminate DB System. For <em>state=present</em>, if it does not exist, it gets created. If it exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>subnet_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the subnet the DB System is associated with.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">version<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>This attribute describes the patch version and what actions to perform with that on specified DB system. This is required only for update use case.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object version</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>action<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td><ul><li>APPLY</li><li>PRECHECK</li></ul></td>
-        <td>
-        <div>The action to perform on the patch.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>patch_id<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The OCID of the patch.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -618,345 +641,433 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_system</td>
-    <td>
-        <div>Attributes of the launched/updated DB System. For delete, deleted DB System description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'domain': 'ansiblevcn955.ansiblevcn955.oraclevcn.com', 'backup_subnet_id': None, 'reco_storage_size_in_gb': None, 'database_edition': 'STANDARD_EDITION', 'time_created': '2018-02-10T19:21:44.171000+00:00', 'shape': 'BM.DenseIO1.36', 'disk_redundancy': 'NORMAL', 'last_patch_history_entry_id': None, 'license_model': 'LICENSE_INCLUDED', 'lifecycle_details': None, 'data_storage_size_in_gbs': None, 'id': 'ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx', 'listener_port': 1521, 'lifecycle_state': 'PROVISIONING', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'ansible-db-system-955', 'data_storage_percentage': 80, 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'subnet_id': 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'defined_tags': {'target_users': {'division': 'accounts'}}, 'hostname': 'db-system-955', 'freeform_tags': {'deployment': 'production'}, 'ssh_public_keys': ['ssh-rsa AAA'], 'vip_ids': None, 'cluster_name': 'db-clus-955', 'scan_ip_ids': None, 'version': None, 'cpu_core_count': 2, 'scan_dns_record_id': None, 'node_count': None}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>domain</td>
-        <td>
-            <div>The domain name for the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansiblevcn955.ansiblevcn955.oraclevcn.com</td>
-        </tr>
-
-        <tr>
-        <td>data_storage_percentage</td>
-        <td>
-            <div>The percentage assigned to DATA storage</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>80</td>
-        </tr>
-
-        <tr>
-        <td>reco_storage_size_in_gb</td>
-        <td>
-            <div>RECO/REDO storage size, in GBs, that is currently allocated to the DB system. This is applicable only for VM-based DBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>1024</td>
-        </tr>
-
-        <tr>
-        <td>database_edition</td>
-        <td>
-            <div>The Oracle Database Edition that applies to all the databases on the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>STANDARD_EDITION</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the DB System was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>shape</td>
-        <td>
-            <div>The shape of the DB System</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BM.DenseIO1.36</td>
-        </tr>
-
-        <tr>
-        <td>disk_redundancy</td>
-        <td>
-            <div>The type of redundancy configured for the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>NORMAL</td>
-        </tr>
-
-        <tr>
-        <td>last_patch_history_entry_id</td>
-        <td>
-            <div>The OCID of the last patch history. This is updated as soon as a patch operation is started.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.lastpatchhistory.aaaa</td>
-        </tr>
-
-        <tr>
-        <td>license_model</td>
-        <td>
-            <div>The Oracle license model that applies to all the databases on the DB System</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>LICENSE_INCLUDED</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>Additional information about the current lifecycle state.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>details</td>
-        </tr>
-
-        <tr>
-        <td>data_storage_size_in_gbs</td>
-        <td>
-            <div>Data storage size, in GBs, that is currently available to the DB system. This is applicable only for VM-based DBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2048</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The identifier of the DB System</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbsystem.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>listener_port</td>
-        <td>
-            <div>The port number configured for the listener on the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>1521</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain where the DB System is located.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IwGV:US-ASHBURN-AD-2</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>The user-friendly name for the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-db-system</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the DB System</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>subnet_id</td>
-        <td>
-            <div>The OCID of the subnet the DB System is associated with.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.subnet.aaaa</td>
-        </tr>
-
-        <tr>
-        <td>scan_dns_record_id</td>
-        <td>
-            <div>The OCID of the DNS record for the SCAN IP addresses that are associated with the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid.dnsrecord.aaaa</td>
-        </tr>
-
-        <tr>
-        <td>hostname</td>
-        <td>
-            <div>The user-friendly name for the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>db-system</td>
-        </tr>
-
-        <tr>
-        <td>ssh_public_keys</td>
-        <td>
-            <div>The public key portion of one or more key pairs used for SSH access to the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>['ssh-rsa 3NzaC1y']</td>
-        </tr>
-
-        <tr>
-        <td>vip_ids</td>
-        <td>
-            <div>The OCID of the virtual IP (VIP) addresses associated with the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>['159.28.0.1']</td>
-        </tr>
-
-        <tr>
-        <td>cluster_name</td>
-        <td>
-            <div>Cluster name for Exadata and 2-node RAC DB Systems</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>db-cluster</td>
-        </tr>
-
-        <tr>
-        <td>scan_ip_ids</td>
-        <td>
-            <div>The OCID of the Single Client Access Name (SCAN) IP addresses associated with the DB System. SCAN IP addresses are typically used for load balancing and are not assigned to any interface. Clusterware directs the requests to the appropriate nodes in the cluster. For a single-node DB System, this list is empty.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.scanip.aaaa</td>
-        </tr>
-
-        <tr>
-        <td>version</td>
-        <td>
-            <div>The version of the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>12.2.0.1</td>
-        </tr>
-
-        <tr>
-        <td>cpu_core_count</td>
-        <td>
-            <div>The number of CPU cores to enable.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2</td>
-        </tr>
-
-        <tr>
-        <td>node_count</td>
-        <td>
-            <div>Number of nodes in this DB system. For RAC DBs, this will be greater than 1.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_system</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the launched/updated DB System. For delete, deleted DB System description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'domain': 'ansiblevcn955.ansiblevcn955.oraclevcn.com', 'backup_subnet_id': None, 'reco_storage_size_in_gb': None, 'database_edition': 'STANDARD_EDITION', 'time_created': '2018-02-10T19:21:44.171000+00:00', 'shape': 'BM.DenseIO1.36', 'disk_redundancy': 'NORMAL', 'last_patch_history_entry_id': None, 'license_model': 'LICENSE_INCLUDED', 'lifecycle_details': None, 'data_storage_size_in_gbs': None, 'id': 'ocid1.dbsystem.oc1.iad.xxxxxEXAMPLExxxxx', 'listener_port': 1521, 'lifecycle_state': 'PROVISIONING', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'ansible-db-system-955', 'data_storage_percentage': 80, 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'subnet_id': 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'defined_tags': {'target_users': {'division': 'accounts'}}, 'hostname': 'db-system-955', 'freeform_tags': {'deployment': 'production'}, 'ssh_public_keys': ['ssh-rsa AAA'], 'vip_ids': None, 'cluster_name': 'db-clus-955', 'scan_ip_ids': None, 'version': None, 'cpu_core_count': 2, 'scan_dns_record_id': None, 'node_count': None}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The domain name for the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansiblevcn955.ansiblevcn955.oraclevcn.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>data_storage_percentage</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The percentage assigned to DATA storage</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">80</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>reco_storage_size_in_gb</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>RECO/REDO storage size, in GBs, that is currently allocated to the DB system. This is applicable only for VM-based DBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1024</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>database_edition</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Oracle Database Edition that applies to all the databases on the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">STANDARD_EDITION</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the DB System was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The shape of the DB System</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BM.DenseIO1.36</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>disk_redundancy</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of redundancy configured for the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NORMAL</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>last_patch_history_entry_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the last patch history. This is updated as soon as a patch operation is started.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.lastpatchhistory.aaaa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>license_model</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Oracle license model that applies to all the databases on the DB System</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">LICENSE_INCLUDED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional information about the current lifecycle state.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">details</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>data_storage_size_in_gbs</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Data storage size, in GBs, that is currently available to the DB system. This is applicable only for VM-based DBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2048</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the DB System</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbsystem.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>listener_port</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The port number configured for the listener on the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1521</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain where the DB System is located.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ASHBURN-AD-2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The user-friendly name for the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-db-system</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the DB System</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the subnet the DB System is associated with.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.subnet.aaaa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>scan_dns_record_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the DNS record for the SCAN IP addresses that are associated with the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid.dnsrecord.aaaa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostname</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The user-friendly name for the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">db-system</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ssh_public_keys</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The public key portion of one or more key pairs used for SSH access to the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['ssh-rsa 3NzaC1y']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vip_ids</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the virtual IP (VIP) addresses associated with the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['159.28.0.1']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cluster_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Cluster name for Exadata and 2-node RAC DB Systems</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">db-cluster</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>scan_ip_ids</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the Single Client Access Name (SCAN) IP addresses associated with the DB System. SCAN IP addresses are typically used for load balancing and are not assigned to any interface. Clusterware directs the requests to the appropriate nodes in the cluster. For a single-node DB System, this list is empty.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.scanip.aaaa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The version of the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">12.2.0.1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cpu_core_count</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The number of CPU cores to enable.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>node_count</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Number of nodes in this DB system. For RAC DBs, this will be greater than 1.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_system.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_system_patch_facts_module.rst
+++ b/docs/modules/oci_db_system_patch_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_system_patch_facts:
+:source: cloud/oracle/oci_db_system_patch_facts.py
+
+:orphan:
+
+.. _oci_db_system_patch_facts_module:
 
 
 oci_db_system_patch_facts - Fetches details of one or more DB System Patches
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,142 +17,159 @@ oci_db_system_patch_facts - Fetches details of one or more DB System Patches
 
 Synopsis
 --------
-
-
-* Fetches details of one or more  DB System Patches.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of one or more  DB System Patches.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_system_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the  DB System for which the Patches are supported.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>patch_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of a Patch whose details needs to be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_system_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the  DB System for which the Patches are supported.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>patch_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of a Patch whose details needs to be fetched.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch all DB System Patches
@@ -165,155 +183,167 @@ Examples
         patch_id: "ocid1.dbpatch.aaaa"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_system_patches</td>
-    <td>
-        <div>Attributes of the DB System Patch.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'PRECHECK', 'description': 'Oct 2017 12.2 Database patch', 'last_action': 'PRECHECK', 'id': 'ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx', 'version': '12.2.0.1.171017', 'time_released': '2018-01-29T01:00:00+00:00', 'available_actions': ['APPLY', 'PRECHECK'], 'lifecycle_details': 'Operation was successful'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the patch as a result of last_action.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The  text describing this patch package.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Oct 2017 12.2 Database patch</td>
-        </tr>
-
-        <tr>
-        <td>last_action</td>
-        <td>
-            <div>Action that is currently being performed or was completed last.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>PRECHECK</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the DB Home Patch.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>version</td>
-        <td>
-            <div>The version of this patch package.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>12.2.0.1.171017</td>
-        </tr>
-
-        <tr>
-        <td>time_released</td>
-        <td>
-            <div>The date and time that the patch was released.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-01-29 01:00:00</td>
-        </tr>
-
-        <tr>
-        <td>available_actions</td>
-        <td>
-            <div>Actions that can possibly be performed using this patch.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>APPLY</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>A descriptive text associated with the lifecycle_state. Typically can contain additional displayable text.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>DCS-10001:Internal error encountered</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_system_patches</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the DB System Patch.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'PRECHECK', 'description': 'Oct 2017 12.2 Database patch', 'last_action': 'PRECHECK', 'id': 'ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx', 'version': '12.2.0.1.171017', 'time_released': '2018-01-29T01:00:00+00:00', 'available_actions': ['APPLY', 'PRECHECK'], 'lifecycle_details': 'Operation was successful'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the patch as a result of last_action.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The  text describing this patch package.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Oct 2017 12.2 Database patch</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>last_action</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Action that is currently being performed or was completed last.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PRECHECK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the DB Home Patch.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The version of this patch package.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">12.2.0.1.171017</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_released</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time that the patch was released.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-01-29 01:00:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>available_actions</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Actions that can possibly be performed using this patch.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">APPLY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A descriptive text associated with the lifecycle_state. Typically can contain additional displayable text.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">DCS-10001:Internal error encountered</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_system_patch_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_system_patch_history_entry_facts_module.rst
+++ b/docs/modules/oci_db_system_patch_history_entry_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_system_patch_history_entry_facts:
+:source: cloud/oracle/oci_db_system_patch_history_entry_facts.py
+
+:orphan:
+
+.. _oci_db_system_patch_history_entry_facts_module:
 
 
 oci_db_system_patch_history_entry_facts - Fetches details of one or more DB System Patch History Entries
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,142 +17,159 @@ oci_db_system_patch_history_entry_facts - Fetches details of one or more DB Syst
 
 Synopsis
 --------
-
-
-* Fetches details of one or more  DB System Patch History Entries.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of one or more  DB System Patch History Entries.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_system_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the  DB System whose Patch History Entries needs to be fetched</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>patch_history_entry_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of a Patch History Entry whose details needs to be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_system_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the  DB System whose Patch History Entries needs to be fetched</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>patch_history_entry_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of a Patch History Entry whose details needs to be fetched.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch all DB System Patch History Entries
@@ -165,145 +183,153 @@ Examples
         patch_history_entry_id: 'ocid1.dbpatchhistory.oc1.ad.abu'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_system_patch_history_entries</td>
-    <td>
-        <div>Attributes of the DB System Patch History Entry</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'time_ended': '2018-02-24T18:28:52.198000+00:00', 'lifecycle_state': 'SUCCEEDED', 'patch_id': 'ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx', 'time_started': '2018-02-24T18:25:06.151000+00:00', 'action': 'PRECHECK', 'lifecycle_details': 'Action was successful', 'id': 'ocid1.dbpatchhistory.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>time_ended</td>
-        <td>
-            <div>The date and time when the patch action completed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-01-29 01:00:00</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the action.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>SUCCEEDED</td>
-        </tr>
-
-        <tr>
-        <td>patch_id</td>
-        <td>
-            <div>Identifier of the Patch whose history is fetched</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_started</td>
-        <td>
-            <div>The date and time when the patch action started.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-01-29 12:30:00</td>
-        </tr>
-
-        <tr>
-        <td>action</td>
-        <td>
-            <div>The action being performed or was completed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>APPLY</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_details</td>
-        <td>
-            <div>A descriptive text associated with the lifecycle_state. Typically can contain additional displayable text.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>DCS-10001:Internal error encountered</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the DB System Patch History Entry.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dbpatchhistory.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_system_patch_history_entries</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the DB System Patch History Entry</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'time_ended': '2018-02-24T18:28:52.198000+00:00', 'lifecycle_state': 'SUCCEEDED', 'patch_id': 'ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx', 'time_started': '2018-02-24T18:25:06.151000+00:00', 'action': 'PRECHECK', 'lifecycle_details': 'Action was successful', 'id': 'ocid1.dbpatchhistory.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_ended</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time when the patch action completed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-01-29 01:00:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the action.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">SUCCEEDED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>patch_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Patch whose history is fetched</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbpatch.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_started</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time when the patch action started.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-01-29 12:30:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>action</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The action being performed or was completed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">APPLY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A descriptive text associated with the lifecycle_state. Typically can contain additional displayable text.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">DCS-10001:Internal error encountered</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the DB System Patch History Entry.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dbpatchhistory.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_system_patch_history_entry_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_system_shape_facts_module.rst
+++ b/docs/modules/oci_db_system_shape_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_system_shape_facts:
+:source: cloud/oracle/oci_db_system_shape_facts.py
+
+:orphan:
+
+.. _oci_db_system_shape_facts_module:
 
 
 oci_db_system_shape_facts - Fetches details of all DB System Shapes
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,228 +17,156 @@ oci_db_system_shape_facts - Fetches details of all DB System Shapes
 
 Synopsis
 --------
-
-
-* Fetches details of all DB System Shapes.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of all DB System Shapes.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Availability Domain where DB Systems should belong.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment where DB Systems should be created whose Shapes needs to be fetched</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    #Fetch DB System Shapes
-    - name: Fetch all DB System Shapes
-      oci_db_system_shape_facts:
-        compartment_id: 'ocid1.compartment.aaaa'
-        availability_domain: 'AD2'
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_system_shapes</td>
-    <td>
-        <div>Attributes of the DB System Shape.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'shape': 'VM.Standard1.4', 'available_core_count': 4, 'name': 'VM.Standard1.4'}, {'shape': 'Exadata.Quarter1.84', 'available_core_count': 84, 'name': 'Exadata.Quarter1.84'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>shape</td>
-        <td>
-            <div>Deprecated. Use name instead of shape.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>VM.Standard1.4</td>
-        </tr>
-
-        <tr>
-        <td>available_core_count</td>
-        <td>
-            <div>The maximum number of CPU cores that can be enabled on the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>4</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name of the shape used for the DB System.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>VM.Standard1.4</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>availability_domain</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Availability Domain where DB Systems should belong.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment where DB Systems should be created whose Shapes needs to be fetched</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -247,19 +176,110 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Debayan Gupta(@debayan_gupta)
+.. code-block:: yaml+jinja
+
+    
+    #Fetch DB System Shapes
+    - name: Fetch all DB System Shapes
+      oci_db_system_shape_facts:
+        compartment_id: 'ocid1.compartment.aaaa'
+        availability_domain: 'AD2'
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>db_system_shapes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the DB System Shape.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'shape': 'VM.Standard1.4', 'available_core_count': 4, 'name': 'VM.Standard1.4'}, {'shape': 'Exadata.Quarter1.84', 'available_core_count': 84, 'name': 'Exadata.Quarter1.84'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Deprecated. Use name instead of shape.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">VM.Standard1.4</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>available_core_count</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The maximum number of CPU cores that can be enabled on the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">4</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the shape used for the DB System.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">VM.Standard1.4</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_system_shape_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_version_facts_module.rst
+++ b/docs/modules/oci_db_version_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_db_version_facts:
+:source: cloud/oracle/oci_db_version_facts.py
+
+:orphan:
+
+.. _oci_db_version_facts_module:
 
 
 oci_db_version_facts - Fetches details of all DB Versions
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,142 +17,159 @@ oci_db_version_facts - Fetches details of all DB Versions
 
 Synopsis
 --------
-
-
-* Fetches details of all DB Versions.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of all DB Versions.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment where Database should be created whose supported versions needs to be fetched</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>db_system_shape</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>If provided, filters the results to the set of Database versions which are supported for the given shape.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment where Database should be created whose supported versions needs to be fetched</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>db_system_shape<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>If provided, filters the results to the set of Database versions which are supported for the given shape.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch All DB Versions
@@ -165,95 +183,83 @@ Examples
           db_system_shape: 'VM.Standard1.4'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>db_system_versions</td>
-    <td>
-        <div>Attributes of the Database Version.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'supports_pdb': False, 'version': '11.2.0.4'}, {'supports_pdb': True, 'version': '12.1.0.2'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>supports_pdb</td>
-        <td>
-            <div>Decides if this version of the Oracle database software supports pluggable database.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>True</td>
-        </tr>
-
-        <tr>
-        <td>version</td>
-        <td>
-            <div>A valid Oracle database version.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>12.2.0.1</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>db_system_versions</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Database Version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'supports_pdb': False, 'version': '11.2.0.4'}, {'supports_pdb': True, 'version': '12.1.0.2'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>supports_pdb</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Decides if this version of the Oracle database software supports pluggable database.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A valid Oracle database version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">12.2.0.1</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_db_version_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_dhcp_options_facts_module.rst
+++ b/docs/modules/oci_dhcp_options_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_dhcp_options_facts:
+:source: cloud/oracle/oci_dhcp_options_facts.py
+
+:orphan:
+
+.. _oci_dhcp_options_facts_module:
 
 
 oci_dhcp_options_facts - Fetches details of a specific Dhcp Options or a list of Dhcp Optionss in the specified VCN and compartment
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,153 +17,180 @@ oci_dhcp_options_facts - Fetches details of a specific Dhcp Options or a list of
 
 Synopsis
 --------
-
-
-* Fetches details of a specific Dhcp Options or a list of Dhcp Optionss in the specified VCN and compartment.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of a specific Dhcp Options or a list of Dhcp Optionss in the specified VCN and compartment.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment details about whose Dhcp Options must be retrived</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>dhcp_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Dhcp Options. Required if the detailsof a specific Dhcp Options details needs to be fetched. Mutually exclusive with compartment_id and vcn_id.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Cloud Network to which the Dhcp Options is attached.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment details about whose Dhcp Options must be retrived</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>dhcp_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Dhcp Options. Required if the detailsof a specific Dhcp Options details needs to be fetched. Mutually exclusive with compartment_id and vcn_id.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Virtual Cloud Network to which the Dhcp Options is attached.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Fetch details of all Dhcp Optionss in the specified compartment and VCN
@@ -177,145 +205,153 @@ Examples
           dhcp_id: 'ocid1.dhcpoptions..xcds'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>dhcp_options_list</td>
-    <td>
-        <div>Attributes of the fetched Dhcp Options(s).</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_dhcp_options', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-26T16:41:06.996000+00:00', 'id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx', 'options': [{'type': 'DomainNameServer', 'custom_dns_servers': [], 'server_type': 'VcnLocalPlusInternet'}, {'type': 'SearchDomain', 'search_domain_names': ['ansibletestvcn.oraclevcn.com']}, {'type': 'DomainNameServer', 'custom_dns_servers': ['10.0.0.8'], 'server_type': 'CustomDnsServer'}]}, {'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_dhcp_options_two', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'large'}}, 'freeform_tags': {'region': 'west'}, 'time_created': '2017-10-26T16:41:06.996000+00:00', 'id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx', 'options': [{'type': 'DomainNameServer', 'custom_dns_servers': [], 'server_type': 'VcnLocalPlusInternet'}, {'type': 'SearchDomain', 'search_domain_names': ['vcn.oraclevcn.com']}, {'type': 'DomainNameServer', 'custom_dns_servers': ['10.0.0.8', '10.0.0.12', '10.0.0.14'], 'server_type': 'CustomDnsServer'}]}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>vcn_id</td>
-        <td>
-            <div>Identifier of the Virtual Cloud Network to which the Dhcp Options is attached.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn..ixcd</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name assigned to the Dhcp Options during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_dhcp_options</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the Dhcp Options</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Dhcp Options</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Dhcp Options</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dhcpoptions.oc1.axdf</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Dhcp Options was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>options</td>
-        <td>
-            <div>A list of dhcp options.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'type': 'DomainNameServer', 'custom_dns_servers': [], 'server_type': 'CustomDnsServer'}, {'type': 'SearchDomain', 'search_domain_names': ['myansiblevcn.oraclevcn.com']}]</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>dhcp_options_list</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the fetched Dhcp Options(s).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_dhcp_options', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-26T16:41:06.996000+00:00', 'id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx', 'options': [{'type': 'DomainNameServer', 'custom_dns_servers': [], 'server_type': 'VcnLocalPlusInternet'}, {'type': 'SearchDomain', 'search_domain_names': ['ansibletestvcn.oraclevcn.com']}, {'type': 'DomainNameServer', 'custom_dns_servers': ['10.0.0.8'], 'server_type': 'CustomDnsServer'}]}, {'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_dhcp_options_two', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'large'}}, 'freeform_tags': {'region': 'west'}, 'time_created': '2017-10-26T16:41:06.996000+00:00', 'id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx', 'options': [{'type': 'DomainNameServer', 'custom_dns_servers': [], 'server_type': 'VcnLocalPlusInternet'}, {'type': 'SearchDomain', 'search_domain_names': ['vcn.oraclevcn.com']}, {'type': 'DomainNameServer', 'custom_dns_servers': ['10.0.0.8', '10.0.0.12', '10.0.0.14'], 'server_type': 'CustomDnsServer'}]}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Virtual Cloud Network to which the Dhcp Options is attached.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn..ixcd</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Dhcp Options during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_dhcp_options</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the Dhcp Options</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Dhcp Options</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Dhcp Options</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dhcpoptions.oc1.axdf</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Dhcp Options was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>options</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of dhcp options.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'type': 'DomainNameServer', 'custom_dns_servers': [], 'server_type': 'CustomDnsServer'}, {'type': 'SearchDomain', 'search_domain_names': ['myansiblevcn.oraclevcn.com']}]</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_dhcp_options_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_dhcp_options_module.rst
+++ b/docs/modules/oci_dhcp_options_module.rst
@@ -1,13 +1,14 @@
-.. _oci_dhcp_options:
+:source: cloud/oracle/oci_dhcp_options.py
+
+:orphan:
+
+.. _oci_dhcp_options_module:
 
 
 oci_dhcp_options - Create,update and delete OCI Dhcp Options
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,327 +17,355 @@ oci_dhcp_options - Create,update and delete OCI Dhcp Options
 
 Synopsis
 --------
-
-
-* Creates OCI Dhcp Options
-* Update OCI Dhcp Options, if present, with a new display name
-* Update OCI Dhcp Options, if present, by appending new options to existing options
-* Update OCI Dhcp Options, if present, by purging existing options and replacing them with specified ones
-* Delete OCI Dhcp Options, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Creates OCI Dhcp Options
+- Update OCI Dhcp Options, if present, with a new display name
+- Update OCI Dhcp Options, if present, by appending new options to existing options
+- Update OCI Dhcp Options, if present, by purging existing options and replacing them with specified ones
+- Delete OCI Dhcp Options, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment under which this Dhcp Options would be created. Mandatory for create operation.Optional for delete and update. Mutually exclusive with dhcp_id.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>dhcp_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Dhcp Options. Mandatory for delete and update.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the Dhcp Options. A user friendly name. Does not have to be unique, and could be changed. If not specified, a default name would be provided.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">options<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A set of DHCP options. Mandatory for create and update.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object options</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which this Dhcp Options would be created. Mandatory for create operation.Optional for delete and update. Mutually exclusive with dhcp_id.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>dhcp_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Dhcp Options. Mandatory for delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the Dhcp Options. A user friendly name. Does not have to be unique, and could be changed. If not specified, a default name would be provided.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>options</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A set of DHCP options. Mandatory for create and update.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>type</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>DomainNameServer</li>
+                                                                                                                                                                                                <li>SearchDomain</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The specific DHCP option.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>search_domain_names</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Applicable only for the <em>type='SearchDomain'</em>.A single search domain name according to RFC 952 and RFC 1123. Do not include this option with an empty list of search domain names, or with an empty string as the value for any search domain name.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>custom_dns_servers</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Applicable only for the <em>type='DomainNameServer'</em> and <em>server_type='CustomDnsServer'</em>. Maximum three DNS server ips are allowed as part of this option.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>server_type</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>VcnLocalPlusInternet</li>
+                                                                                                                                                                                                <li>CustomDnsServer</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Applicable only for the <em>type='DomainNameServer'</em>.Describes the type of the server.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>purge_dhcp_options</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Purge existing Dhcp Options which are not present in the provided Dhcp Options. If <em>purge_dhcp_options=no</em>, provided options would be appended to existing options.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete Dhcp Options. For <em>state=present</em>, if it does not exist, it gets created. If it exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Cloud Network to which the Dhcp Options should be attached. Mandatory for create operation. Optional for delete and update. Mutually exclusive with dhcp_id.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>type<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td><ul><li>DomainNameServer</li><li>SearchDomain</li></ul></td>
-        <td>
-        <div>The specific DHCP option.</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>search_domain_names<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Applicable only for the <em>type='SearchDomain'</em>.A single search domain name according to RFC 952 and RFC 1123. Do not include this option with an empty list of search domain names, or with an empty string as the value for any search domain name.</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        <tr>
-        <td>custom_dns_servers<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Applicable only for the <em>type='DomainNameServer'</em> and <em>server_type='CustomDnsServer'</em>. Maximum three DNS server ips are allowed as part of this option.</div>
-        </td>
-        </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-        <tr>
-        <td>server_type<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td><ul><li>VcnLocalPlusInternet</li><li>CustomDnsServer</li></ul></td>
-        <td>
-        <div>Applicable only for the <em>type='DomainNameServer'</em>.Describes the type of the server.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>purge_dhcp_options<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>yes</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Purge existing Dhcp Options which are not present in the provided Dhcp Options. If <em>purge_dhcp_options=no</em>, provided options would be appended to existing options.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete Dhcp Options. For <em>state=present</em>, if it does not exist, it gets created. If it exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Virtual Cloud Network to which the Dhcp Options should be attached. Mandatory for create operation. Optional for delete and update. Mutually exclusive with dhcp_id.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Note: These examples do not set authentication details.
@@ -391,145 +420,153 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>dhcp_options</td>
-    <td>
-        <div>Attributes of the created/updated Dhcp Options. For delete, deleted Dhcp Options description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_dhcp_options', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-26T16:41:06.996000+00:00', 'id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx', 'options': [{'type': 'DomainNameServer', 'custom_dns_servers': [], 'server_type': 'VcnLocalPlusInternet'}, {'type': 'SearchDomain', 'search_domain_names': ['ansibletestvcn.oraclevcn.com']}, {'type': 'DomainNameServer', 'custom_dns_servers': ['10.0.0.8'], 'server_type': 'CustomDnsServer'}]}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>vcn_id</td>
-        <td>
-            <div>Identifier of the Virtual Cloud Network to which the Dhcp Options is attached.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn..ixcd</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name assigned to the Dhcp Options during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_dhcp_options</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the Dhcp Options</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Dhcp Options</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Dhcp Options</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dhcpoptions.oc1.axdf</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Dhcp Options was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>options</td>
-        <td>
-            <div>A list of dhcp options.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'type': 'DomainNameServer', 'custom_dns_servers': [], 'server_type': 'CustomDnsServer'}, {'type': 'SearchDomain', 'search_domain_names': ['myansiblevcn.oraclevcn.com']}]</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>dhcp_options</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated Dhcp Options. For delete, deleted Dhcp Options description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_dhcp_options', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-26T16:41:06.996000+00:00', 'id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx', 'options': [{'type': 'DomainNameServer', 'custom_dns_servers': [], 'server_type': 'VcnLocalPlusInternet'}, {'type': 'SearchDomain', 'search_domain_names': ['ansibletestvcn.oraclevcn.com']}, {'type': 'DomainNameServer', 'custom_dns_servers': ['10.0.0.8'], 'server_type': 'CustomDnsServer'}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Virtual Cloud Network to which the Dhcp Options is attached.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn..ixcd</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Dhcp Options during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_dhcp_options</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the Dhcp Options</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Dhcp Options</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Dhcp Options</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dhcpoptions.oc1.axdf</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Dhcp Options was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>options</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of dhcp options.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'type': 'DomainNameServer', 'custom_dns_servers': [], 'server_type': 'CustomDnsServer'}, {'type': 'SearchDomain', 'search_domain_names': ['myansiblevcn.oraclevcn.com']}]</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_dhcp_options.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_domain_records_facts_module.rst
+++ b/docs/modules/oci_domain_records_facts_module.rst
@@ -1,0 +1,377 @@
+:source: cloud/oracle/oci_domain_records_facts.py
+
+:orphan:
+
+.. _oci_domain_records_facts_module:
+
+
+oci_domain_records_facts - Retrieve facts of domain records in a specified zone in Oracle Cloud Infrastructure DNS Service
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves information of all records at the specified zone and domain. The results are sorted by rtype in alphabetical order by default.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment the resource belongs to. Use <em>zone_id</em> or <em>zone_name</em> to retrieve a specific zone's information using its OCID.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Search by domain. Will match any record whose domain (case-insensitive) equals the provided value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A case-sensitive filter for zone names. Will match any zone with a name that equals the provided value.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: zone_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>rtype</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Search by record type. Will match any record whose type (case-insensitive) equals the provided value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>zone_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of the target zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>zone_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The version of the zone for which data is requested.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get a list of domain zone records in the specified zone and domain
+      oci_domain_records_facts:
+        zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+        domain: "test_zone_1.com"
+    - name: Get a list of NS zone records in the specified zone and domain
+      oci_domain_records_facts:
+        zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+        domain: "test_zone_1.com"
+        rtype: 'NS'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>domain_records</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A collection of DNS resource record objects.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'domain': 'test_zone_1.com', 'is_protected': True, 'rrset_version': '1', 'rtype': 'NS', 'ttl': 86400, 'record_hash': '9be3279d81b5e8430fd94c70cfa5f0a8', 'rdata': 'ns2.p68.dns.oraclecloud.net.'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">test_zone_1.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_protected</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rrset_version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rtype</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NS</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ttl</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">86400</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>record_hash</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">f439fa9a087ff74757485953fe0a8c7d</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rdata</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ns1.p68.dns.oraclecloud.net. hostmaster.test_zone_1.com. 1 3600 600 604800 1800</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_domain_records_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_domain_records_module.rst
+++ b/docs/modules/oci_domain_records_module.rst
@@ -1,0 +1,601 @@
+:source: cloud/oracle/oci_domain_records.py
+
+:orphan:
+
+.. _oci_domain_records_module:
+
+
+oci_domain_records - Update or Patch a collection of records in the specified zone in OCI DNS Service
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module allows the user to update or patch a collection of records in the specified DNS zone in OCI DNS Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment the resource belongs to.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>domain</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The target fully-qualified domain name (FQDN) within the target zone.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the zone. Required to create a zone. Either <em>name</em> or <em>zone_id</em> must be specified to update or patch the collection of recordsin the specified zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: zone_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>patch_items</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The record operations to patch the Zone's domain records collection. Updates records in the specified zone at a domain. You can update one record or all records for the specified zone depending on the changes provided in the request body. You can also add or remove records using this option. Required to patch a zone's domain records.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rtype</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rr_set_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rdata</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>is_protected</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ttl</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>operation</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>REQUIRE</li>
+                                                                                                                                                                                                <li>PROHIBIT</li>
+                                                                                                                                                                                                <li>ADD</li>
+                                                                                                                                                                                                <li>REMOVE</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>A description of how a record relates to a PATCH operation. REQUIRE indicates a precondition that record data must already exist. PROHIBIT indicates a precondition that record data must not already exist. ADD indicates that record data must exist after successful application. REMOVE indicates that record data must not exist after successful application. Note - ADD and REMOVE operations can succeed even if they require no changes when applied, such as when the described records are already present or absent. Note - ADD and REMOVE operations can describe changes for more than one record. Example - { &quot;domain&quot; - &quot;www.example.com&quot;, &quot;rtype&quot; - &quot;AAAA&quot;, &quot;ttl&quot; - 60 } specifies a new TTL for every record in the www.example.com AAAA RRSet.'</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>record_hash</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>State of the Zone's domain records</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>update_items</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The items to update the Zone's domain records collection to. Replaces records in the specified zone at a domain with the records specified in the request body. If a specified record does not exist, it will be created. If the record exists, then it will be updated to represent the record in the body of the request. If a record in the zone does not exist in the request body, the record will be removed from the zone. Required to update a zone's domain records.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>domain</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>is_protected</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rtype</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rr_set_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ttl</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>record_hash</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rdata</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>zone_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the target zone. Either <em>name</em> or <em>zone_id</em> must be specified to update or path the collection of records in the specified zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Update a zone's domain records by adding a new record. This operation replaces domain records in the specified
+            zone with the specified records. So ensure that you include the original domain records, if you want to retain
+            existing records.
+      oci_domain_records:
+        name: "test_zone_1.com"
+        domain: "test_zone_1.com"
+        update_items: [ <original zone records...> , { domain: "test_zone_1.com", ttl: 30, rtype='TXT', rdata='some textual
+                        data' } ]
+
+    - name: Patch a zone's domain's records
+      oci_domain_records:
+        name: test_zone1.com
+        patch_items: [ { domain: "test_zone_1.com", is_protected: false, rdata: 'some textual data',
+                         rtype: "TXT", ttl: 30, operation: "REMOVE" }]
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>domain_records</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful update or patch of zone's domain resource records</td>
+                <td>
+                                            <div>Information about the zone's domain resource records</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'domain': 'test_zone_1.com', 'is_protected': True, 'rrset_version': '1', 'rtype': 'NS', 'ttl': 86400, 'record_hash': '9be3279d81b5e8430fd94c70cfa5f0a8', 'rdata': 'ns2.p68.dns.oraclecloud.net.'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">test_zone_1.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_protected</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rrsetVersion</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">5</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rtype</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NS</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ttl</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">86400</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>record_hash</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">722af089872ffe65ba909fc8fea1867e</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rdata</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ns3.p68.dns.oraclecloud.net.</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_domain_records.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_dynamic_group_facts_module.rst
+++ b/docs/modules/oci_dynamic_group_facts_module.rst
@@ -1,0 +1,358 @@
+:source: cloud/oracle/oci_dynamic_group_facts.py
+
+:orphan:
+
+.. _oci_dynamic_group_facts_module:
+
+
+oci_dynamic_group_facts - Retrieve facts of dynamic groups
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves information of the specified dynamic group or lists all the dynamic groups in a tenancy.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment (remember that the tenancy is simply the root compartment). Required to list all the dynamic groups in a tenancy.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>dynamic_group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the dynamic group. <em>dynamic_group_id</em> is required to get a specific dynamic group's information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get all the dynamic groups in a tenancy
+      oci_dynamic_group_facts:
+        compartment_id: ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Get information of a specific dynamic group
+      oci_dynamic_group_facts:
+        dynamic_group_id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>dynamic_groups</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of dynamic group details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'description': 'Group for all instances with the tag namespace and tag key operations.department', 'compartment_id': 'ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx', 'matching_rule': 'tag.operations.department.value', 'time_created': '2018-07-05T09:38:27.176000+00:00', 'id': 'ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx', 'name': 'Sample dynamic group'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The group's current state. After creating a group, make sure its lifecycleState changes from CREATING to ACTIVE before using it.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The detailed status of INACTIVE lifecycleState.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description you assign to the group. Does not have to be unique, and it's changeable.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Group for all instances with the tag namespace and tag key operations.department</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the tenancy containing the group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>matching_rule</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A rule string that defines which instance certificates will be matched. For syntax, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm</a>.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">tag.operations.department.value</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time the group was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-03-28 18:37:56.190000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name you assign to the group during creation. The name must be unique across all groups in the tenancy and cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Sample dynamic group</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_dynamic_group_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_dynamic_group_module.rst
+++ b/docs/modules/oci_dynamic_group_module.rst
@@ -1,0 +1,344 @@
+:source: cloud/oracle/oci_dynamic_group.py
+
+:orphan:
+
+.. _oci_dynamic_group_module:
+
+
+oci_dynamic_group - Manage dynamic groups in OCI
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module allows the user to create, delete and update dynamic groups in Oracle Cloud Infrastructure.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the tenancy containing the group. Required to create a dynamic group.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>description</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The description you assign to the group during creation. Does not have to be unique, and it's changeable. Required to create a dynamic group.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>dynamic_group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the dynamic group. Required to delete or update a dynamic group.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>matching_rule</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The matching rule to dynamically match an instance certificate to this dynamic group. For rule syntax, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm</a>. Required to create a dynamic group.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name you assign to the group during creation. The name must be unique across all groups in the tenancy and cannot be changed. Required to create a dynamic group.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a dynamic group with <em>state=present</em>. Use <em>state=absent</em> to delete a dynamic group.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create a dynamic group
+      oci_dynamic_group:
+        compartment_id: ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx
+        description: Group for all instances that are in a specific compartment
+        matching_rule: "instance.compartment.id = 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx'"
+        name: Sample dynamic group
+
+    - name: Update matching rule and description of a dynamic group
+      oci_dynamic_group:
+        id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+        description: Group for all instances with the tag namespace and tag key operations.department
+        matching_rule: "tag.operations.department.value"
+
+    - name: Delete a dynamic group
+      oci_dynamic_group:
+        id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>dynamic_group</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful create, delete &amp; update operation</td>
+                <td>
+                                            <div>Information about the dynamic group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'description': 'Group for all instances with the tag namespace and tag key operations.department', 'compartment_id': 'ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx', 'matching_rule': 'tag.operations.department.value', 'time_created': '2018-07-05T09:38:27.176000+00:00', 'id': 'ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx', 'name': 'Sample dynamic group'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_dynamic_group.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_fault_domain_facts_module.rst
+++ b/docs/modules/oci_fault_domain_facts_module.rst
@@ -1,0 +1,298 @@
+:source: cloud/oracle/oci_fault_domain_facts.py
+
+:orphan:
+
+.. _oci_fault_domain_facts_module:
+
+
+oci_fault_domain_facts - Retrieve details of fault domains in your tenancy
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves details of all fault domains in your tenancy. Specify the OCID of either the tenancy or another of your compartments as the value for the compartment ID (remember that the tenancy is simply the root compartment).
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>availability_domain</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the availibility domain.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get details of all the fault domains in AD1 in your tenancy
+      oci_fault_domain_facts:
+        compartment_id: 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...vm62xq'
+        availability_domain: "IwGV:US-ASHBURN-AD-2"
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>fault_domains</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more fault domains in your tenancy</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'fault_domains': [{'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'id': 'ocid1.faultdomain.oc1..xxxxxEXAMPLExxxxx..4dnw3a', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq', 'name': 'FAULT-DOMAIN-1'}, {'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'id': 'ocid1.faultdomain.oc1..xxxxxEXAMPLExxxxx..3dsdaa', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq', 'name': 'FAULT-DOMAIN-2'}, {'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'id': 'ocid1.faultdomain.oc1..xxxxxEXAMPLExxxxx..6ttdaa', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq', 'name': 'FAULT-DOMAIN-3'}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the availabilityDomain where the Fault Domain belongs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ASHBURN-AD-2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the Fault Domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">FAULT-DOMAIN-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the Fault Domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.faultdomain.oc1..xxxxxEXAMPLExxxxx..4dnw3a</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_fault_domain_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_group_facts_module.rst
+++ b/docs/modules/oci_group_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_group_facts:
+:source: cloud/oracle/oci_group_facts.py
+
+:orphan:
+
+.. _oci_group_facts_module:
 
 
 oci_group_facts - Fetches details of all the OCI groups of a tenancy and the users associated
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,133 +17,160 @@ oci_group_facts - Fetches details of all the OCI groups of a tenancy and the use
 
 Synopsis
 --------
-
-
-* Fetches details of all the OCI groups of a tenancy and the users associated with them.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of all the OCI groups of a tenancy and the users associated with them.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the group whose details should be fetched</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>group_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the group whose details should be fetched</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch a specific group details
@@ -156,155 +184,165 @@ Examples
 
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>groups</td>
-    <td>
-        <div>List of group details</div>
-    </td>
-    <td align=center>always</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'description': 'Test Ansible Group', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx', 'defined_tags': {'product': {'type': 'server'}}, 'freeform_tags': {'group_name': 'designer'}, 'time_created': '2017-10-31T16:38:22.289000+00:00', 'members': [{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'test_user1', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx', 'defined_tags': {'department': {'division': 'engineering'}}, 'freeform_tags': {'user_type': 'admin'}, 'time_created': '2017-09-25T09:20:10.768000+00:00', 'id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'description': 'Test User One'}, {'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'test_user2', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx', 'defined_tags': {'department': {'division': 'engineering'}}, 'freeform_tags': {'user_type': 'admin'}, 'time_created': '2017-03-22T04:28:34.943000+00:00', 'id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'description': 'Test User Two'}], 'id': 'ocid1.group.oc1..xxxxxEXAMPLExxxxx', 'name': 'test_ansible_group'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>Current state of the group</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>inactive_status</td>
-        <td>
-            <div>The detailed status of INACTIVE life cycle state</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>Description of the group</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Network Admin group</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>Identifier of the tenancy containing the group</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time the group was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>members</td>
-        <td>
-            <div>A list of all members that are part of this group.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'test_user1', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx', 'id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-09-25T09:20:10.768000+00:00', 'description': 'Test User One'}]</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the group</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.group.oc1.axdf</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Unique name of the group</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>network_admin</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>groups</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of group details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'description': 'Test Ansible Group', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx', 'defined_tags': {'product': {'type': 'server'}}, 'freeform_tags': {'group_name': 'designer'}, 'time_created': '2017-10-31T16:38:22.289000+00:00', 'members': [{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'test_user1', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx', 'defined_tags': {'department': {'division': 'engineering'}}, 'freeform_tags': {'user_type': 'admin'}, 'time_created': '2017-09-25T09:20:10.768000+00:00', 'id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'description': 'Test User One'}, {'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'test_user2', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx', 'defined_tags': {'department': {'division': 'engineering'}}, 'freeform_tags': {'user_type': 'admin'}, 'time_created': '2017-03-22T04:28:34.943000+00:00', 'id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'description': 'Test User Two'}], 'id': 'ocid1.group.oc1..xxxxxEXAMPLExxxxx', 'name': 'test_ansible_group'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Current state of the group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when group's lifecycle_state is INACTIVE</td>
+                <td>
+                                            <div>The detailed status of INACTIVE life cycle state</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Description of the group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Network Admin group</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the tenancy containing the group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time the group was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>members</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of all members that are part of this group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'test_user1', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx', 'id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-09-25T09:20:10.768000+00:00', 'description': 'Test User One'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.group.oc1.axdf</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Unique name of the group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">network_admin</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_group_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_group_module.rst
+++ b/docs/modules/oci_group_module.rst
@@ -1,13 +1,14 @@
-.. _oci_group:
+:source: cloud/oracle/oci_group.py
+
+:orphan:
+
+.. _oci_group_module:
 
 
 oci_group - Create,update and delete OCI user groups and specified user associations
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,248 +17,279 @@ oci_group - Create,update and delete OCI user groups and specified user associat
 
 Synopsis
 --------
-
-
-* Creates OCI group, if not present, without any user associations
-* Creates OCI group, if not present, with any specified user associations
-* Update OCI group, if present, with description
-* Update OCI group, if present, with new user(s) associations
-* Update OCI group, if present, removing all user associations
-* Delete OCI group, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Creates OCI group, if not present, without any user associations
+- Creates OCI group, if not present, with any specified user associations
+- Update OCI group, if present, with description
+- Update OCI group, if present, with new user(s) associations
+- Update OCI group, if present, removing all user associations
+- Delete OCI group, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>description</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Description of the group. The value could be an empty string. Mandatory for <em>state=present</em>. Not required for <em>state=absent</em></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">no</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>If <em>force='no'</em> and group has any user assigned, then in the case of <em>state=absent</em>, group will not be deleted. To delete a group which has user associations, <em>force='yes'</em> should be specified.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Group. Mandatory for delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the group. Must be unique within a tenancy.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>purge_user_memberships</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Purge users in existing memberships which are not present in the provided users memberships. If <em>purge_user_memberships=no</em>, provided users would be appended to existing user memberships.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete group. For <em>state=present</em>, if the group does not exists, it gets created. If exists, it gets updated. For <em>state=absent</em>, group gets deleted.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>users</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>List of users to be associated with the group. The specified users must exist while running this task. If a specified user does not exist, this task would fail.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>description<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Description of the group. The value could be an empty string. Mandatory for <em>state=present</em>. Not required for <em>state=absent</em></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>no</td>
-    <td></td>
-    <td>
-        <div>If <em>force='no'</em> and group has any user assigned, then in the case of <em>state=absent</em>, group will not be deleted. To delete a group which has user associations, <em>force='yes'</em> should be specified.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>group_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Group. Mandatory for delete and update.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the group. Must be unique within a tenancy.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>purge_user_memberships<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Purge users in existing memberships which are not present in the provided users memberships. If <em>purge_user_memberships=no</em>, provided users would be appended to existing user memberships.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete group. For <em>state=present</em>, if the group does not exists, it gets created. If exists, it gets updated. For <em>state=absent</em>, group gets deleted.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>users<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>List of users to be associated with the group. The specified users must exist while running this task. If a specified user does not exist, this task would fail.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -304,145 +336,151 @@ Examples
                 state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>group</td>
-    <td>
-        <div>Attributes of the created/updated group. For delete, deleted group description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'network_admin_group', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx', 'defined_tags': {'product': {'type': 'server'}}, 'freeform_tags': {'group_name': 'designer'}, 'time_created': '2017-10-31T16:38:22.289000+00:00', 'id': 'ocid1.group.oc1..xxxxxEXAMPLExxxxx', 'description': 'Network Admin Group'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>Current state of the group</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>inactive_status</td>
-        <td>
-            <div>The detailed status of INACTIVE life cycle state</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>Description of the group</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Network Admin Group</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>Identifier of the tenancy containing the group</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the group</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.group.oc1.axdf</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time the group was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Unique name of the group</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>network_admin</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>group</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated group. For delete, deleted group description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'name': 'network_admin_group', 'compartment_id': 'ocidv1:tenancy:oc1:phx:xxxxxEXAMPLExxxxx', 'defined_tags': {'product': {'type': 'server'}}, 'freeform_tags': {'group_name': 'designer'}, 'time_created': '2017-10-31T16:38:22.289000+00:00', 'id': 'ocid1.group.oc1..xxxxxEXAMPLExxxxx', 'description': 'Network Admin Group'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Current state of the group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when group's lifecycle_state is INACTIVE</td>
+                <td>
+                                            <div>The detailed status of INACTIVE life cycle state</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Description of the group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Network Admin Group</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the tenancy containing the group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.group.oc1.axdf</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time the group was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Unique name of the group</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">network_admin</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_group.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_image_facts_module.rst
+++ b/docs/modules/oci_image_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_image_facts:
+:source: cloud/oracle/oci_image_facts.py
+
+:orphan:
+
+.. _oci_image_facts_module:
 
 
 oci_image_facts - Retrieve details about one or more Compute images in OCI Compute Service
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,170 @@ oci_image_facts - Retrieve details about one or more Compute images in OCI Compu
 
 Synopsis
 --------
-
-
-* This module retrieves details about a specific image, or all images in a specified Compartment in OCI Compute Service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details about a specific image, or all images in a specified Compartment in OCI Compute Service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy). Required for retrieving information about all images in a Compartment/Tenancy.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>image_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the image. Required for retrieving information about a specific image</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy). Required for retrieving information about all images in a Compartment/Tenancy.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>image_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the image. Required for retrieving information about a specific image</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the images of a specified compartment
@@ -164,165 +192,181 @@ Examples
         id:"ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx...lxiggdq"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>images</td>
-    <td>
-        <div>Information about one or more images</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>{'time-created': '2017-11-16T01:16:41.409000+00:00', 'lifecycle-state': 'AVAILABLE', 'operating-system-version': '7.4', 'base-image-id': None, 'create-image-allowed': True, 'compartment-id': None, 'operating-system': 'Oracle Linux', 'display-name': 'Oracle-Linux-7.4-2017.11.15-0', 'id': 'ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx...cmnzlbv2v4q'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the image.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>DELETED</td>
-        </tr>
-
-        <tr>
-        <td>operating_system_version</td>
-        <td>
-            <div>The image's operating system version.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>7.2</td>
-        </tr>
-
-        <tr>
-        <td>operating_system</td>
-        <td>
-            <div>The image's operating system.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Oracle Linux</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name for the image. It does not have to be unique, and it's changeable.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>my_custom_image_1</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment containing the instance that was used as the basis for the image.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</td>
-        </tr>
-
-        <tr>
-        <td>base_image_id</td>
-        <td>
-            <div>The OCID of the image originally used to create the image.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx....yw2wxfa</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the image was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-20 04:52:54.541000</td>
-        </tr>
-
-        <tr>
-        <td>create_image_allowed</td>
-        <td>
-            <div>Whether instances launched with this image can be used to create new images. For example, an image of an Oracle Database instance cannot be created</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>True</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the image.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx...e4mehv6bv3qca</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>images</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more images</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'time-created': '2017-11-16T01:16:41.409000+00:00', 'lifecycle-state': 'AVAILABLE', 'operating-system-version': '7.4', 'base-image-id': None, 'create-image-allowed': True, 'compartment-id': None, 'operating-system': 'Oracle Linux', 'display-name': 'Oracle-Linux-7.4-2017.11.15-0', 'id': 'ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx...cmnzlbv2v4q'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the image.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">DELETED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>operating_system_version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The image's operating system version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">7.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>operating_system</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The image's operating system.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Oracle Linux</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name for the image. It does not have to be unique, and it's changeable.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">my_custom_image_1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the instance that was used as the basis for the image.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>base_image_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the image originally used to create the image.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx....yw2wxfa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the image was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-20 04:52:54.541000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>create_image_allowed</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether instances launched with this image can be used to create new images. For example, an image of an Oracle Database instance cannot be created</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the image.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx...e4mehv6bv3qca</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_image_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_image_module.rst
+++ b/docs/modules/oci_image_module.rst
@@ -1,13 +1,14 @@
-.. _oci_image:
+:source: cloud/oracle/oci_image.py
+
+:orphan:
+
+.. _oci_image_module:
 
 
 oci_image - Create, import, update and delete OCI Compute images
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,323 +17,344 @@ oci_image - Create, import, update and delete OCI Compute images
 
 Synopsis
 --------
-
-
-* This module allows the user to create an image, import an exported image, update an image and delete OCI Compute Images.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create an image, import an exported image, update an image and delete OCI Compute Images.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment containing the instance that needs to be used as the basis for the image. Required when an image needs to be created with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name to be associated with the image. This does not have to be unique, and can be changed later. An Oracle-provided image name cannot be used as the name for a custom image's name.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>image_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the image. Required while updating an image using <em>state=present</em>, and deleting an existing image using <em>state=absent</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">image_source_details<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Details for creating an image through import. Either <code>instance_id</code> or <code>image_source_details</code> needs to be specified while creating an image using <em>state=present</em>.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object image_source_details</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment containing the instance that needs to be used as the basis for the image. Required when an image needs to be created with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name to be associated with the image. This does not have to be unique, and can be changed later. An Oracle-provided image name cannot be used as the name for a custom image's name.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>image_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the image. Required while updating an image using <em>state=present</em>, and deleting an existing image using <em>state=absent</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>image_source_details</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Details for creating an image through import. Either <code>instance_id</code> or <code>image_source_details</code> needs to be specified while creating an image using <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>source_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The source type for the image. Use 'objectStorageTuple' to get the image from an object in Object Storage and specify <code>namespace</code>, <code>bucket</code>, and <code>object</code>. Use 'objectStorageUri' when specifying an Object Storage URL to get the image, and specify <code>source_uri</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: destination_type</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>source_uri</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Object Storage URL for the image. See Object Storage URLs at <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/Tasks/imageimportexport.htm#URLs'>https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/Tasks/imageimportexport.htm#URLs</a> and pre-authenticated requests at <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingaccess.htm#pre-auth'>https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingaccess.htm#pre-auth</a> for constructing URLs for image import/export. Required when creating an image using <em>state=present</em> and the <em>source_type=objectStorageUri</em> under <code>image_source_details</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>bucket_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Object Storage bucket for the image. Required when creating an image using <em>state=present</em> and the <em>source_type=objectStorageTuple</em> under <code>image_source_details</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: bucket</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>object_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Object Storage name for the image. Required when creating an image using <em>state=present</em> and the <em>source_type=objectStorageTuple</em> under <code>image_source_details</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: object</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>namespace_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Object Storage namespace for the image. Required when creating an image using <em>state=present</em> and the <em>source_type=objectStorageTuple</em> under <code>image_source_details</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: namespace</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>instance_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the instance that needs to be used as the basis for the image. Either <code>instance_id</code> or <code>image_source_details</code> needs to be specified while creating an image using <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The state of the image that must be asserted to. When <em>state=present</em>, and the image doesn't exist, the image is created with the specified details. When <em>state=absent</em>, the image is deleted. Creation of an image may take longer than the default value of <em>wait_timeout</em>. So if <em>wait=true</em>, during creation of an image, it is recommended to set a longer timeout value of <em>wait_timeout</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>source_type<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The source type for the image. Use 'objectStorageTuple' to get the image from an object in Object Storage and specify <code>namespace</code>, <code>bucket</code>, and <code>object</code>. Use 'objectStorageUri' when specifying an Object Storage URL to get the image, and specify <code>source_uri</code>.</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>source_uri<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The Object Storage URL for the image. See Object Storage URLs at <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/Tasks/imageimportexport.htm#URLs'>https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/Tasks/imageimportexport.htm#URLs</a> and pre-authenticated requests at <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingaccess.htm#pre-auth'>https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingaccess.htm#pre-auth</a> for constructing URLs for image import/export. Required when creating an image using <em>state=present</em> and the <em>source_type=objectStorageUri</em> under <code>image_source_details</code>.</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        <tr>
-        <td>bucket_name<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The Object Storage bucket for the image. Required when creating an image using <em>state=present</em> and the <em>source_type=objectStorageTuple</em> under <code>image_source_details</code>.</div>
-        </td>
-        </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-        <tr>
-        <td>object_name<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The Object Storage name for the image. Required when creating an image using <em>state=present</em> and the <em>source_type=objectStorageTuple</em> under <code>image_source_details</code>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>namespace_name<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The Object Storage namespace for the image. Required when creating an image using <em>state=present</em> and the <em>source_type=objectStorageTuple</em> under <code>image_source_details</code>.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instance_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the instance that needs to be used as the basis for the image. Either <code>instance_id</code> or <code>image_source_details</code> needs to be specified while creating an image using <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>The state of the image that must be asserted to. When <em>state=present</em>, and the image doesn't exist, the image is created with the specified details. When <em>state=absent</em>, the image is deleted. Creation of an image may take longer than the default value of <em>wait_timeout</em>. So if <em>wait=true</em>, during creation of an image, it is recommended to set a longer timeout value of <em>wait_timeout</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a new image from a specified instance
@@ -373,58 +395,54 @@ Examples
             state: "absent"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>oci_image</td>
-    <td>
-        <div>Details of the image</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>dict</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'operating_system_version': '16.04', 'operating_system': 'Canonical Ubuntu', 'display_name': 'my-image-1', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....lwbvm62xq', 'base_image_id': 'ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx....qcsa7klnoa', 'time_created': '2017-11-24T13:18:31.579000+00:00', 'create_image_allowed': True, 'id': 'ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx.....dgb3pmci2q'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>oci_image</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>Details of the image</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'operating_system_version': '16.04', 'operating_system': 'Canonical Ubuntu', 'display_name': 'my-image-1', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....lwbvm62xq', 'base_image_id': 'ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx....qcsa7klnoa', 'time_created': '2017-11-24T13:18:31.579000+00:00', 'create_image_allowed': True, 'id': 'ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx.....dgb3pmci2q'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_image.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_instance_facts_module.rst
+++ b/docs/modules/oci_instance_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_instance_facts:
+:source: cloud/oracle/oci_instance_facts.py
+
+:orphan:
+
+.. _oci_instance_facts_module:
 
 
 oci_instance_facts - Retrieve details about one or more Compute instances in OCI Compute Service
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,153 +17,180 @@ oci_instance_facts - Retrieve details about one or more Compute instances in OCI
 
 Synopsis
 --------
-
-
-* This module retrieves details about a specific Compute instance, or all Compute instances in a specified Compartment in a specified Availability Domain in OCI Compute Service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details about a specific Compute instance, or all Compute instances in a specified Compartment in a specified Availability Domain in OCI Compute Service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the Availability Domain.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy). Required for retrieving information about all instances in a Compartment/Tenancy.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>instance_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the instance. Required for retrieving information about a specific instance.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the Availability Domain.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy). Required for retrieving information about all instances in a Compartment/Tenancy.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instance_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the instance. Required for retrieving information about a specific instance.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the compute instances of a specified compartment in a specified Availability Domain
@@ -175,215 +203,577 @@ Examples
         id:"ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx...lxiggdq"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>instances</td>
-    <td>
-        <div>Information about one or more compute instances</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'TERMINATED', 'availability_domain': 'BnQb:PHX-AD-1', 'extended_metadata': {}, 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq', 'region': 'phx', 'time_created': '2017-11-20T04:52:54.541000+00:00', 'display_name': 'ansible-modname-968', 'image_id': 'ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx....lnoa', 'shape': 'BM.Standard1.36', 'ipxe_script': None, 'volume_attachments': [{'lifecycle_state': 'ATTACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'ansible_volume_attachment', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-11-23T11:17:50.139000+00:00', 'id': 'ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:472a085d-41a9-4c18-ae7d-dea5b296dad3', 'ipv4': '169.254.2.2', 'volume_id': 'ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}], 'boot_volume_attachment': {'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-15T07:23:10.838000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}, 'id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx.....2siq', 'metadata': {'foo': 'bar', 'baz': 'quux'}}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="3">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>TERMINATED</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain the instance is running in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BnQb:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>extended_metadata</td>
-        <td>
-            <div>Additional key-value pairs associated with the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict(str, str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</td>
-        </tr>
-
-        <tr>
-        <td>region</td>
-        <td>
-            <div>The region that contains the Availability Domain the instance is running in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>phx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the instance was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-20 04:52:54.541000</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name for the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-instance-968</td>
-        </tr>
-
-        <tr>
-        <td>image_id</td>
-        <td>
-            <div>The OCID of the image that the instance is based on</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>shape</td>
-        <td>
-            <div>The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BM.Standard1.36</td>
-        </tr>
-
-        <tr>
-        <td>ipxe_script</td>
-        <td>
-            <div>A custom iPXE script that will run when the instance boots</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>volume_attachments</td>
-        <td>
-            <div>List of information about volume attachments</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>complex</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>boot_volume_attachment</td>
-        <td>
-            <div>Information of the boot volume attachment.</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>dict</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>metadata</td>
-        <td>
-            <div>Custom metadata that was associated with the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict(str, str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="3">
+                    <b>instances</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more compute instances</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'TERMINATED', 'availability_domain': 'BnQb:PHX-AD-1', 'extended_metadata': {}, 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq', 'region': 'phx', 'time_created': '2017-11-20T04:52:54.541000+00:00', 'display_name': 'ansible-modname-968', 'image_id': 'ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx....lnoa', 'shape': 'BM.Standard1.36', 'ipxe_script': None, 'volume_attachments': [{'lifecycle_state': 'ATTACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'ansible_volume_attachment', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-11-23T11:17:50.139000+00:00', 'id': 'ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:472a085d-41a9-4c18-ae7d-dea5b296dad3', 'ipv4': '169.254.2.2', 'volume_id': 'ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}], 'boot_volume_attachment': {'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-15T07:23:10.838000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}, 'id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx.....2siq', 'metadata': {'foo': 'bar', 'baz': 'quux'}}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">TERMINATED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain the instance is running in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>extended_metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str, str)</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional key-value pairs associated with the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>region</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The region that contains the Availability Domain the instance is running in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">phx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the instance was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-20 04:52:54.541000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name for the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-instance-968</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>image_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the image that the instance is based on</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BM.Standard1.36</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>ipxe_script</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A custom iPXE script that will run when the instance boots</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>volume_attachments</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>List of information about volume attachments</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of an instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_username</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>iqn</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The target volume's iSCSI Qualified Name in the format defined by RFC 3720.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ipv4</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI IP address.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">169.254.0.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>attachment_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iscsi</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3260</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_secret</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the &quot;CHAP password&quot;.)</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">d6866c0d-298b-48ba-95af-309b4faux45e</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>boot_volume_attachment</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>Information of the boot volume attachment.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My boot volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str, str)</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Custom metadata that was associated with the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_instance_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_instance_module.rst
+++ b/docs/modules/oci_instance_module.rst
@@ -1,13 +1,14 @@
-.. _oci_instance:
+:source: cloud/oracle/oci_instance.py
+
+:orphan:
+
+.. _oci_instance_module:
 
 
 oci_instance - Launch, terminate and control the lifecycle of OCI Compute instances
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,591 +17,598 @@ oci_instance - Launch, terminate and control the lifecycle of OCI Compute instan
 
 Synopsis
 --------
-
-
-* This module allows the user to launch/create, terminate and perform other power actions on OCI Compute Service instances. An instance represents a compute host. The image used to launch the instance determines its operating system and other software. The shape specified during the launch process determines the number of CPUs and memory allocated to the instance. For more information, see Overview of the Compute Service at https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/Concepts/computeoverview.htm. In experimental mode, this module also allows attaching/detaching volumes and boot volumes to an instance.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to launch/create, terminate and perform other power actions on OCI Compute Service instances. An instance represents a compute host. The image used to launch the instance determines its operating system and other software. The shape specified during the launch process determines the number of CPUs and memory allocated to the instance. For more information, see Overview of the Compute Service at https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/Concepts/computeoverview.htm. In experimental mode, this module also allows attaching/detaching volumes and boot volumes to an instance.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Availability Domain of the instance. Required when creating a compute instance with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">boot_volume_details<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Details for attaching/detaching a boot volume to/from an instance. <em>boot_volume_details</em> is mutually exclusive with <em>image_id</em>. This option is only supported in experimental mode. To use an experimental feature, set the environment variable OCI_ANSIBLE_EXPERIMENTAL to True.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object boot_volume_details</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Availability Domain of the instance. Required when creating a compute instance with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>boot_volume_details</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Details for attaching/detaching a boot volume to/from an instance. <em>boot_volume_details</em> is mutually exclusive with <em>image_id</em>. This option is only supported in experimental mode. To use an experimental feature, set the environment variable OCI_ANSIBLE_EXPERIMENTAL to True.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>attachment_state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Attach a boot volume to the instance <em>instance_id</em> with <em>attachment_state=present</em>. Detach a boot volume from the instance <em>instance_id</em> with <em>attachment_state=absent</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. Required when <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>count_tag</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Used with <em>exact_count</em> to determine how many compute instances matching the specific tag criteria <code>count_tag</code> must be running. Only <em>defined_tags</em> associated with an instance are considered for matching against <code>count_tag</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information. If a <code>display_name</code> is specified, and if <em>exact_count</em> is specified, the display name would be suffixed with an auto-incrementing integer.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>exact_count</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Indicates how many instances that match the <em>count_tag</em> option should be running. This must be used with <em>state=present</em> and a valid <em>count_tag</em>. If the number of compute instances that match <code>count_tag</code> is lesser than <code>exact_count</code>, additional compute instances would be provisioned to match the desired <code>exact_count</code>. If the number of matching compute instances is larger than <code>exact_count</code>, compute instances would be terminated to match the desired <code>exact_count</code>. The latest launch instance(s) from the set of instances that match <code>count_tag</code> are picked for termination. Private IP assignments through <em>private_ip</em>, and specification of <em>hostname_label</em> and <em>volume_details</em> and <em>boot_volume_details</em> is not supported with <em>exact_count</em> and <em>count_tag</em>. By default, an auto-incremented integer value is suffixed to the value of <em>display_name</em> and assigned as the display_name of a newly provisioned instance. For example, if <em>display_name</em> is 'my_web_server', new compute instances would be called 'my_web_server_0', 'my_web_server_1' and so on. To control the generated display name in a fine-grained manner, use &quot;printf&quot; style format in <em>display_name</em> such as 'my_%d_web_server'.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>extended_metadata</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Additional metadata key/value pairs that you provide. They serve a similar purpose and functionality from fields in the <em>metadata</em> object. They are distinguished from <em>metadata</em> fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only). If you don't need nested metadata values, it is strongly advised to avoid using this object and use the Metadata object instead.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>fault_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A fault domain is a grouping of hardware and infrastructure within an availability domain. Each availability domain contains three fault domains. Fault domains let you distribute your instances so that they are not on the same physical hardware within a single availability domain. A hardware failure or Compute hardware maintenance that affects one fault domain does not affect instances in other fault domains. If you do not specify the fault domain, the system selects one for you. To change the fault domain for an instance, terminate it and launch a new instance in the preferred fault domain. To get a list of fault domains, use <span class='module'>oci_fault_domain_facts</span>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>image_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the image used to boot the instance. Required to launch an instance using an image with <em>state=present</em>. <em>image_id</em> is mutually exclusive with <em>boot_volume_details</em>. This can also be provided through <em>source_details</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>instance_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compute instance. Required for updating an existing compute instance when <em>state=present</em>, for performing power actions (such as start, stop, softreset or reset) on an instance, and for terminating an instance <em>state=absent</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>ipxe_script</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>custom iPXE script that will run when the instance boots.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>metadata</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A hash/dictionary of custom key/value pairs that are associated with the instance. This option is also used to provide information to cloud-init and specifying &quot;ssh_authorized_keys&quot; for the default user of the instance. This hash is specified as '{&quot;key&quot;:&quot;value&quot;}' and '{&quot;key&quot;:&quot;value&quot;,&quot;key&quot;:&quot;value&quot;}'.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>preserve_boot_volume</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to preserve the boot volume when terminating an instance with <em>state=absent</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>shape</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The shape of the instance. Required when creating a compute instance with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>source_details</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Details for creating an instance. Use this parameter to specify whether a boot volume or an image should be used to launch a new instance.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCID of the boot volume used to boot the instance. Required if <em>source_type</em> is &quot;bootVolume&quot;.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>image_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCID of the image used to boot the instance. Required if <em>source_type</em> is &quot;image&quot;.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>source_type</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>image</li>
+                                                                                                                                                                                                <li>bootVolume</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The source type for the instance. Use image when specifying the image OCID. Use bootVolume when specifying the boot volume OCID.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li>running</li>
+                                                                                                                                                                                                <li>reset</li>
+                                                                                                                                                                                                <li>softreset</li>
+                                                                                                                                                                                                <li>stopped</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The state of the instance that must be asserted to. When <em>state=present</em>, and the compute instance doesn't exist, the instance is launched/created with the specified details. When <em>state=absent</em>, the compute instance is terminated. When <em>state=stopped</em>, the compute instance is powered off. When <em>state=running</em>, the compute instance is powered on. When <em>state=softreset</em>, an ACPI shutdown is initiated and the compute instance is powered on. When <em>state=reset</em>, the compute instance is powered off and then powered on. Note that <em>state=softreset</em> and <em>state=reset</em> states are not idempotent. Every time a play is executed with these <code>state</code> options, a shutdown and a power on sequence is executed against the instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>vnic</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Details for the primary VNIC that is automatically created and attached when the instance is launched. Required when creating a compute instance with <em>state=present</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: create_vnic_details</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>skip_source_dest_check</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                                                                <b>Default:</b><br/><div style="color: blue">no</div>
+                                    </td>
+                                                                <td>
+                                            <div>Determines whether the source/destination check is disabled on the VNIC. Defaults to false, which means the check is performed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A user-friendly name for the VNIC. Does not have to be unique.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>hostname_label</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The hostname for the VNIC's primary private IP. Used for DNS. The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>assign_public_ip</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Determines whether the VNIC should be assigned a public IP address.  If not set and the VNIC is being created in a private subnet (that is, where <em>prohibitPublicIpOnVnic = true</em> in the Subnet), then no public IP address is assigned. If not set and the subnet is public <em>prohibitPublicIpOnVnic = false</em>, then a public IP address is assigned. If set to true and <em>prohibitPublicIpOnVnic = true</em>, an error is returned.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>subnet_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCID of the subnet to create the VNIC in.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>private_ip</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The private IP to assign to the VNIC. Must be an available IP address within the subnet's CIDR. If you don't specify a value, Oracle automatically assigns a private IP address from the subnet. This is the VNIC's primary private IP address.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>volume_details</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Details for attaching or detaching a volume to an instance with <em>state=present</em> or <em>state=RUNNING</em>. This option is only supported in experimental mode. To use an experimental feature, set the environment variable OCI_ANSIBLE_EXPERIMENTAL to True.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>attachment_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed. Avoid entering confidential information.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>attachment_state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Attach a volume to the instance <em>instance_id</em> with <em>attachment_state=present</em>. Detach a volume from the instance <em>instance_id</em> with <em>attachment_state=absent</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>iscsi</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The type of volume. The only supported value is &quot;iscsi&quot;.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>volume_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCID of the volume to be attached to or detached from the instance <em>instance_id</em>.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>attachment_state<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>present</td>
-        <td><ul><li>present</li><li>absent</li></ul></td>
-        <td>
-        <div>Attach a boot volume to the instance <em>instance_id</em> with <em>attachment_state=present</em>. Detach a boot volume from the instance <em>instance_id</em> with <em>attachment_state=absent</em>.</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>boot_volume_id<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The OCID of the boot volume.</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        </table>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment. Required when <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>count_tag<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Used with <em>exact_count</em> to determine how many compute instances matching the specific tag criteria <code>count_tag</code> must be running. Only <em>defined_tags</em> associated with an instance are considered for matching against <code>count_tag</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information. If a <code>display_name</code> is specified, and if <em>exact_count</em> is specified, the display name would be suffixed with an auto-incrementing integer.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>exact_count<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Indicates how many instances that match the <em>count_tag</em> option should be running. This must be used with <em>state=present</em> and a valid <em>count_tag</em>. If the number of compute instances that match <code>count_tag</code> is lesser than <code>exact_count</code>, additional compute instances would be provisioned to match the desired <code>exact_count</code>. If the number of matching compute instances is larger than <code>exact_count</code>, compute instances would be terminated to match the desired <code>exact_count</code>. The latest launch instance(s) from the set of instances that match <code>count_tag</code> are picked for termination. Private IP assignments through <em>private_ip</em>, and specification of <em>hostname_label</em> and <em>volume_details</em> and <em>boot_volume_details</em> is not supported with <em>exact_count</em> and <em>count_tag</em>. By default, an auto-incremented integer value is suffixed to the value of <em>display_name</em> and assigned as the display_name of a newly provisioned instance. For example, if <em>display_name</em> is 'my_web_server', new compute instances would be called 'my_web_server_0', 'my_web_server_1' and so on. To control the generated display name in a fine-grained manner, use &quot;printf&quot; style format in <em>display_name</em> such as 'my_%d_web_server'.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>extended_metadata<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Additional metadata key/value pairs that you provide. They serve a similar purpose and functionality from fields in the <em>metadata</em> object. They are distinguished from <em>metadata</em> fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only). If you don't need nested metadata values, it is strongly advised to avoid using this object and use the Metadata object instead.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>image_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the image used to boot the instance. Required to launch an instance using an image with <em>state=present</em>. <em>image_id</em> is mutually exclusive with <em>boot_volume_details</em>. This can also be provided through <em>source_details</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instance_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compute instance. Required for updating an existing compute instance when <em>state=present</em>, for performing power actions (such as start, stop, softreset or reset) on an instance, and for terminating an instance <em>state=absent</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>ipxe_script<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>custom iPXE script that will run when the instance boots.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>metadata<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A hash/dictionary of custom key/value pairs that are associated with the instance. This option is also used to provide information to cloud-init and specifying &quot;ssh_authorized_keys&quot; for the default user of the instance. This hash is specified as '{&quot;key&quot;:&quot;value&quot;}' and '{&quot;key&quot;:&quot;value&quot;,&quot;key&quot;:&quot;value&quot;}'.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>preserve_boot_volume<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to preserve the boot volume when terminating an instance with <em>state=absent</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>shape<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The shape of the instance. Required when creating a compute instance with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">source_details<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Details for creating an instance. Use this parameter to specify whether a boot volume or an image should be used to launch a new instance.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object source_details</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>boot_volume_id<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The OCID of the boot volume used to boot the instance. Required if <em>source_type</em> is &quot;bootVolume&quot;.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>image_id<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The OCID of the image used to boot the instance. Required if <em>source_type</em> is &quot;image&quot;.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>source_type<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td><ul><li>image</li><li>bootVolume</li></ul></td>
-        <td>
-        <div>The source type for the instance. Use image when specifying the image OCID. Use bootVolume when specifying the boot volume OCID.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li><li>running</li><li>reset</li><li>softreset</li><li>stopped</li></ul></td>
-    <td>
-        <div>The state of the instance that must be asserted to. When <em>state=present</em>, and the compute instance doesn't exist, the instance is launched/created with the specified details. When <em>state=absent</em>, the compute instance is terminated. When <em>state=stopped</em>, the compute instance is powered off. When <em>state=running</em>, the compute instance is powered on. When <em>state=softreset</em>, an ACPI shutdown is initiated and the compute instance is powered on. When <em>state=reset</em>, the compute instance is powered off and then powered on. Note that <em>state=softreset</em> and <em>state=reset</em> states are not idempotent. Every time a play is executed with these <code>state</code> options, a shutdown and a power on sequence is executed against the instance.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">vnic<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Details for the primary VNIC that is automatically created and attached when the instance is launched. Required when creating a compute instance with <em>state=present</em>.</div>
-        </br><div style="font-size: small;">aliases: create_vnic_details</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object vnic</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>skip_source_dest_check<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Determines whether the source/destination check is disabled on the VNIC. Defaults to false, which means the check is performed.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>name<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A user-friendly name for the VNIC. Does not have to be unique.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>hostname_label<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The hostname for the VNIC's primary private IP. Used for DNS. The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>assign_public_ip<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Determines whether the VNIC should be assigned a public IP address.  If not set and the VNIC is being created in a private subnet (that is, where <em>prohibitPublicIpOnVnic = true</em> in the Subnet), then no public IP address is assigned. If not set and the subnet is public <em>prohibitPublicIpOnVnic = false</em>, then a public IP address is assigned. If set to true and <em>prohibitPublicIpOnVnic = true</em>, an error is returned.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>subnet_id<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The OCID of the subnet to create the VNIC in.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>private_ip<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The private IP to assign to the VNIC. Must be an available IP address within the subnet's CIDR. If you don't specify a value, Oracle automatically assigns a private IP address from the subnet. This is the VNIC's primary private IP address.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">volume_details<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Details for attaching or detaching a volume to an instance with <em>state=present</em> or <em>state=RUNNING</em>. This option is only supported in experimental mode. To use an experimental feature, set the environment variable OCI_ANSIBLE_EXPERIMENTAL to True.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object volume_details</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>attachment_name<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A user-friendly name. Does not have to be unique, and it cannot be changed. Avoid entering confidential information.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>attachment_state<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>present</td>
-        <td><ul><li>present</li><li>absent</li></ul></td>
-        <td>
-        <div>Attach a volume to the instance <em>instance_id</em> with <em>attachment_state=present</em>. Detach a volume from the instance <em>instance_id</em> with <em>attachment_state=absent</em>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>type<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>iscsi</td>
-        <td><ul><li>iscsi</li></ul></td>
-        <td>
-        <div>The type of volume. The only supported value is &quot;iscsi&quot;.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>volume_id<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The OCID of the volume to be attached to or detached from the instance <em>instance_id</em>.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Launch/create an instance using an image, with custom metadata and a private IP assignment
@@ -621,10 +629,12 @@ Examples
             private_ip: "10.0.0.5"
             subnet_id: "ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...5iddusmpqpaoa"
 
-    - name: Launch/create an instance using a boot volume, a private IP assignment and attach a volume
+    - name: Launch/create an instance using a boot volume, a private IP assignment and attach a volume, and a specific
+            fault domain
       oci_instance:
          name: myinstance2
          availability_domain: "BnQb:PHX-AD-1"
+         fault_domain: "FAULT-DOMAIN-2"
          source_details:
             source_type: bootVolume
             boot_volume_id: ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx
@@ -704,716 +714,2225 @@ Examples
 
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>added_instances</td>
-    <td>
-        <div>Details of newly added compute instances</div>
-    </td>
-    <td align=center>On successful addition of new compute instances</td>
-    <td align=center>complex</td>
-    <td align=center>Same as the instances sample</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="3">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>TERMINATED</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain the instance is running in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BnQb:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>extended_metadata</td>
-        <td>
-            <div>Additional key-value pairs associated with the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict(str, str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</td>
-        </tr>
-
-        <tr>
-        <td>region</td>
-        <td>
-            <div>The region that contains the Availability Domain the instance is running in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>phx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the instance was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-20 04:52:54.541000</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name for the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-instance-968</td>
-        </tr>
-
-        <tr>
-        <td>image_id</td>
-        <td>
-            <div>The OCID of the image that the instance is based on</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>shape</td>
-        <td>
-            <div>The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BM.Standard1.36</td>
-        </tr>
-
-        <tr>
-        <td>ipxe_script</td>
-        <td>
-            <div>A custom iPXE script that will run when the instance boots</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>volume_attachments</td>
-        <td>
-            <div>List of information about volume attachments</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>complex</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>boot_volume_attachment</td>
-        <td>
-            <div>Information of the boot volume attachment.</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>dict</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>metadata</td>
-        <td>
-            <div>Custom metadata that was associated with the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict(str, str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instance</td>
-    <td>
-        <div>Details of the OCI compute instance launched, updated or terminated as a result of the current operation</div>
-    </td>
-    <td align=center>On successful operation (create, update and terminate) on a single Compute instance</td>
-    <td align=center>complex</td>
-    <td align=center></td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
-        <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>TERMINATED</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain the instance is running in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BnQb:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>extended_metadata</td>
-        <td>
-            <div>Additional key-value pairs associated with the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict(str, str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</td>
-        </tr>
-
-        <tr>
-        <td>region</td>
-        <td>
-            <div>The region that contains the Availability Domain the instance is running in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>phx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the instance was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-20 04:52:54.541000</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name for the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-instance-968</td>
-        </tr>
-
-        <tr>
-        <td>image_id</td>
-        <td>
-            <div>The OCID of the image that the instance is based on</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>shape</td>
-        <td>
-            <div>The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BM.Standard1.36</td>
-        </tr>
-
-        <tr>
-        <td>ipxe_script</td>
-        <td>
-            <div>A custom iPXE script that will run when the instance boots</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>volume_attachments</td>
-        <td>
-            <div>List of information about volume attachments</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>complex</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>boot_volume_attachment</td>
-        <td>
-            <div>Information of the boot volume attachment.</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>dict</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>metadata</td>
-        <td>
-            <div>Custom metadata that was associated with the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict(str, str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    <tr>
-    <td>terminated_instances</td>
-    <td>
-        <div>Details of terminated compute instances</div>
-    </td>
-    <td align=center>On successful termination of compute instances</td>
-    <td align=center>complex</td>
-    <td align=center>Same as the instances sample</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
-        <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>TERMINATED</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain the instance is running in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BnQb:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>extended_metadata</td>
-        <td>
-            <div>Additional key-value pairs associated with the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict(str, str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</td>
-        </tr>
-
-        <tr>
-        <td>region</td>
-        <td>
-            <div>The region that contains the Availability Domain the instance is running in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>phx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the instance was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-20 04:52:54.541000</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name for the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-instance-968</td>
-        </tr>
-
-        <tr>
-        <td>image_id</td>
-        <td>
-            <div>The OCID of the image that the instance is based on</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>shape</td>
-        <td>
-            <div>The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BM.Standard1.36</td>
-        </tr>
-
-        <tr>
-        <td>ipxe_script</td>
-        <td>
-            <div>A custom iPXE script that will run when the instance boots</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>volume_attachments</td>
-        <td>
-            <div>List of information about volume attachments</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>complex</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>boot_volume_attachment</td>
-        <td>
-            <div>Information of the boot volume attachment.</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>dict</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>metadata</td>
-        <td>
-            <div>Custom metadata that was associated with the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict(str, str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instances</td>
-    <td>
-        <div>List of details of the OCI compute instances launched or terminated as a result of the current operation</div>
-    </td>
-    <td align=center>On successful operation (launch, update and terminate) of compute instances. For 'exact_count' scenarios, details of all matching instances are returned for this key.</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'RUNNING', 'availability_domain': 'BnQb:PHX-AD-1', 'extended_metadata': {}, 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...vm62xq', 'region': 'phx', 'time_created': '2017-11-14T16:09:07.557000+00:00', 'display_name': 'ansible-test-968', 'image_id': 'ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx....7klnoa', 'shape': 'BM.Standard1.36', 'ipxe_script': None, 'volume_attachments': [{'lifecycle_state': 'ATTACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'ansible_volume_attachment', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-11-23T11:17:50.139000+00:00', 'id': 'ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:472a085d-41a9-4c18-ae7d-dea5b296dad3', 'ipv4': '169.254.2.2', 'volume_id': 'ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}], 'boot_volume_attachment': {'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-15T07:23:10.838000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}, 'id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx....lxiggdq', 'metadata': {'foo': 'bar', 'baz': 'quux'}}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
-        <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>TERMINATED</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain the instance is running in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BnQb:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>extended_metadata</td>
-        <td>
-            <div>Additional key-value pairs associated with the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict(str, str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</td>
-        </tr>
-
-        <tr>
-        <td>region</td>
-        <td>
-            <div>The region that contains the Availability Domain the instance is running in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>phx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the instance was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-20 04:52:54.541000</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name for the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible-instance-968</td>
-        </tr>
-
-        <tr>
-        <td>image_id</td>
-        <td>
-            <div>The OCID of the image that the instance is based on</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>shape</td>
-        <td>
-            <div>The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BM.Standard1.36</td>
-        </tr>
-
-        <tr>
-        <td>ipxe_script</td>
-        <td>
-            <div>A custom iPXE script that will run when the instance boots</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>volume_attachments</td>
-        <td>
-            <div>List of information about volume attachments</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>complex</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>boot_volume_attachment</td>
-        <td>
-            <div>Information of the boot volume attachment.</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>dict</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>metadata</td>
-        <td>
-            <div>Custom metadata that was associated with the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict(str, str)</td>
-        <td align=center>{'foo': 'bar'}</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="3">
+                    <b>added_instances</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful addition of new compute instances</td>
+                <td>
+                                            <div>Details of newly added compute instances</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Same as the instances sample</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">TERMINATED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain the instance is running in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>extended_metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str, str)</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional key-value pairs associated with the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>region</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The region that contains the Availability Domain the instance is running in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">phx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the instance was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-20 04:52:54.541000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name for the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-instance-968</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>image_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the image that the instance is based on</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BM.Standard1.36</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>ipxe_script</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A custom iPXE script that will run when the instance boots</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>volume_attachments</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>List of information about volume attachments</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of an instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_username</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>iqn</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The target volume's iSCSI Qualified Name in the format defined by RFC 3720.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ipv4</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI IP address.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">169.254.0.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>attachment_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iscsi</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3260</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_secret</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the &quot;CHAP password&quot;.)</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">d6866c0d-298b-48ba-95af-309b4faux45e</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>boot_volume_attachment</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>Information of the boot volume attachment.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My boot volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str, str)</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Custom metadata that was associated with the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                <td colspan="3">
+                    <b>instance</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful operation (create, update and terminate) on a single Compute instance</td>
+                <td>
+                                            <div>Details of the OCI compute instance launched, updated or terminated as a result of the current operation</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">TERMINATED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>fault_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the fault domain the instance is running in. A fault domain is a grouping of hardware and infrastructure within an availability domain. Each availability domain contains three fault domains. Fault domains let you distribute your instances so that they are not on the same physical hardware within a single availability domain. A hardware failure or Compute hardware maintenance that affects one fault domain does not affect instances in other fault domains. If you do not specify the fault domain, the system selects one for you. To change the fault domain for an instance, terminate it and launch a new instance in the preferred fault domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">FAULT-DOMAIN-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>extended_metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str, str)</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional key-value pairs associated with the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>region</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The region that contains the Availability Domain the instance is running in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">phx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the instance was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-20 04:52:54.541000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name for the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-instance-968</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>image_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the image that the instance is based on</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BM.Standard1.36</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain the instance is running in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>volume_attachments</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>List of information about volume attachments</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of an instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_username</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>iqn</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The target volume's iSCSI Qualified Name in the format defined by RFC 3720.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ipv4</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI IP address.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">169.254.0.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>attachment_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iscsi</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3260</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_secret</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the &quot;CHAP password&quot;.)</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">d6866c0d-298b-48ba-95af-309b4faux45e</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>ipxe_script</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A custom iPXE script that will run when the instance boots</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>boot_volume_attachment</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>Information of the boot volume attachment.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My boot volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str, str)</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Custom metadata that was associated with the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                <td colspan="3">
+                    <b>instances</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful operation (launch, update and terminate) of compute instances. For 'exact_count' scenarios, details of all matching instances are returned for this key.</td>
+                <td>
+                                            <div>List of details of the OCI compute instances launched or terminated as a result of the current operation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'RUNNING', 'fault_domain': 'FAULT-DOMAIN-1', 'extended_metadata': {}, 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...vm62xq', 'region': 'phx', 'time_created': '2017-11-14T16:09:07.557000+00:00', 'display_name': 'ansible-test-968', 'image_id': 'ocid1.image.oc1.phx.xxxxxEXAMPLExxxxx....7klnoa', 'shape': 'BM.Standard1.36', 'availability_domain': 'BnQb:PHX-AD-1', 'volume_attachments': [{'lifecycle_state': 'ATTACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'ansible_volume_attachment', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-11-23T11:17:50.139000+00:00', 'id': 'ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:472a085d-41a9-4c18-ae7d-dea5b296dad3', 'ipv4': '169.254.2.2', 'volume_id': 'ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}], 'ipxe_script': None, 'boot_volume_attachment': {'boot_volume_id': 'ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'Remote boot attachment for instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'lifecycle_state': 'ATTACHED', 'time_created': '2018-01-15T07:23:10.838000+00:00', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx'}, 'id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx....lxiggdq', 'metadata': {'foo': 'bar', 'baz': 'quux'}}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">TERMINATED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>fault_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the fault domain the instance is running in. A fault domain is a grouping of hardware and infrastructure within an availability domain. Each availability domain contains three fault domains. Fault domains let you distribute your instances so that they are not on the same physical hardware within a single availability domain. A hardware failure or Compute hardware maintenance that affects one fault domain does not affect instances in other fault domains. If you do not specify the fault domain, the system selects one for you. To change the fault domain for an instance, terminate it and launch a new instance in the preferred fault domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">FAULT-DOMAIN-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>extended_metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str, str)</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional key-value pairs associated with the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>region</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The region that contains the Availability Domain the instance is running in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">phx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the instance was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-20 04:52:54.541000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name for the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-instance-968</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>image_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the image that the instance is based on</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BM.Standard1.36</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain the instance is running in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>volume_attachments</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>List of information about volume attachments</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of an instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_username</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>iqn</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The target volume's iSCSI Qualified Name in the format defined by RFC 3720.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ipv4</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI IP address.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">169.254.0.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>attachment_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iscsi</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3260</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_secret</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the &quot;CHAP password&quot;.)</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">d6866c0d-298b-48ba-95af-309b4faux45e</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>ipxe_script</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A custom iPXE script that will run when the instance boots</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>boot_volume_attachment</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>Information of the boot volume attachment.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My boot volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str, str)</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Custom metadata that was associated with the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                <td colspan="3">
+                    <b>terminated_instances</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful termination of compute instances</td>
+                <td>
+                                            <div>Details of terminated compute instances</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Same as the instances sample</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">TERMINATED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>fault_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the fault domain the instance is running in. A fault domain is a grouping of hardware and infrastructure within an availability domain. Each availability domain contains three fault domains. Fault domains let you distribute your instances so that they are not on the same physical hardware within a single availability domain. A hardware failure or Compute hardware maintenance that affects one fault domain does not affect instances in other fault domains. If you do not specify the fault domain, the system selects one for you. To change the fault domain for an instance, terminate it and launch a new instance in the preferred fault domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">FAULT-DOMAIN-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>extended_metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str, str)</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Additional key-value pairs associated with the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx....62xq</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>region</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The region that contains the Availability Domain the instance is running in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">phx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the instance was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-20 04:52:54.541000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name for the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-instance-968</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>image_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the image that the instance is based on</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BM.Standard1.36</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain the instance is running in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>volume_attachments</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>List of information about volume attachments</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of an instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_username</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>iqn</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The target volume's iSCSI Qualified Name in the format defined by RFC 3720.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ipv4</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI IP address.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">169.254.0.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>attachment_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iscsi</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3260</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_secret</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the &quot;CHAP password&quot;.)</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">d6866c0d-298b-48ba-95af-309b4faux45e</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>ipxe_script</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A custom iPXE script that will run when the instance boots</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>boot_volume_attachment</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>Information of the boot volume attachment.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>boot_volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.bootvolume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My boot volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the boot volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the boot volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the boot volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>metadata</b>
+                    <br/><div style="font-size: small; color: red">dict(str, str)</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Custom metadata that was associated with the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'foo': 'bar'}</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_instance.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_internet_gateway_facts_module.rst
+++ b/docs/modules/oci_internet_gateway_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_internet_gateway_facts:
+:source: cloud/oracle/oci_internet_gateway_facts.py
+
+:orphan:
+
+.. _oci_internet_gateway_facts_module:
 
 
 oci_internet_gateway_facts - Fetches details of the OCI Internet Gateway under a Virtual Cloud Network
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,153 +17,180 @@ oci_internet_gateway_facts - Fetches details of the OCI Internet Gateway under a
 
 Synopsis
 --------
-
-
-* Fetches details of the OCI Internet Gateway under a Virtual Cloud Network.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of the OCI Internet Gateway under a Virtual Cloud Network.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment in which this Internet Gateway exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>ig_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Internet Gateway. Required if any specific Internet Gateway details needs to be fetched. Mutually exclusive with compartment_id and vcn_id.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Cloud Network to which the Internet Gateway is attached.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment in which this Internet Gateway exists</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>ig_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Internet Gateway. Required if any specific Internet Gateway details needs to be fetched. Mutually exclusive with compartment_id and vcn_id.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Virtual Cloud Network to which the Internet Gateway is attached.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch Internet Gateway
@@ -177,135 +205,139 @@ Examples
           id: 'ocid1.internetgateway..xcds'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>internet_gateways</td>
-    <td>
-        <div>Attributes of the  Internet Gateways.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'is_enabled': True, 'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_internet_gateway_updated', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-14T18:50:50.751000+00:00', 'id': 'ocid1.internetgateway.oc1.phx.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>vcn_id</td>
-        <td>
-            <div>Identifier of the Virtual Cloud Network to which the Internet Gateway is attached.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn..ixcd</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name assigned to the Internet Gateway during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_ig</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the Internet Gateway</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Internet Gateway</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Internet Gateway</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.internetgateway.oc1.axdf</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Internet Gateway was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>internet_gateways</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the  Internet Gateways.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'is_enabled': True, 'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_internet_gateway_updated', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-14T18:50:50.751000+00:00', 'id': 'ocid1.internetgateway.oc1.phx.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Virtual Cloud Network to which the Internet Gateway is attached.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn..ixcd</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Internet Gateway during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_ig</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the Internet Gateway</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Internet Gateway</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Internet Gateway</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.internetgateway.oc1.axdf</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Internet Gateway was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_internet_gateway_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_internet_gateway_module.rst
+++ b/docs/modules/oci_internet_gateway_module.rst
@@ -1,13 +1,14 @@
-.. _oci_internet_gateway:
+:source: cloud/oracle/oci_internet_gateway.py
+
+:orphan:
+
+.. _oci_internet_gateway_module:
 
 
 oci_internet_gateway - Create,update and delete OCI Internet Gateway
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,258 +17,292 @@ oci_internet_gateway - Create,update and delete OCI Internet Gateway
 
 Synopsis
 --------
-
-
-* Creates OCI Internet Gateway
-* Update OCI Internet Gateway, if present, with a new display name
-* Update OCI Internet Gateway, if present, with enable/disable state
-* Delete OCI Internet Gateway, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Creates OCI Internet Gateway
+- Update OCI Internet Gateway, if present, with a new display name
+- Update OCI Internet Gateway, if present, with enable/disable state
+- Delete OCI Internet Gateway, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which this Internet Gateway would be created. Mandatory for create operation.Optional for delete and update. Mutually exclusive with <em>ig_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the Internet Gateway. A user friendly name. Does not have to be unique, and could be changed. If not specified, a default name would be provided.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>ig_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Internet Gateway. Mandatory for delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>is_enabled</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>This option is mandatory for create operation.If <em>is_enabled=yes</em>, the gateway would be enabled. If <em>is_enabled=no</em>, traffic is not routed to/from the Internet, regardless of route rules.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: enabled</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete Internet Gateway. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Cloud Network to which the Internet Gateway should be attached. Mandatory for create operation. Optional for delete and update. Mutually exclusive with <em>ig_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment under which this Internet Gateway would be created. Mandatory for create operation.Optional for delete and update. Mutually exclusive with <em>ig_id</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the Internet Gateway. A user friendly name. Does not have to be unique, and could be changed. If not specified, a default name would be provided.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>ig_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Internet Gateway. Mandatory for delete and update.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>is_enabled<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>This option is mandatory for create operation.If <em>is_enabled=yes</em>, the gateway would be enabled. If <em>is_enabled=no</em>, traffic is not routed to/from the Internet, regardless of route rules.</div>
-        </br><div style="font-size: small;">aliases: enabled</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete Internet Gateway. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Virtual Cloud Network to which the Internet Gateway should be attached. Mandatory for create operation. Optional for delete and update. Mutually exclusive with <em>ig_id</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Note: These examples do not set authentication details.
@@ -308,135 +343,139 @@ Examples
 
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>internet_gateway</td>
-    <td>
-        <div>Attributes of the created/updated Internet Gateway. For delete, deleted Internet Gateway description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'is_enabled': False, 'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_ig', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-12T13:17:36.564000+00:00', 'id': 'ocid1.internetgateway.oc1.phx.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>vcn_id</td>
-        <td>
-            <div>Identifier of the Virtual Cloud Network to which the Internet Gateway is attached.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn..ixcd</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name assigned to the Internet Gateway during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_ig</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the Internet Gateway</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Internet Gateway</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Internet Gateway</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.internetgateway.oc1.axdf</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Internet Gateway was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>internet_gateway</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated Internet Gateway. For delete, deleted Internet Gateway description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'is_enabled': False, 'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_ig', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-12T13:17:36.564000+00:00', 'id': 'ocid1.internetgateway.oc1.phx.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Virtual Cloud Network to which the Internet Gateway is attached.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn..ixcd</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Internet Gateway during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_ig</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the Internet Gateway</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Internet Gateway</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Internet Gateway</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.internetgateway.oc1.axdf</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Internet Gateway was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_internet_gateway.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_kubeconfig_module.rst
+++ b/docs/modules/oci_kubeconfig_module.rst
@@ -1,0 +1,281 @@
+:source: cloud/oracle/oci_kubeconfig.py
+
+:orphan:
+
+.. _oci_kubeconfig_module:
+
+
+oci_kubeconfig - Create the Kubeconfig YAML for a cluster in OCI container engine for Kubernetes service.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module creates a cluster kubeconfig in OCI Container Engine for Kubernetes Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>cluster_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the cluster.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>create_cluster_kubeconfig_content_details</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The details of the cluster kubeconfig to create.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>token_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The version of the kubeconfig token.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>expiration</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The desired expiration, in seconds, to use for the kubeconfig token.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>dest</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The complete file path of the file to which kubeconfig content should be written.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to force overwrite an existing kubeconfig file.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: overwrite</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create a kubeconfig for a cluster
+      oci_kubeconfig:
+        cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+        create_cluster_kubeconfig_content_details:
+            expiration: 600
+        dest: "/usr/local/my_kubeconfig"
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>kubeconfig</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>kubeconfig content</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'kubeconfig': 'apiVersion: v1 clusters: - cluster: certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJ Q0FURS0tLS0tCk1JSURqRENDQW5TZ.....'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_kubeconfig.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_backend_facts_module.rst
+++ b/docs/modules/oci_load_balancer_backend_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_backend_facts:
+:source: cloud/oracle/oci_load_balancer_backend_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_backend_facts_module:
 
 
 oci_load_balancer_backend_facts - Fetch details of all Backends in a load balancer backend set of a load balancer
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,163 +17,180 @@ oci_load_balancer_backend_facts - Fetch details of all Backends in a load balanc
 
 Synopsis
 --------
-
-
-* Fetch details of all Backends in a load balancer backend set of a load balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetch details of all Backends in a load balancer backend set of a load balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>backend_set_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the backend set under which the backend exists.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>ip_address</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The IP address of the backend server.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer to which the Backends belongs.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>port</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The communication port for the backend server.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>backend_set_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the backend set under which the backend exists.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>ip_address<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The IP address of the backend server.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer to which the Backends belongs.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>port<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The communication port for the backend server.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch details of all load balancer backends of a load balancer
@@ -190,145 +208,147 @@ Examples
           port: '8181'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>backends</td>
-    <td>
-        <div>Attributes of the Load Balancer Backend.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'drain': False, 'name': '10.159.34.21:8181', 'weight': 3, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8181}, {'drain': False, 'name': '10.159.34.21:1234', 'weight': 1, 'ip_address': '10.159.34.55', 'offline': False, 'backup': False, 'port': 1234}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>drain</td>
-        <td>
-            <div>The drain state of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>False</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>10.45.121.59:8080</td>
-        </tr>
-
-        <tr>
-        <td>weight</td>
-        <td>
-            <div>The weight of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>1</td>
-        </tr>
-
-        <tr>
-        <td>backup</td>
-        <td>
-            <div>The backup state of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>False</td>
-        </tr>
-
-        <tr>
-        <td>offline</td>
-        <td>
-            <div>The offline state of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>False</td>
-        </tr>
-
-        <tr>
-        <td>ip_address</td>
-        <td>
-            <div>Ip Address of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>10.45.121.69</td>
-        </tr>
-
-        <tr>
-        <td>port</td>
-        <td>
-            <div>Port of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>8080</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>backends</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Load Balancer Backend.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'drain': False, 'name': '10.159.34.21:8181', 'weight': 3, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8181}, {'drain': False, 'name': '10.159.34.21:1234', 'weight': 1, 'ip_address': '10.159.34.55', 'offline': False, 'backup': False, 'port': 1234}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>drain</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The drain state of the Load Balancer Backend</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the Load Balancer Backend</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.45.121.59:8080</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>weight</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The weight of the Load Balancer Backend</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>backup</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The backup state of the Load Balancer Backend</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>offline</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The offline state of the Load Balancer Backend</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ip_address</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Ip Address of the Load Balancer Backend</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.45.121.69</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Port of the Load Balancer Backend</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">8080</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_backend_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_backend_health_facts_module.rst
+++ b/docs/modules/oci_load_balancer_backend_health_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_backend_health_facts:
+:source: cloud/oracle/oci_load_balancer_backend_health_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_backend_health_facts_module:
 
 
 oci_load_balancer_backend_health_facts - Fetch details of Backend Health in a load balancer backend set of a load balancer
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,163 +17,180 @@ oci_load_balancer_backend_health_facts - Fetch details of Backend Health in a lo
 
 Synopsis
 --------
-
-
-* Fetch details of Backend Health in a load balancer backend set of a load balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetch details of Backend Health in a load balancer backend set of a load balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>backend_set_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the backend set under which the backend exists.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>ip_address</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The IP address of the backend server.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer to which the Backends belongs.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>port</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The communication port for the backend server.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>backend_set_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the backend set under which the backend exists.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>ip_address<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The IP address of the backend server.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer to which the Backends belongs.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>port<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The communication port for the backend server.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch details of the backend health of a backend set
@@ -184,95 +202,83 @@ Examples
           port: '8181'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>backend_health</td>
-    <td>
-        <div>Attributes of the Backend Health</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'health_check_results': [{'subnet_id': 'ocid1.subnet.aaaa', 'source_ip_address': '10.1.253.55', 'health_check_status': 'OK', 'timestamp': '2018-01-27T15:41:19.188000+00:00'}], 'status': 'CRITICAL'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>health_check_results</td>
-        <td>
-            <div>A list of the most recent health check results returned for the specified backend server. Element of the list represent instance of HealthCheckResult</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>[{'subnet_id': 'oci1.subnet.aaaa', 'source_ip_address': '10.0.0.64', 'health_check_status': 'OK', 'timestamp': '2018-01-27T15:41:19.188000+00:00'}]</td>
-        </tr>
-
-        <tr>
-        <td>status</td>
-        <td>
-            <div>The general health status of the specified backend server as reported by the primary and standby load balancers. Allowed values - - OK - WARNING - CRITICAL - UNKWON</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>OK</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>backend_health</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Backend Health</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'health_check_results': [{'subnet_id': 'ocid1.subnet.aaaa', 'source_ip_address': '10.1.253.55', 'health_check_status': 'OK', 'timestamp': '2018-01-27T15:41:19.188000+00:00'}], 'status': 'CRITICAL'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>health_check_results</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of the most recent health check results returned for the specified backend server. Element of the list represent instance of HealthCheckResult</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'subnet_id': 'oci1.subnet.aaaa', 'source_ip_address': '10.0.0.64', 'health_check_status': 'OK', 'timestamp': '2018-01-27T15:41:19.188000+00:00'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The general health status of the specified backend server as reported by the primary and standby load balancers. Allowed values - - OK - WARNING - CRITICAL - UNKWON</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">OK</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_backend_health_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_backend_module.rst
+++ b/docs/modules/oci_load_balancer_backend_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_backend:
+:source: cloud/oracle/oci_load_balancer_backend.py
+
+:orphan:
+
+.. _oci_load_balancer_backend_module:
 
 
 oci_load_balancer_backend - Add, modify and remove a backend from a load balancer in OCI Load Balancing Service
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,245 +17,283 @@ oci_load_balancer_backend - Add, modify and remove a backend from a load balance
 
 Synopsis
 --------
-
-
-* Add a Backend server to OCI Load Balancer
-* Update a Backend server in a Load Balancer, if present, with any changed attribute
-* Delete a Backend server from OCI Load Balancer Backends, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Add a Backend server to OCI Load Balancer
+- Update a Backend server in a Load Balancer, if present, with any changed attribute
+- Delete a Backend server from OCI Load Balancer Backends, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>backend_set_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the backend set to add the backend server to.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>backup</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether the load balancer should treat this server as a backup unit. If true, the load balancer forwards no ingress traffic to this backend server unless all other backend servers not marked as &quot;backup&quot; fail the health check policy.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>drain</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether the load balancer should drain this server. Servers marked &quot;drain&quot; receive no new incoming traffic.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>ip_address</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The IP address of the backend server.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer in which the Backend belongs.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>offline</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether the load balancer should treat this server as offline. Offline servers receive no incoming traffic.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>port</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The communication port for the backend server.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete Load Balancer Backend. For <em>state=present</em>, if it does not exists, it gets added. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>weight</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The load balancing policy weight assigned to the server. Backend servers with a higher weight receive a larger proportion of incoming traffic. For example, a server weighted 3 receives 3 times the number of new connections as a server weighted 1.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>backend_set_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the backend set to add the backend server to.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>backup<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether the load balancer should treat this server as a backup unit. If true, the load balancer forwards no ingress traffic to this backend server unless all other backend servers not marked as &quot;backup&quot; fail the health check policy.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>drain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether the load balancer should drain this server. Servers marked &quot;drain&quot; receive no new incoming traffic.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>ip_address<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The IP address of the backend server.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer in which the Backend belongs.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>offline<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether the load balancer should treat this server as offline. Offline servers receive no incoming traffic.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>port<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The communication port for the backend server.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete Load Balancer Backend. For <em>state=present</em>, if it does not exists, it gets added. If exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>weight<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The load balancing policy weight assigned to the server. Backend servers with a higher weight receive a larger proportion of incoming traffic. For example, a server weighted 3 receives 3 times the number of new connections as a server weighted 1.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -316,145 +355,147 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>backend</td>
-    <td>
-        <div>Attributes of the created/updated Load Balancer Backend. For delete, deleted Load Balancer Backend description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'drain': False, 'name': '10.159.34.21:8181', 'weight': 3, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8181}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>drain</td>
-        <td>
-            <div>The drain state of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>False</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>10.45.121.59:8080</td>
-        </tr>
-
-        <tr>
-        <td>weight</td>
-        <td>
-            <div>The weight of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>1</td>
-        </tr>
-
-        <tr>
-        <td>backup</td>
-        <td>
-            <div>The backup state of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>False</td>
-        </tr>
-
-        <tr>
-        <td>offline</td>
-        <td>
-            <div>The offline state of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>False</td>
-        </tr>
-
-        <tr>
-        <td>ip_address</td>
-        <td>
-            <div>Ip Address of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>10.45.121.69</td>
-        </tr>
-
-        <tr>
-        <td>port</td>
-        <td>
-            <div>Port of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>8080</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>backend</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated Load Balancer Backend. For delete, deleted Load Balancer Backend description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'drain': False, 'name': '10.159.34.21:8181', 'weight': 3, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8181}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>drain</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The drain state of the Load Balancer Backend</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the Load Balancer Backend</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.45.121.59:8080</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>weight</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The weight of the Load Balancer Backend</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>backup</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The backup state of the Load Balancer Backend</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>offline</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The offline state of the Load Balancer Backend</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ip_address</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Ip Address of the Load Balancer Backend</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.45.121.69</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Port of the Load Balancer Backend</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">8080</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_backend.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_backend_set_facts_module.rst
+++ b/docs/modules/oci_load_balancer_backend_set_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_backend_set_facts:
+:source: cloud/oracle/oci_load_balancer_backend_set_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_backend_set_facts_module:
 
 
 oci_load_balancer_backend_set_facts - Fetches details of backend set(s) that are associated with a load balancer
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,160 @@ oci_load_balancer_backend_set_facts - Fetches details of backend set(s) that are
 
 Synopsis
 --------
-
-
-* Fetches details of all backend sets, or a specific backend set, that are associated with a load balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of all backend sets, or a specific backend set, that are associated with a load balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer where the Backend Set belongs</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the Backend Set</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer where the Backend Set belongs</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the Backend Set</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch Load Balancer Backend Set
@@ -168,135 +186,139 @@ Examples
            load_balancer_id: 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>backend_sets</td>
-    <td>
-        <div>Attributes of the  Load Balancer Backend Set.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'ssl_configuration': {'certificate_name': 'certs1', 'verify_depth': 3, 'verify_peer_certificate': True}, 'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}, {'drain': False, 'name': '10.159.34.21:8282', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8282}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 500, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}, 'name': 'backend_set_1', 'policy': 'IP_HASH', 'session_persistence_configuration': {'cookie_name': 'first_backend_set_cookie_updated', 'disable_fallback': True}}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>ssl_configuration</td>
-        <td>
-            <div>The load balancer's SSL handling configuration details.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}</td>
-        </tr>
-
-        <tr>
-        <td>backends</td>
-        <td>
-            <div>A list of configurations related to Backends that are part of the backend set</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}, {'drain': False, 'name': '10.159.34.21:8282', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8282}]</td>
-        </tr>
-
-        <tr>
-        <td>health_checker</td>
-        <td>
-            <div>Health check policy for a backend set.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name assigned to the Load Balancer Backend Set during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_backend_set</td>
-        </tr>
-
-        <tr>
-        <td>policy</td>
-        <td>
-            <div>The load balancer policy for the backend set.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>LEAST_CONNECTIONS</td>
-        </tr>
-
-        <tr>
-        <td>session_persistence_configuration</td>
-        <td>
-            <div>The configuration details for implementing session persistence</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'cookie_name': 'first_backend_set_cookie', 'disable_fallback': True}</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>backend_sets</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the  Load Balancer Backend Set.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'ssl_configuration': {'certificate_name': 'certs1', 'verify_depth': 3, 'verify_peer_certificate': True}, 'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}, {'drain': False, 'name': '10.159.34.21:8282', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8282}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 500, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}, 'name': 'backend_set_1', 'policy': 'IP_HASH', 'session_persistence_configuration': {'cookie_name': 'first_backend_set_cookie_updated', 'disable_fallback': True}}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ssl_configuration</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The load balancer's SSL handling configuration details.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>backends</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of configurations related to Backends that are part of the backend set</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}, {'drain': False, 'name': '10.159.34.21:8282', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8282}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>health_checker</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Health check policy for a backend set.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Load Balancer Backend Set during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_backend_set</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>policy</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The load balancer policy for the backend set.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">LEAST_CONNECTIONS</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>session_persistence_configuration</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The configuration details for implementing session persistence</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'cookie_name': 'first_backend_set_cookie', 'disable_fallback': True}</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_backend_set_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_backend_set_health_facts_module.rst
+++ b/docs/modules/oci_load_balancer_backend_set_health_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_backend_set_health_facts:
+:source: cloud/oracle/oci_load_balancer_backend_set_health_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_backend_set_health_facts_module:
 
 
 oci_load_balancer_backend_set_health_facts - Fetch details of a Backend Set's health in a load balancer
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,249 +17,147 @@ oci_load_balancer_backend_set_health_facts - Fetch details of a Backend Set's he
 
 Synopsis
 --------
-
-
-* Fetch details of Backend Set's health in a load balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetch details of Backend Set's health in a load balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>backend_set_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the backend set under which the backend exists.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer to which the Backends belongs.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    #Fetch details of the backend set health of a load balancer
-    - name: List a specific Load Balancer Backend Set's Health
-      oci_load_balancer_backend_set_health_facts:
-          load_balancer_id: 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx'
-          backend_set_name: 'ansible_backend_set'
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>backend_health</td>
-    <td>
-        <div>Attributes of the Backend Health</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'status': 'CRITICAL', 'critical_state_backend_names': ['10.159.34.21:8080', '10.159.34.21:8181'], 'unknown_state_backend_names': [], 'total_backend_count': 2, 'warning_state_backend_names': []}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>status</td>
-        <td>
-            <div>Overall health status of the backend set. Allowed values - - OK - WARNING - CRITICAL - UNKWON</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>OK</td>
-        </tr>
-
-        <tr>
-        <td>critical_state_backend_names</td>
-        <td>
-            <div>A list of backend servers that are currently in the CRITICAL health state. The list identifies each backend server by IP address and port.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>10.1.2.3:80</td>
-        </tr>
-
-        <tr>
-        <td>unknown_state_backend_names</td>
-        <td>
-            <div>A list of backend servers that are currently in the UNKWON health state. The list identifies each backend server by IP address and port.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>10.1.2.4:80</td>
-        </tr>
-
-        <tr>
-        <td>total_backend_count</td>
-        <td>
-            <div>The total number of backend servers in this backend set.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>2</td>
-        </tr>
-
-        <tr>
-        <td>warning_state_backend_names</td>
-        <td>
-            <div>A list of backend servers that are currently in the WARNING health state. The list identifies each backend server by IP address and port.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>10.1.55.2:80</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>backend_set_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the backend set under which the backend exists.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer to which the Backends belongs.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -268,19 +167,138 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Debayan Gupta(@debayan_gupta)
+.. code-block:: yaml+jinja
+
+    
+    #Fetch details of the backend set health of a load balancer
+    - name: List a specific Load Balancer Backend Set's Health
+      oci_load_balancer_backend_set_health_facts:
+          load_balancer_id: 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx'
+          backend_set_name: 'ansible_backend_set'
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>backend_health</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Backend Health</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'status': 'CRITICAL', 'critical_state_backend_names': ['10.159.34.21:8080', '10.159.34.21:8181'], 'unknown_state_backend_names': [], 'total_backend_count': 2, 'warning_state_backend_names': []}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Overall health status of the backend set. Allowed values - - OK - WARNING - CRITICAL - UNKWON</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">OK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>critical_state_backend_names</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of backend servers that are currently in the CRITICAL health state. The list identifies each backend server by IP address and port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.1.2.3:80</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>unknown_state_backend_names</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of backend servers that are currently in the UNKWON health state. The list identifies each backend server by IP address and port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.1.2.4:80</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>total_backend_count</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The total number of backend servers in this backend set.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>warning_state_backend_names</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of backend servers that are currently in the WARNING health state. The list identifies each backend server by IP address and port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.1.55.2:80</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_backend_set_health_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_backend_set_module.rst
+++ b/docs/modules/oci_load_balancer_backend_set_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_backend_set:
+:source: cloud/oracle/oci_load_balancer_backend_set.py
+
+:orphan:
+
+.. _oci_load_balancer_backend_set_module:
 
 
 oci_load_balancer_backend_set - Create, update and delete a backend set of a load balancer.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,481 +17,503 @@ oci_load_balancer_backend_set - Create, update and delete a backend set of a loa
 
 Synopsis
 --------
-
-
-* Create an OCI Load Balancer Backend Set
-* Update OCI Load Balancers Backend Set, if present.
-* Delete OCI Load Balancers Backend Set, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Create an OCI Load Balancer Backend Set
+- Update OCI Load Balancers Backend Set, if present.
+- Delete OCI Load Balancers Backend Set, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">backends<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A list of configurations related to Backends that are part of a backend set.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object backends</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>backends</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A list of configurations related to Backends that are part of a backend set.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>drain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                                                                <b>Default:</b><br/><div style="color: blue">no</div>
+                                    </td>
+                                                                <td>
+                                            <div>Specifies whether the load balancer should drain this server. Servers marked &quot;drain&quot; receive no new incoming traffic.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>weight</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1</div>
+                                    </td>
+                                                                <td>
+                                            <div>Describes the load balancing policy weight assigned to the server. Backend servers with a higher weight receive a larger proportion of incoming traffic. For example, a server weighted '3' receives 3 times the number of new connections as a server weighted '1'.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>backup</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                                                                <b>Default:</b><br/><div style="color: blue">no</div>
+                                    </td>
+                                                                <td>
+                                            <div>Specifies whether the load balancer should treat this server as a backup unit. If true, the load balancer forwards no ingress traffic to this backend server unless all other backend servers not marked as &quot;backup&quot; fail the health check policy.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>offline</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                                                                <b>Default:</b><br/><div style="color: blue">no</div>
+                                    </td>
+                                                                <td>
+                                            <div>Ensures whether the load balancer should treat this server as offline. Offline servers receive no incoming traffic.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ip_address</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>IP address of the backend server.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>port</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The communication port for the backend server</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>health_checker</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Describes the health check policy for a backend set.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>retries</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">3</div>
+                                    </td>
+                                                                <td>
+                                            <div>Describes the number of retries to attempt before a backend server is considered unhealthy.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>protocol</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>HTTP</li>
+                                                                                                                                                                                                <li>TCP</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Describes the protocol the health check must use, either HTTP or TCP.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>response_body_regex</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">.*</div>
+                                    </td>
+                                                                <td>
+                                            <div>Describes a regular expression for parsing the response body from the backend server.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>return_code</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">200</div>
+                                    </td>
+                                                                <td>
+                                            <div>Describes the status code a healthy backend server should return.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>timeout_in_millis</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">3000</div>
+                                    </td>
+                                                                <td>
+                                            <div>Describes the maximum time, in milliseconds, to wait for a reply to a health check. A health check is successful only if a reply returns within this timeout period.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>interval_in_millis</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">10000</div>
+                                    </td>
+                                                                <td>
+                                            <div>Describes the interval between health checks, in milliseconds.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>url_path</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Describes the path against which to run the health check.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>port</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">0</div>
+                                    </td>
+                                                                <td>
+                                            <div>Describes the backend server port against which to run the health check. If the port is not specified, the load balancer uses the port information from the backends.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer. Mandatory for create,delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the Load Balancer Backend Set. A user friendly name. Does not have to be unique, and could be changed. Mandatory for create and update.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>policy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The load balancer policy for the backend set. <span class='module'>oci_load_balancer_policy_facts</span> could be used to fetch policy types suupported by OCI Load Balancer Service.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>purge_backends</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Purge any backends in the  Backend Set named <em>name</em> that is not specified in <em>backends</em>. If <em>purge_backends=no</em>, provided backends would be appended to existing backends.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>session_persistence_configuration</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The configuration details for implementing session persistence. Session persistence enables the Load Balancing Service to direct any number of requests that originate from a single logical client to a single backend web server.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>cookie_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Describes the name of the cookie used to detect a session initiated by the backend server. Use '*' to specify that any cookie set by the backend causes the session to persist.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>disable_fallback</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                                                                <b>Default:</b><br/><div style="color: blue">no</div>
+                                    </td>
+                                                                <td>
+                                            <div>DescribesWhether the load balancer is prevented from directing traffic from a persistent session client to a different backend server if the original server is unavailable.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>ssl_configuration</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The load balancer's SSL handling configuration details.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>certificate_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Describes a friendly name for the certificate bundle. It must be unique and it cannot be changed. Valid certificate bundle names include only alphanumeric characters, dashes, and underscores.Certificate bundle names cannot contain spaces.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>verify_depth</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Describes the maximum depth for peer certificate chain verification.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>verify_peer_certificate</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Describeswhether the load balancer listener should verify peer certificates.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete Load Balancer Backend Set. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>drain<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Specifies whether the load balancer should drain this server. Servers marked &quot;drain&quot; receive no new incoming traffic.</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>weight<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>1</td>
-        <td></td>
-        <td>
-        <div>Describes the load balancing policy weight assigned to the server. Backend servers with a higher weight receive a larger proportion of incoming traffic. For example, a server weighted '3' receives 3 times the number of new connections as a server weighted '1'.</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        <tr>
-        <td>backup<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Specifies whether the load balancer should treat this server as a backup unit. If true, the load balancer forwards no ingress traffic to this backend server unless all other backend servers not marked as &quot;backup&quot; fail the health check policy.</div>
-        </td>
-        </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-        <tr>
-        <td>offline<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Ensures whether the load balancer should treat this server as offline. Offline servers receive no incoming traffic.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>ip_address<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>IP address of the backend server.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>port<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The communication port for the backend server</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">health_checker<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Describes the health check policy for a backend set.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object health_checker</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>retries<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>3</td>
-        <td></td>
-        <td>
-        <div>Describes the number of retries to attempt before a backend server is considered unhealthy.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>protocol<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td><ul><li>HTTP</li><li>TCP</li></ul></td>
-        <td>
-        <div>Describes the protocol the health check must use, either HTTP or TCP.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>response_body_regex<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>.*</td>
-        <td></td>
-        <td>
-        <div>Describes a regular expression for parsing the response body from the backend server.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>return_code<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>200</td>
-        <td></td>
-        <td>
-        <div>Describes the status code a healthy backend server should return.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>timeout_in_millis<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>3000</td>
-        <td></td>
-        <td>
-        <div>Describes the maximum time, in milliseconds, to wait for a reply to a health check. A health check is successful only if a reply returns within this timeout period.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>interval_in_millis<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>10000</td>
-        <td></td>
-        <td>
-        <div>Describes the interval between health checks, in milliseconds.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>url_path<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Describes the path against which to run the health check.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>port<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Describes the backend server port against which to run the health check. If the port is not specified, the load balancer uses the port information from the backends.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer. Mandatory for create,delete and update.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the Load Balancer Backend Set. A user friendly name. Does not have to be unique, and could be changed. Mandatory for create and update.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>policy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The load balancer policy for the backend set. <span class='module'>oci_load_balancer_policy_facts</span> could be used to fetch policy types suupported by OCI Load Balancer Service.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>purge_backends<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>yes</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Purge any backends in the  Backend Set named <em>name</em> that is not specified in <em>backends</em>. If <em>purge_backends=no</em>, provided backends would be appended to existing backends.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">session_persistence_configuration<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The configuration details for implementing session persistence. Session persistence enables the Load Balancing Service to direct any number of requests that originate from a single logical client to a single backend web server.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object session_persistence_configuration</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>cookie_name<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Describes the name of the cookie used to detect a session initiated by the backend server. Use '*' to specify that any cookie set by the backend causes the session to persist.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>disable_fallback<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>DescribesWhether the load balancer is prevented from directing traffic from a persistent session client to a different backend server if the original server is unavailable.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">ssl_configuration<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The load balancer's SSL handling configuration details.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object ssl_configuration</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>certificate_name<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Describes a friendly name for the certificate bundle. It must be unique and it cannot be changed. Valid certificate bundle names include only alphanumeric characters, dashes, and underscores.Certificate bundle names cannot contain spaces.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>verify_depth<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Describes the maximum depth for peer certificate chain verification.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>verify_peer_certificate<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Describeswhether the load balancer listener should verify peer certificates.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete Load Balancer Backend Set. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -539,135 +562,139 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>backend_set</td>
-    <td>
-        <div>Attributes of the created/updated Load Balancer Backend Set. For delete, deleted Load Balancer Backend Set description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'ssl_configuration': {'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}, 'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}, {'drain': False, 'name': '10.159.34.21:8282', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8282}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 500, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}, 'name': 'backend_set_1', 'policy': 'IP_HASH', 'session_persistence_configuration': {'cookie_name': 'first_backend_set_cookie_updated', 'disable_fallback': True}}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>ssl_configuration</td>
-        <td>
-            <div>The load balancer's SSL handling configuration details.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}</td>
-        </tr>
-
-        <tr>
-        <td>backends</td>
-        <td>
-            <div>A list of configurations related to Backends that are part of the backend set</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}, {'drain': False, 'name': '10.159.34.21:8282', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8282}]</td>
-        </tr>
-
-        <tr>
-        <td>health_checker</td>
-        <td>
-            <div>Health check policy for a backend set.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name assigned to the Load Balancer Backend Set during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_backend_set</td>
-        </tr>
-
-        <tr>
-        <td>policy</td>
-        <td>
-            <div>The load balancer policy for the backend set.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>LEAST_CONNECTIONS</td>
-        </tr>
-
-        <tr>
-        <td>session_persistence_configuration</td>
-        <td>
-            <div>The configuration details for implementing session persistence</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'cookie_name': 'first_backend_set_cookie', 'disable_fallback': True}</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>backend_set</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated Load Balancer Backend Set. For delete, deleted Load Balancer Backend Set description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'ssl_configuration': {'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}, 'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}, {'drain': False, 'name': '10.159.34.21:8282', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8282}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 500, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}, 'name': 'backend_set_1', 'policy': 'IP_HASH', 'session_persistence_configuration': {'cookie_name': 'first_backend_set_cookie_updated', 'disable_fallback': True}}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ssl_configuration</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The load balancer's SSL handling configuration details.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>backends</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of configurations related to Backends that are part of the backend set</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}, {'drain': False, 'name': '10.159.34.21:8282', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8282}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>health_checker</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Health check policy for a backend set.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Load Balancer Backend Set during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_backend_set</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>policy</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The load balancer policy for the backend set.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">LEAST_CONNECTIONS</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>session_persistence_configuration</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The configuration details for implementing session persistence</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'cookie_name': 'first_backend_set_cookie', 'disable_fallback': True}</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_backend_set.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_certificate_facts_module.rst
+++ b/docs/modules/oci_load_balancer_certificate_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_certificate_facts:
+:source: cloud/oracle/oci_load_balancer_certificate_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_certificate_facts_module:
 
 
 oci_load_balancer_certificate_facts - Fetch details of all certificates associated with a load balancer
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,160 @@ oci_load_balancer_certificate_facts - Fetch details of all certificates associat
 
 Synopsis
 --------
-
-
-* Fetch details of all certificates or details of a particular certificate that is associated with a load balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetch details of all certificates or details of a particular certificate that is associated with a load balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer to which the certificate belongs.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the certificate wose details needs to be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer to which the certificate belongs.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the certificate wose details needs to be fetched.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch details of all certificates of a load balancer
@@ -167,105 +185,97 @@ Examples
           name: 'ansible_certificate'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>certificate</td>
-    <td>
-        <div>Attributes of the created certificates.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'certificate_name': 'ansible_cert_one', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIDPjCCAiYCCQC5OEUUNtrC\n-----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIDlTCCAn2gAw\n-----END CERTIFICATE-----'}, {'certificate_name': 'ansible_cert_two', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIDPjCCAiYCCQC5OEUUNtrC\n-----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIDlTCCAn2gAw\n-----END CERTIFICATE-----'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>certificate_name</td>
-        <td>
-            <div>Name of the certificate</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_certificate</td>
-        </tr>
-
-        <tr>
-        <td>public_certificate</td>
-        <td>
-            <div>The public certificate, in PEM format, that you received from your SSL certificate provider.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>-----BEGIN CERTIFICATE----- MIIDlTCCAn -----END CERTIFICATE-----</td>
-        </tr>
-
-        <tr>
-        <td>ca_certificate</td>
-        <td>
-            <div>The Certificate Authority certificate, or any interim certificate, that you received from your SSL certificate provider.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>-----BEGIN CERTIFICATE----- MIIDlTCCA -----END CERTIFICATE-----</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>certificate</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created certificates.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'certificate_name': 'ansible_cert_one', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIDPjCCAiYCCQC5OEUUNtrC\n-----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIDlTCCAn2gAw\n-----END CERTIFICATE-----'}, {'certificate_name': 'ansible_cert_two', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIDPjCCAiYCCQC5OEUUNtrC\n-----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIDlTCCAn2gAw\n-----END CERTIFICATE-----'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>certificate_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the certificate</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_certificate</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>public_certificate</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The public certificate, in PEM format, that you received from your SSL certificate provider.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">-----BEGIN CERTIFICATE----- MIIDlTCCAn -----END CERTIFICATE-----</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ca_certificate</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Certificate Authority certificate, or any interim certificate, that you received from your SSL certificate provider.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">-----BEGIN CERTIFICATE----- MIIDlTCCA -----END CERTIFICATE-----</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_certificate_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_certificate_module.rst
+++ b/docs/modules/oci_load_balancer_certificate_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_certificate:
+:source: cloud/oracle/oci_load_balancer_certificate.py
+
+:orphan:
+
+.. _oci_load_balancer_certificate_module:
 
 
 oci_load_balancer_certificate - Add or remove a SSL certificate from a load balancer in OCI Load Balancing Service
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,194 +17,250 @@ oci_load_balancer_certificate - Add or remove a SSL certificate from a load bala
 
 Synopsis
 --------
-
-
-* Add a SSL certificate to OCI Load Balancer
-* Delete a SSL certificate, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Add a SSL certificate to OCI Load Balancer
+- Delete a SSL certificate, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>ca_certificate</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Certificate Authority certificate, or any interim certificate, that you received from your SSL certificate provider. The absolute path of the certificate file should be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer in which the certificate belongs</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the certificate  to add to the load balancer.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>passphrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A passphrase for encrypted private keys. This is needed only if you created your certificate with a passphrase.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>private_key</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The SSL private key for your certificate, in PEM format.The absolute path of the private key file should be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>public_certificate</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The public certificate, in PEM format, that you received from your SSL certificate provider. The absolute path of the public certificate file should be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or  delete certificate. For <em>state=present</em>, if it does not exists, it gets added.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>ca_certificate<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Certificate Authority certificate, or any interim certificate, that you received from your SSL certificate provider. The absolute path of the certificate file should be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer in which the certificate belongs</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the certificate  to add to the load balancer.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>passphrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A passphrase for encrypted private keys. This is needed only if you created your certificate with a passphrase.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>private_key<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The SSL private key for your certificate, in PEM format.The absolute path of the private key file should be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>public_certificate<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The public certificate, in PEM format, that you received from your SSL certificate provider. The absolute path of the public certificate file should be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create or  delete certificate. For <em>state=present</em>, if it does not exists, it gets added.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -234,105 +291,97 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>certificate</td>
-    <td>
-        <div>Attributes of the created certificate. For delete, deleted certificate description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'certificate_name': 'ansible_cert', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIDPjCCAiYCCQC5OEUUNtrC\n-----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIDlTCCAn2gAw\n-----END CERTIFICATE-----'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>certificate_name</td>
-        <td>
-            <div>Name of the certificate</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_certificate</td>
-        </tr>
-
-        <tr>
-        <td>public_certificate</td>
-        <td>
-            <div>The public certificate, in PEM format, that you received from your SSL certificate provider.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>-----BEGIN CERTIFICATE----- MIIDlTCCAn -----END CERTIFICATE-----</td>
-        </tr>
-
-        <tr>
-        <td>ca_certificate</td>
-        <td>
-            <div>The Certificate Authority certificate, or any interim certificate, that you received from your SSL certificate provider.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>-----BEGIN CERTIFICATE----- MIIDlTCCA -----END CERTIFICATE-----</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>certificate</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created certificate. For delete, deleted certificate description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'certificate_name': 'ansible_cert', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIDPjCCAiYCCQC5OEUUNtrC\n-----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIDlTCCAn2gAw\n-----END CERTIFICATE-----'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>certificate_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the certificate</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_certificate</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>public_certificate</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The public certificate, in PEM format, that you received from your SSL certificate provider.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">-----BEGIN CERTIFICATE----- MIIDlTCCAn -----END CERTIFICATE-----</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ca_certificate</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Certificate Authority certificate, or any interim certificate, that you received from your SSL certificate provider.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">-----BEGIN CERTIFICATE----- MIIDlTCCA -----END CERTIFICATE-----</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_certificate.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_facts_module.rst
+++ b/docs/modules/oci_load_balancer_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_facts:
+:source: cloud/oracle/oci_load_balancer_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_facts_module:
 
 
 oci_load_balancer_facts - Fetches details of the OCI Load Balancer
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,170 @@ oci_load_balancer_facts - Fetches details of the OCI Load Balancer
 
 Synopsis
 --------
-
-
-* Fetches details of the OCI Load Balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of the OCI Load Balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment in which this Load Balancer exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer whose details needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment in which this Load Balancer exists</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer whose details needs to be fetched.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch Load Balancer
@@ -166,185 +194,209 @@ Examples
           load_balancer_id: 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>load_balancers</td>
-    <td>
-        <div>Attributes of the  Load Balancers.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'ACTIVE', 'display_name': 'ansible_lb955', 'shape_name': '100Mbps', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'ip_addresses': [{'is_public': True, 'ip_address': '129.213.72.32'}], 'time_created': '2018-01-06T18:22:17.198000+00:00', 'id': 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx', 'listeners': {'listener1': {'ssl_configuration': None, 'protocol': 'HTTP', 'name': 'listerner1', 'default_backend_set_name': 'backend1', 'connection_configuration': {'idle_timeout': 1200}, 'port': 80}}, 'certificates': {'certs1': {'certificate_name': 'certs1', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n- ----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n-----END CERTIFICATE -----\n-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}}, 'subnet_ids': ['ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx'], 'backend_sets': {'backend1': {'ssl_configuration': None, 'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}, 'name': 'backend1', 'policy': 'LEAST_CONNECTIONS', 'session_persistence_configuration': None}}, 'path_route_sets': {'ansible_path_route_set': {'path_routes': [{'path': '/example/user', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]}}, 'is_private': False}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Load Balancer</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name assigned to the Load Balancer during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_lb</td>
-        </tr>
-
-        <tr>
-        <td>shape_name</td>
-        <td>
-            <div>A template that determines the total pre-provisioned bandwidth (ingress plus egress).</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>100Mbps</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the Load Balancer</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Load Balancer was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Load Balancer</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>listeners</td>
-        <td>
-            <div>The listener configuration details.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'listerner1': {'ssl_configuration': None, 'protocol': 'HTTP', 'name': 'listerner1', 'default_backend_set_name': 'backend1', 'connection_configuration': {'idle_timeout': 1200}, 'port': 80}}</td>
-        </tr>
-
-        <tr>
-        <td>certificates</td>
-        <td>
-            <div>The configuration details for a listener certificate bundle.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'certs1': {'certificate_name': 'certs1', 'public_certificate': '-----BEGIN CERTIFICATE----- MIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n -----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n -----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}}</td>
-        </tr>
-
-        <tr>
-        <td>subnet_ids</td>
-        <td>
-            <div>An array of subnet OCIDs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>['ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx']</td>
-        </tr>
-
-        <tr>
-        <td>backend_sets</td>
-        <td>
-            <div>The configuration details for a load balancer backend set</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'backend1': {'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'name': 'backend1', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'ssl_configuration': None, 'timeout_in_millis': 6000, 'policy': 'LEAST_CONNECTIONS', 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080, 'session_persistence_configuration': None}}}</td>
-        </tr>
-
-        <tr>
-        <td>path_route_sets</td>
-        <td>
-            <div>The path route sets configuration details.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'ansible_path_route_set': {'path_routes': [{'path': '/example/user', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]}}</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>load_balancers</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the  Load Balancers.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ACTIVE', 'display_name': 'ansible_lb955', 'shape_name': '100Mbps', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'ip_addresses': [{'is_public': True, 'ip_address': '129.213.72.32'}], 'time_created': '2018-01-06T18:22:17.198000+00:00', 'id': 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx', 'listeners': {'listener1': {'ssl_configuration': None, 'protocol': 'HTTP', 'name': 'listerner1', 'default_backend_set_name': 'backend1', 'connection_configuration': {'idle_timeout': 1200}, 'port': 80}}, 'certificates': {'certs1': {'certificate_name': 'certs1', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n- ----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n-----END CERTIFICATE -----\n-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}}, 'subnet_ids': ['ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx'], 'backend_sets': {'backend1': {'ssl_configuration': None, 'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}, 'name': 'backend1', 'policy': 'LEAST_CONNECTIONS', 'session_persistence_configuration': None}}, 'path_route_sets': {'ansible_path_route_set': {'path_routes': [{'path': '/example/user', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]}}, 'is_private': False}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Load Balancer</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Load Balancer during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_lb</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>shape_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A template that determines the total pre-provisioned bandwidth (ingress plus egress).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">100Mbps</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the Load Balancer</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Load Balancer was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Load Balancer</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>listeners</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The listener configuration details.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'listerner1': {'ssl_configuration': None, 'protocol': 'HTTP', 'name': 'listerner1', 'default_backend_set_name': 'backend1', 'connection_configuration': {'idle_timeout': 1200}, 'port': 80}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>certificates</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The configuration details for a listener certificate bundle.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'certs1': {'certificate_name': 'certs1', 'public_certificate': '-----BEGIN CERTIFICATE----- MIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n -----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n -----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_ids</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>An array of subnet OCIDs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>backend_sets</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The configuration details for a load balancer backend set</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'backend1': {'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'name': 'backend1', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'ssl_configuration': None, 'timeout_in_millis': 6000, 'policy': 'LEAST_CONNECTIONS', 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080, 'session_persistence_configuration': None}}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>path_route_sets</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The path route sets configuration details.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'ansible_path_route_set': {'path_routes': [{'path': '/example/user', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]}}</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_health_checker_facts_module.rst
+++ b/docs/modules/oci_load_balancer_health_checker_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_health_checker_facts:
+:source: cloud/oracle/oci_load_balancer_health_checker_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_health_checker_facts_module:
 
 
 oci_load_balancer_health_checker_facts - Fetch details of all health checker details of load balancer backend sets of a load balancer
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,160 @@ oci_load_balancer_health_checker_facts - Fetch details of all health checker det
 
 Synopsis
 --------
-
-
-* Fetch details of all health checker details of load balancer backend sets of a load balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetch details of all health checker details of load balancer backend sets of a load balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>backend_set_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the backend set under which the backend exists.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer to which the Backends belongs.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>backend_set_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the backend set under which the backend exists.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer to which the Backends belongs.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch details of all health checker details of load balancer backends of a load balancer
@@ -167,155 +185,167 @@ Examples
           load_balancer_id: 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>health_checkers</td>
-    <td>
-        <div>Attributes of the health checker</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}, {'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '.*', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8282}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>retries</td>
-        <td>
-            <div>The number of retries to attempt before a backend server is considered unhealthy</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>3</td>
-        </tr>
-
-        <tr>
-        <td>protocol</td>
-        <td>
-            <div>The protocol the health check must use</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>HTTP</td>
-        </tr>
-
-        <tr>
-        <td>response_body_regex</td>
-        <td>
-            <div>A regular expression for parsing the response body from the backend server.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>^(500|40[1348])$</td>
-        </tr>
-
-        <tr>
-        <td>return_code</td>
-        <td>
-            <div>The status code a healthy backend server should return</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>200</td>
-        </tr>
-
-        <tr>
-        <td>timeout_in_millis</td>
-        <td>
-            <div>The maximum time, in milliseconds, to wait for a reply to a health check</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>60000</td>
-        </tr>
-
-        <tr>
-        <td>interval_in_millis</td>
-        <td>
-            <div>The interval between health checks, in milliseconds.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>3000</td>
-        </tr>
-
-        <tr>
-        <td>url_path</td>
-        <td>
-            <div>The path against which to run the health check.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>/healthcheck</td>
-        </tr>
-
-        <tr>
-        <td>port</td>
-        <td>
-            <div>Port of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>8080</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>health_checkers</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the health checker</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}, {'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '.*', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8282}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>retries</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The number of retries to attempt before a backend server is considered unhealthy</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>protocol</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The protocol the health check must use</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">HTTP</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>response_body_regex</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A regular expression for parsing the response body from the backend server.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">^(500|40[1348])$</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>return_code</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The status code a healthy backend server should return</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">200</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>timeout_in_millis</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The maximum time, in milliseconds, to wait for a reply to a health check</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">60000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>interval_in_millis</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The interval between health checks, in milliseconds.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>url_path</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The path against which to run the health check.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">/healthcheck</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Port of the Load Balancer Backend</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">8080</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_health_checker_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_health_checker_module.rst
+++ b/docs/modules/oci_load_balancer_health_checker_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_health_checker:
+:source: cloud/oracle/oci_load_balancer_health_checker.py
+
+:orphan:
+
+.. _oci_load_balancer_health_checker_module:
 
 
 oci_load_balancer_health_checker - Update health checker details of a backend set in a load balancer in OCI Load Balancing Service
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,223 +17,275 @@ oci_load_balancer_health_checker - Update health checker details of a backend se
 
 Synopsis
 --------
-
-
-* Update health checker details of a backend set in a load balancer in OCI Load Balancing Service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Update health checker details of a backend set in a load balancer in OCI Load Balancing Service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>backend_set_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the backend set containing health checker details.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>interval_in_millis</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The interval between health checks, in milliseconds.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer in which the backend set containing the health checker details belongs</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>port</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The communication port for the backend server.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>protocol</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The protocol the health check must use, either HTTP or TCP.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>response_body_regex</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>regular expression for parsing the response body from the backend server.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>retries</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The number of retries to attempt before a backend server is considered unhealthy.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>return_code</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The status code a healthy backend server should return.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>timeout_in_millis</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The maximum time, in milliseconds, to wait for a reply to a health check. A health check is successful only if a reply returns within this timeout period.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>url_path</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The path against which to run the health check..</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>backend_set_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the backend set containing health checker details.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>interval_in_millis<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The interval between health checks, in milliseconds.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer in which the backend set containing the health checker details belongs</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>port<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The communication port for the backend server.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>protocol<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The protocol the health check must use, either HTTP or TCP.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>response_body_regex<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>regular expression for parsing the response body from the backend server.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>retries<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The number of retries to attempt before a backend server is considered unhealthy.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>return_code<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The status code a healthy backend server should return.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>timeout_in_millis<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The maximum time, in milliseconds, to wait for a reply to a health check. A health check is successful only if a reply returns within this timeout period.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>url_path<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The path against which to run the health check..</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -251,155 +304,167 @@ Examples
         url_path: "/healthcheckupdated"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>health_checker</td>
-    <td>
-        <div>Attributes of the health checker</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>retries</td>
-        <td>
-            <div>The number of retries to attempt before a backend server is considered unhealthy</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>3</td>
-        </tr>
-
-        <tr>
-        <td>protocol</td>
-        <td>
-            <div>The protocol the health check must use</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>HTTP</td>
-        </tr>
-
-        <tr>
-        <td>response_body_regex</td>
-        <td>
-            <div>A regular expression for parsing the response body from the backend server.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>^(500|40[1348])$</td>
-        </tr>
-
-        <tr>
-        <td>return_code</td>
-        <td>
-            <div>The status code a healthy backend server should return</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>200</td>
-        </tr>
-
-        <tr>
-        <td>timeout_in_millis</td>
-        <td>
-            <div>The maximum time, in milliseconds, to wait for a reply to a health check</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>60000</td>
-        </tr>
-
-        <tr>
-        <td>interval_in_millis</td>
-        <td>
-            <div>The interval between health checks, in milliseconds.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>3000</td>
-        </tr>
-
-        <tr>
-        <td>url_path</td>
-        <td>
-            <div>The path against which to run the health check.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>/healthcheck</td>
-        </tr>
-
-        <tr>
-        <td>port</td>
-        <td>
-            <div>Port of the Load Balancer Backend</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>8080</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>health_checker</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the health checker</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>retries</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The number of retries to attempt before a backend server is considered unhealthy</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>protocol</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The protocol the health check must use</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">HTTP</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>response_body_regex</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A regular expression for parsing the response body from the backend server.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">^(500|40[1348])$</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>return_code</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The status code a healthy backend server should return</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">200</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>timeout_in_millis</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The maximum time, in milliseconds, to wait for a reply to a health check</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">60000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>interval_in_millis</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The interval between health checks, in milliseconds.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>url_path</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The path against which to run the health check.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">/healthcheck</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Port of the Load Balancer Backend</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">8080</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_health_checker.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_health_facts_module.rst
+++ b/docs/modules/oci_load_balancer_health_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_health_facts:
+:source: cloud/oracle/oci_load_balancer_health_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_health_facts_module:
 
 
 oci_load_balancer_health_facts - Fetch details of a Load Balancer Health
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,238 +17,137 @@ oci_load_balancer_health_facts - Fetch details of a Load Balancer Health
 
 Synopsis
 --------
-
-
-* Fetch details of a Load Balancer Health.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetch details of a Load Balancer Health.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    #Fetch details of health of a load balancer
-    - name: List a specific Load Balancer Health
-      oci_load_balancer_health_facts:
-          load_balancer_id: 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx'
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>load_balancer_health</td>
-    <td>
-        <div>Attributes of the Load Balancer Health</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'status': 'CRITICAL', 'total_backend_set_count': 3, 'unknown_state_backend_set_names': [], 'critical_state_backend_set_names': ['test_backend_one', 'test_backend_two'], 'warning_state_backend_set_names': []}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>status</td>
-        <td>
-            <div>The overall health status of the load balancer. Allowed values - - OK - WARNING - CRITICAL - UNKWON</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>OK</td>
-        </tr>
-
-        <tr>
-        <td>total_backend_set_count</td>
-        <td>
-            <div>The total number of backend sets in this load balancer.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>integer</td>
-        <td align=center>2</td>
-        </tr>
-
-        <tr>
-        <td>unknown_state_backend_set_names</td>
-        <td>
-            <div>A list of backend sets that are currently in the UNKWON health state. The list identifies each backend set by the friendly name which was assigned when it was created .</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>10.1.2.4:80</td>
-        </tr>
-
-        <tr>
-        <td>critical_state_backend_set_names</td>
-        <td>
-            <div>A list of backend sets that are currently in the CRITICAL health state. The list identifies each backend set by the friendly name which was assigned when it was created .</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>10.1.2.3:80</td>
-        </tr>
-
-        <tr>
-        <td>warning_state_backend_set_names</td>
-        <td>
-            <div>A list of backend sets that are currently in the WARNING health state. The list identifies each backend set by the friendly name which was assigned when it was created .</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>10.1.55.2:80</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -257,19 +157,137 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Debayan Gupta(@debayan_gupta)
+.. code-block:: yaml+jinja
+
+    
+    #Fetch details of health of a load balancer
+    - name: List a specific Load Balancer Health
+      oci_load_balancer_health_facts:
+          load_balancer_id: 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx'
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>load_balancer_health</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Load Balancer Health</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'status': 'CRITICAL', 'total_backend_set_count': 3, 'unknown_state_backend_set_names': [], 'critical_state_backend_set_names': ['test_backend_one', 'test_backend_two'], 'warning_state_backend_set_names': []}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The overall health status of the load balancer. Allowed values - - OK - WARNING - CRITICAL - UNKWON</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">OK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>total_backend_set_count</b>
+                    <br/><div style="font-size: small; color: red">integer</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The total number of backend sets in this load balancer.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>unknown_state_backend_set_names</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of backend sets that are currently in the UNKWON health state. The list identifies each backend set by the friendly name which was assigned when it was created .</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.1.2.4:80</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>critical_state_backend_set_names</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of backend sets that are currently in the CRITICAL health state. The list identifies each backend set by the friendly name which was assigned when it was created .</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.1.2.3:80</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>warning_state_backend_set_names</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of backend sets that are currently in the WARNING health state. The list identifies each backend set by the friendly name which was assigned when it was created .</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.1.55.2:80</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_health_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_health_summary_facts_module.rst
+++ b/docs/modules/oci_load_balancer_health_summary_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_health_summary_facts:
+:source: cloud/oracle/oci_load_balancer_health_summary_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_health_summary_facts_module:
 
 
 oci_load_balancer_health_summary_facts - Fetches the summary health statuses for all load balancers in a given compartment.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,208 +17,137 @@ oci_load_balancer_health_summary_facts - Fetches the summary health statuses for
 
 Synopsis
 --------
-
-
-* Fetches the summary health statuses for all load balancers in a given compartment.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches the summary health statuses for all load balancers in a given compartment.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Compartment containing all Load Balancer</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    #Fetch details of health summary of all load balancer
-    - name: List all Load Balancer Health Summary in a Compartment
-      oci_load_balancer_health_summary_facts:
-          compartment_id: 'ocid1.compartment..xcds'
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>load_balancer_health_summary</td>
-    <td>
-        <div>Attributes of all Load Balancer Health Summary in a List</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'status': 'WARNING', 'load_balancer_id': 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>status</td>
-        <td>
-            <div>The overall health status of the load balancer. Allowed values - - OK - WARNING - CRITICAL - UNKWON</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>OK</td>
-        </tr>
-
-        <tr>
-        <td>load_balancer_id</td>
-        <td>
-            <div>The OCID of the load balancer the health status is associated with.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.loadbalancer.aaaa</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Compartment containing all Load Balancer</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -227,19 +157,95 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Debayan Gupta(@debayan_gupta)
+.. code-block:: yaml+jinja
+
+    
+    #Fetch details of health summary of all load balancer
+    - name: List all Load Balancer Health Summary in a Compartment
+      oci_load_balancer_health_summary_facts:
+          compartment_id: 'ocid1.compartment..xcds'
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>load_balancer_health_summary</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of all Load Balancer Health Summary in a List</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'status': 'WARNING', 'load_balancer_id': 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The overall health status of the load balancer. Allowed values - - OK - WARNING - CRITICAL - UNKWON</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">OK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the load balancer the health status is associated with.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.loadbalancer.aaaa</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_health_summary_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_hostname_facts_module.rst
+++ b/docs/modules/oci_load_balancer_hostname_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_hostname_facts:
+:source: cloud/oracle/oci_load_balancer_hostname_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_hostname_facts_module:
 
 
 oci_load_balancer_hostname_facts - Fetch details of all hostnames of a load balancer
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,160 @@ oci_load_balancer_hostname_facts - Fetch details of all hostnames of a load bala
 
 Synopsis
 --------
-
-
-* Fetch details of all hostnames of a load balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetch details of all hostnames of a load balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer to which the hostnames belongs.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the hostname whose details needs to be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer to which the hostnames belongs.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the hostname whose details needs to be fetched.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch details of all hostname of a load balancer
@@ -167,95 +185,83 @@ Examples
           name: 'ansible_hostname'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>hostnames</td>
-    <td>
-        <div>Attributes of the Hostnames fecthed.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'hostname': {'hostname': 'app.example.com', 'name': 'ansible_hostname'}}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>hostname</td>
-        <td>
-            <div>A virtual hostname</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>app.example.com</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name assigned to the Load Balancer Hostname during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_hostname</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>hostnames</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Hostnames fecthed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'hostname': {'hostname': 'app.example.com', 'name': 'ansible_hostname'}}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostname</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A virtual hostname</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">app.example.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Load Balancer Hostname during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_hostname</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_hostname_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_hostname_module.rst
+++ b/docs/modules/oci_load_balancer_hostname_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_hostname:
+:source: cloud/oracle/oci_load_balancer_hostname.py
+
+:orphan:
+
+.. _oci_load_balancer_hostname_module:
 
 
 oci_load_balancer_hostname - Create, update and delete a hostname resource in the specified load balancer.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,195 +17,221 @@ oci_load_balancer_hostname - Create, update and delete a hostname resource in th
 
 Synopsis
 --------
-
-
-* Create an OCI Load Balancer Hostname
-* Update OCI Load Balancers Hostname, if present.
-* Delete OCI Load Balancers Hostname, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Create an OCI Load Balancer Hostname
+- Update OCI Load Balancers Hostname, if present.
+- Delete OCI Load Balancers Hostname, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>hostname</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A virtual hostname. Mandatory for create and update.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer. Mandatory for create,delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A friendly name for the hostname resource. It must be unique and it cannot be changed. Avoid entering confidential information.Mandatory for create,update and delete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete Load Balancer Hostname. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>hostname<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A virtual hostname. Mandatory for create and update.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer. Mandatory for create,delete and update.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A friendly name for the hostname resource. It must be unique and it cannot be changed. Avoid entering confidential information.Mandatory for create,update and delete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete Load Balancer Hostname. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -231,95 +258,83 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>hostname</td>
-    <td>
-        <div>Attributes of the created/updated Load Balancer Hostname. For delete, deleted Load Balancer Hostname description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'hostname': 'app.example.com', 'name': 'ansible_hostname'}, {'hostname': 'app.production.com', 'name': 'ansible_hostname_002'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>hostname</td>
-        <td>
-            <div>A virtual hostname</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>app.example.com</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name assigned to the Load Balancer Hostname during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_hostname</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>hostname</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated Load Balancer Hostname. For delete, deleted Load Balancer Hostname description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'hostname': 'app.example.com', 'name': 'ansible_hostname'}, {'hostname': 'app.production.com', 'name': 'ansible_hostname_002'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostname</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A virtual hostname</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">app.example.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Load Balancer Hostname during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_hostname</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_hostname.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_listener_facts_module.rst
+++ b/docs/modules/oci_load_balancer_listener_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_listener_facts:
+:source: cloud/oracle/oci_load_balancer_listener_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_listener_facts_module:
 
 
 oci_load_balancer_listener_facts - Fetch details of all listeners of a load balancer
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,160 @@ oci_load_balancer_listener_facts - Fetch details of all listeners of a load bala
 
 Synopsis
 --------
-
-
-* Fetch details of all listeners of a load balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetch details of all listeners of a load balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer to which the listeners belongs.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the listener whose details needs to be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer to which the listeners belongs.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the listener whose details needs to be fetched.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch details of all listener of a load balancer
@@ -167,155 +185,167 @@ Examples
           name: 'ansible_listener'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>listeners</td>
-    <td>
-        <div>Attributes of Listener.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'path_route_set_name': 'path_route_set_001', 'protocol': 'HTTP', 'name': 'ansible_listener', 'connection_configuration': {'idle_timeout': 1200}, 'ssl_configuration': {'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}, 'hostname_names': ['hostname_001'], 'default_backend_set_name': 'ansible_backend', 'port': 87}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>path_route_set_name</td>
-        <td>
-            <div>The name of the set of path-based routing rules, PathRouteSet, applied to this listener's traffic.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>path_route_set_001</td>
-        </tr>
-
-        <tr>
-        <td>protocol</td>
-        <td>
-            <div>The protocol on which the listener accepts connection requests.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>HTTP</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name of the Listener</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_listener</td>
-        </tr>
-
-        <tr>
-        <td>connection_configuration</td>
-        <td>
-            <div>Configuration details for the connection between the client and backend servers.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'idle_timeout': 1200}</td>
-        </tr>
-
-        <tr>
-        <td>ssl_configuration</td>
-        <td>
-            <div>The load balancer SSL handling configuration details</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}</td>
-        </tr>
-
-        <tr>
-        <td>hostname_names</td>
-        <td>
-            <div>An array of hostname resource names.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>['hostname_001']</td>
-        </tr>
-
-        <tr>
-        <td>default_backend_set_name</td>
-        <td>
-            <div>The name of the associated backend set</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_backend_set</td>
-        </tr>
-
-        <tr>
-        <td>port</td>
-        <td>
-            <div>The communication port for the listener.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>80</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>listeners</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of Listener.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'path_route_set_name': 'path_route_set_001', 'protocol': 'HTTP', 'name': 'ansible_listener', 'connection_configuration': {'idle_timeout': 1200}, 'ssl_configuration': {'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}, 'hostname_names': ['hostname_001'], 'default_backend_set_name': 'ansible_backend', 'port': 87}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>path_route_set_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the set of path-based routing rules, PathRouteSet, applied to this listener's traffic.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">path_route_set_001</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>protocol</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The protocol on which the listener accepts connection requests.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">HTTP</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the Listener</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_listener</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>connection_configuration</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Configuration details for the connection between the client and backend servers.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'idle_timeout': 1200}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ssl_configuration</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The load balancer SSL handling configuration details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostname_names</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>An array of hostname resource names.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['hostname_001']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>default_backend_set_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the associated backend set</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_backend_set</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The communication port for the listener.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">80</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_listener_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_listener_module.rst
+++ b/docs/modules/oci_load_balancer_listener_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_listener:
+:source: cloud/oracle/oci_load_balancer_listener.py
+
+:orphan:
+
+.. _oci_load_balancer_listener_module:
 
 
 oci_load_balancer_listener - Add, modify and remove a listener from a backend set of a load balancer in OCI Load Balancing Service
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,313 +17,341 @@ oci_load_balancer_listener - Add, modify and remove a listener from a backend se
 
 Synopsis
 --------
-
-
-* Add a listener to a backend set in a OCI Load Balancer
-* Update a listener in a Load Balancer, if present, with any changed attribute
-* Delete a listener from OCI Load Balancer Backends, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Add a listener to a backend set in a OCI Load Balancer
+- Update a listener in a Load Balancer, if present, with any changed attribute
+- Delete a listener from OCI Load Balancer Backends, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">connection_configuration<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Configuration details for the connection between the client and backend servers.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object connection_configuration</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>connection_configuration</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Configuration details for the connection between the client and backend servers.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>idle_timeout</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The maximum idle time, in seconds, allowed between two successive receive or two successive send operations between the client and backend servers. A send operation does not reset the timer for receive operations. A receive operation does not reset the timer for send operations.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>default_backend_set_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the associated backend set. Mandatory for create and update.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>hostname_names</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>An array of hostname resource names.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer in which the listener belongs.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the listener. It must be unique and it cannot be changed. Mandatory field for all use cases.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>path_route_set_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the set of path-based routing rules, PathRouteSet, applied to this listener's traffic.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>port</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The communication port for the listener. Mandatory for create and update.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>protocol</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The protocol on which the listener accepts connection requests. Mandatory for create and update.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>purge_hostname_names</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Purge any Hostname names in the  Listener named <em>name</em> that is not specified in <em>hostname_names</em>. This is only applicable in case of updating Listener.If <em>purge_hostname_names=no</em>, provided <em>hostname_names</em> would be appended to existing <em>hostname_names</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>ssl_configuration</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The load balancer SSL handling configuration details</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>certificate_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A friendly name for the certificate bundle. It must be unique and it cannot be changed. Valid certificate bundle names include only alphanumeric characters,dashes, and underscores.Certificate bundle names cannot contain spaces.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>verify_depth</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The maximum depth for peer certificate chain verification.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>verify_peer_certificate</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Whether the load balancer listener should verify peer certificates.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete Load Balancer Backend. For <em>state=present</em>, if it does not exists, it gets added. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>idle_timeout<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The maximum idle time, in seconds, allowed between two successive receive or two successive send operations between the client and backend servers. A send operation does not reset the timer for receive operations. A receive operation does not reset the timer for send operations.</div>
-        </td>
-        </tr>
 
-        </table>
+Notes
+-----
 
-    </td>
-    </tr>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>default_backend_set_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the associated backend set. Mandatory for create and update.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>hostname_names<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>An array of hostname resource names.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer in which the listener belongs.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the listener. It must be unique and it cannot be changed. Mandatory field for all use cases.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>path_route_set_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the set of path-based routing rules, PathRouteSet, applied to this listener's traffic.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>port<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The communication port for the listener. Mandatory for create and update.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>protocol<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The protocol on which the listener accepts connection requests. Mandatory for create and update.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>purge_hostname_names<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>yes</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Purge any Hostname names in the  Listener named <em>name</em> that is not specified in <em>hostname_names</em>. This is only applicable in case of updating Listener.If <em>purge_hostname_names=no</em>, provided <em>hostname_names</em> would be appended to existing <em>hostname_names</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">ssl_configuration<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The load balancer SSL handling configuration details</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object ssl_configuration</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>certificate_name<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A friendly name for the certificate bundle. It must be unique and it cannot be changed. Valid certificate bundle names include only alphanumeric characters,dashes, and underscores.Certificate bundle names cannot contain spaces.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>verify_depth<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The maximum depth for peer certificate chain verification.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>verify_peer_certificate<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Whether the load balancer listener should verify peer certificates.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete Load Balancer Backend. For <em>state=present</em>, if it does not exists, it gets added. If exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -408,155 +437,167 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>listener</td>
-    <td>
-        <div>Attributes of the created/updated Listener. For delete, deleted Listener description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'path_route_set_name': 'path_route_set_001', 'protocol': 'HTTP', 'name': 'ansible_listener', 'connection_configuration': {'idle_timeout': 1200}, 'ssl_configuration': {'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}, 'hostname_names': ['hostname_001'], 'default_backend_set_name': 'ansible_backend', 'port': 87}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>path_route_set_name</td>
-        <td>
-            <div>The name of the set of path-based routing rules, PathRouteSet, applied to this listener's traffic.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>path_route_set_001</td>
-        </tr>
-
-        <tr>
-        <td>protocol</td>
-        <td>
-            <div>The protocol on which the listener accepts connection requests.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>HTTP</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name of the Listener</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_listener</td>
-        </tr>
-
-        <tr>
-        <td>connection_configuration</td>
-        <td>
-            <div>Configuration details for the connection between the client and backend servers.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'idle_timeout': 1200}</td>
-        </tr>
-
-        <tr>
-        <td>ssl_configuration</td>
-        <td>
-            <div>The load balancer SSL handling configuration details</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}</td>
-        </tr>
-
-        <tr>
-        <td>hostname_names</td>
-        <td>
-            <div>An array of hostname resource names.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>['hostname_001']</td>
-        </tr>
-
-        <tr>
-        <td>default_backend_set_name</td>
-        <td>
-            <div>The name of the associated backend set</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_backend_set</td>
-        </tr>
-
-        <tr>
-        <td>port</td>
-        <td>
-            <div>The communication port for the listener.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>80</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>listener</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated Listener. For delete, deleted Listener description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'path_route_set_name': 'path_route_set_001', 'protocol': 'HTTP', 'name': 'ansible_listener', 'connection_configuration': {'idle_timeout': 1200}, 'ssl_configuration': {'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}, 'hostname_names': ['hostname_001'], 'default_backend_set_name': 'ansible_backend', 'port': 87}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>path_route_set_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the set of path-based routing rules, PathRouteSet, applied to this listener's traffic.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">path_route_set_001</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>protocol</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The protocol on which the listener accepts connection requests.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">HTTP</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the Listener</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_listener</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>connection_configuration</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Configuration details for the connection between the client and backend servers.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'idle_timeout': 1200}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ssl_configuration</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The load balancer SSL handling configuration details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'certificate_name': 'certs1', 'verify_depth': 1, 'verify_peer_certificate': True}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostname_names</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>An array of hostname resource names.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['hostname_001']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>default_backend_set_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the associated backend set</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_backend_set</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The communication port for the listener.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">80</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_listener.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_module.rst
+++ b/docs/modules/oci_load_balancer_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer:
+:source: cloud/oracle/oci_load_balancer.py
+
+:orphan:
+
+.. _oci_load_balancer_module:
 
 
 oci_load_balancer - Create, update and delete load balancers in OCI Load Balancing Service
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,541 +17,533 @@ oci_load_balancer - Create, update and delete load balancers in OCI Load Balanci
 
 Synopsis
 --------
-
-
-* Creates OCI Load Balancers
-* Update OCI Load Balancers, if present, with a new display name
-* Delete OCI Load Balancers, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Creates OCI Load Balancers
+- Update OCI Load Balancers, if present, with a new display name
+- Delete OCI Load Balancers, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">backend_sets<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The configuration details for a load balancer's backend sets</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object backend_sets</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>backend_sets</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The configuration details for a load balancer's backend sets</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>policy</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The load balancer policy for the backend set.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ssl_configuration</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The load balancer's SSL handling configuration details. This should be specified as a dict/hash with the following keys [certificate_name describes a friendly name for the certificate bundle. It must be unique and it cannot be changed. Valid certificate bundle names include only alphanumeric characters, dashes, and underscores.Certificate bundle names cannot contain spaces. required - true], ['verify_depth'  describes the maximum depth for peer certificate chain verification. required - false], ['verify_peer_certificate'  describes whether the load balancer listener should verify peer certificates. required - false]</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>backends</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of configurations related to Backends that are part of a backend set. Each Backend's configuration should be a dict/hash that consist of the following keys ['backup' option specifies whether the load balancer should treat this server as a backup unit. If true, the load balancer forwards no ingress traffic to this backend server unless all other backend servers not marked as &quot;backup&quot; fail the health check policy. required - false],['drain' option specifies whether the load balancer should drain this server. Servers marked &quot;drain&quot; receive no new incoming traffic. required - false], [ip_address describes the IP address of the backend server. required - true], ['offline' ensures whether the load balancer should treat this server as offline. Offline servers receive no incoming traffic. required - false], ['port'  describes the communication port for the backend server. required - true], [ 'weight' describes the load balancing policy weight assigned to the server. Backend servers with a higher weight receive a larger proportion of incoming traffic. For example, a server weighted '3' receives 3 times the number of new connections as a server weighted '1'. required - false]</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>health_checker</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Describes the health check policy for a backend set. This should be a dict/hash that consists of the following keys ['interval_in_millis' describes the interval between health checks, in milliseconds. required - false], [ 'port' describes the backend server port against which to run the health check. If the port is not specified, the load balancer uses the port information from the backends mentioned above. required - false], ['protocol' describes the protocol the health check must use, either HTTP or TCP. required - true], [ 'response_body_regex' describes a regular expression for parsing the response body from the backend server. required - false], ['retries' describes the number of retries to attempt before a backend server is considered unhealthy. required - false], ['return_code' describes the status code a healthy backend server should return. required - false], ['timeout_in_millis' describes the maximum time, in milliseconds, to wait for a reply to a health check. A health check is successful only if a reply returns within this timeout period. required - false], ['url_path' describes the path against which to run the health check. required - true]</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>session_persistence_configuration</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The configuration details for implementing session persistence. Session persistence enables the Load Balancing Service to direct any number of requests that originate from a single logical client to a single backend web server. This should be specified as a dict/hash with the following keys ['cookie_name' describes the name of the cookie used to detect a session initiated by the backend server. Use '*' to specify that any cookie set by the backend causes the session to persist. required - true], ['disable_fallback' describes Whether the load balancer is prevented from directing traffic from a persistent session client to a different backend server if the original server is unavailable. Defaults to false. required - false]</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>certificates</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The configuration details for a listener certificate bundle.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>certificate_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A friendly name for the certificate bundle. It must be unique and it cannot be changed. Valid certificate bundle names include only alphanumeric characters, dashes, and underscores. Certificate bundle names cannot contain spaces.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>private_key</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The SSL private key for your certificate, in PEM format.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ca_certificate</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Certificate Authority certificate, or any interim certificate, that you received from your SSL certificate provider.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>passphrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A passphrase for encrypted private keys. This is needed only if you created your certificate with a passphrase.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>public_certificate</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The public certificate, in PEM format, that you received from your SSL certificate provider.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which this Load Balancer would be created. Mandatory for create operation.Optional for delete and update. Mutually exclusive with <code>oci_load_balancer_id</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the Load Balancer. A user friendly name. Does not have to be unique, and could be changed. Mandatory for create and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>hostnames</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The details of a hostname resource associated with a load balancer.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>hostname</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A virtual hostname.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The name of the hostname resource.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>is_private</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Defines whether the load balancer has a VCN-local (private) IP address.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>listeners</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The listener configuration details.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ssl_configuration</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The load balancer SSL handling configuration details. Consists of following options, ['certificate_name' describes a friendly name for the certificate bundle. It must be unique and it cannot be changed. Valid certificate bundle names include only alphanumeric characters, dashes, and underscores.Certificate bundle names cannot contain spaces. required - true],['verify_depth'  describes the maximum depth for peer certificate chain verification. required - false], ['verify_peer_certificate' describes whether the load balancer listener should verify peer certificates. required - false]</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>connection_configuration</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Configuration details for the connection between the client and backend servers. Consists of following options, ['idle_timeout' describes The maximum idle time, in seconds, allowed between two successive receive or two successive send operations between the client and backend servers. A send operation does not reset the timer for receive operations. A receive operation does not reset the timer for send operations.]</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>protocol</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The protocol on which the listener accepts connection requests.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>port</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The communication port for the listener.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>default_backend_set_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The name of the associated backend set.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>load_balancer_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer. Mandatory for delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>path_route_sets</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The configuration details for a load balancer's path route sets</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>path_routes</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of configurations related to Path Routes that are part of a path route set. Each Path Route's configuration should be a dict/hash that consist of the following keys ['backend_set_name' option specifies The name of the target backend set for requests where the incoming URI matches the specified path.required - true],['path' option specifies the path string to match against the incoming URI path. required - true], ['path_match_type' describes the type of matching to apply to incoming URIs.The value of this attribute is another dict/hash with 'match_type' is key and value is one of EXACT_MATCH, FORCE_LONGEST_PREFIX_MATCH, PREFIX_MATCH, SUFFIX_MATCH. required - true]</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>shape_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A template that determines the total pre-provisioned bandwidth (ingress plus egress).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete Load Balancer. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>subnet_ids</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>An array of subnet OCIDs.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>policy<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The load balancer policy for the backend set.</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>ssl_configuration<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The load balancer's SSL handling configuration details. This should be specified as a dict/hash with the following keys [certificate_name describes a friendly name for the certificate bundle. It must be unique and it cannot be changed. Valid certificate bundle names include only alphanumeric characters, dashes, and underscores.Certificate bundle names cannot contain spaces. required - true], ['verify_depth'  describes the maximum depth for peer certificate chain verification. required - false], ['verify_peer_certificate'  describes whether the load balancer listener should verify peer certificates. required - false]</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        <tr>
-        <td>backends<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A list of configurations related to Backends that are part of a backend set. Each Backend's configuration should be a dict/hash that consist of the following keys ['backup' option specifies whether the load balancer should treat this server as a backup unit. If true, the load balancer forwards no ingress traffic to this backend server unless all other backend servers not marked as &quot;backup&quot; fail the health check policy. required - false],['drain' option specifies whether the load balancer should drain this server. Servers marked &quot;drain&quot; receive no new incoming traffic. required - false], [ip_address describes the IP address of the backend server. required - true], ['offline' ensures whether the load balancer should treat this server as offline. Offline servers receive no incoming traffic. required - false], ['port'  describes the communication port for the backend server. required - true], [ 'weight' describes the load balancing policy weight assigned to the server. Backend servers with a higher weight receive a larger proportion of incoming traffic. For example, a server weighted '3' receives 3 times the number of new connections as a server weighted '1'. required - false]</div>
-        </td>
-        </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-        <tr>
-        <td>health_checker<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Describes the health check policy for a backend set. This should be a dict/hash that consists of the following keys ['interval_in_millis' describes the interval between health checks, in milliseconds. required - false], [ 'port' describes the backend server port against which to run the health check. If the port is not specified, the load balancer uses the port information from the backends mentioned above. required - false], ['protocol' describes the protocol the health check must use, either HTTP or TCP. required - true], [ 'response_body_regex' describes a regular expression for parsing the response body from the backend server. required - false], ['retries' describes the number of retries to attempt before a backend server is considered unhealthy. required - false], ['return_code' describes the status code a healthy backend server should return. required - false], ['timeout_in_millis' describes the maximum time, in milliseconds, to wait for a reply to a health check. A health check is successful only if a reply returns within this timeout period. required - false], ['url_path' describes the path against which to run the health check. required - true]</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>session_persistence_configuration<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The configuration details for implementing session persistence. Session persistence enables the Load Balancing Service to direct any number of requests that originate from a single logical client to a single backend web server. This should be specified as a dict/hash with the following keys ['cookie_name' describes the name of the cookie used to detect a session initiated by the backend server. Use '*' to specify that any cookie set by the backend causes the session to persist. required - true], ['disable_fallback' describes Whether the load balancer is prevented from directing traffic from a persistent session client to a different backend server if the original server is unavailable. Defaults to false. required - false]</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">certificates<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The configuration details for a listener certificate bundle.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object certificates</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>certificate_name<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A friendly name for the certificate bundle. It must be unique and it cannot be changed. Valid certificate bundle names include only alphanumeric characters, dashes, and underscores. Certificate bundle names cannot contain spaces.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>private_key<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The SSL private key for your certificate, in PEM format.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>ca_certificate<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The Certificate Authority certificate, or any interim certificate, that you received from your SSL certificate provider.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>passphrase<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A passphrase for encrypted private keys. This is needed only if you created your certificate with a passphrase.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>public_certificate<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The public certificate, in PEM format, that you received from your SSL certificate provider.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment under which this Load Balancer would be created. Mandatory for create operation.Optional for delete and update. Mutually exclusive with <code>oci_load_balancer_id</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the Load Balancer. A user friendly name. Does not have to be unique, and could be changed. Mandatory for create and update.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">hostnames<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The details of a hostname resource associated with a load balancer.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object hostnames</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>hostname<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A virtual hostname.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>name<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The name of the hostname resource.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>is_private<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Defines whether the load balancer has a VCN-local (private) IP address.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">listeners<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The listener configuration details.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object listeners</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>ssl_configuration<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The load balancer SSL handling configuration details. Consists of following options, ['certificate_name' describes a friendly name for the certificate bundle. It must be unique and it cannot be changed. Valid certificate bundle names include only alphanumeric characters, dashes, and underscores.Certificate bundle names cannot contain spaces. required - true],['verify_depth'  describes the maximum depth for peer certificate chain verification. required - false], ['verify_peer_certificate' describes whether the load balancer listener should verify peer certificates. required - false]</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>connection_configuration<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Configuration details for the connection between the client and backend servers. Consists of following options, ['idle_timeout' describes The maximum idle time, in seconds, allowed between two successive receive or two successive send operations between the client and backend servers. A send operation does not reset the timer for receive operations. A receive operation does not reset the timer for send operations.]</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>protocol<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The protocol on which the listener accepts connection requests.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>port<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The communication port for the listener.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>default_backend_set_name<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The name of the associated backend set.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer. Mandatory for delete and update.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">path_route_sets<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The configuration details for a load balancer's path route sets</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object path_route_sets</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>path_routes<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A list of configurations related to Path Routes that are part of a path route set. Each Path Route's configuration should be a dict/hash that consist of the following keys ['backend_set_name' option specifies The name of the target backend set for requests where the incoming URI matches the specified path.required - true],['path' option specifies the path string to match against the incoming URI path. required - true], ['path_match_type' describes the type of matching to apply to incoming URIs.The value of this attribute is another dict/hash with 'match_type' is key and value is one of EXACT_MATCH, FORCE_LONGEST_PREFIX_MATCH, PREFIX_MATCH, SUFFIX_MATCH. required - true]</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>shape_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A template that determines the total pre-provisioned bandwidth (ingress plus egress).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete Load Balancer. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>subnet_ids<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>An array of subnet OCIDs.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -612,204 +605,232 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>load_balancer</td>
-    <td>
-        <div>Attributes of the created/updated Load Balancer. For delete, deleted Load Balancer description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'ACTIVE', 'display_name': 'ansible_lb955', 'shape_name': '100Mbps', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'ip_addresses': [{'is_public': True, 'ip_address': '129.213.72.32'}], 'time_created': '2018-01-06T18:22:17.198000+00:00', 'id': 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx', 'listeners': {'listerner1': {'ssl_configuration': None, 'protocol': 'HTTP', 'name': 'listerner1', 'default_backend_set_name': 'backend1', 'connection_configuration': {'idle_timeout': 1200}, 'port': 80}}, 'hostnames': {'ansible_hostname': {'hostname': 'app.example.com', 'name': 'ansible_hostname'}}, 'certificates': {'certs1': {'certificate_name': 'certs1', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n- ----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n-----END CERTIFICATE -----\n-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}}, 'subnet_ids': ['ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx'], 'backend_sets': {'backend1': {'ssl_configuration': None, 'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}, 'name': 'backend1', 'policy': 'LEAST_CONNECTIONS', 'session_persistence_configuration': None}}, 'path_route_sets': {'ansible_path_route_set': {'path_routes': [{'path': '/example/user', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]}}, 'is_private': False}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Load Balancer</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name assigned to the Load Balancer during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_lb</td>
-        </tr>
-
-        <tr>
-        <td>shape_name</td>
-        <td>
-            <div>A template that determines the total pre-provisioned bandwidth (ingress plus egress).</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>100Mbps</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the Load Balancer</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Load Balancer was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Load Balancer</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>sample</td>
-        <td>
-        </td>
-        <td align=center></td>
-        <td align=center></td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>listeners</td>
-        <td>
-            <div>The listener configuration details.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'listerner1': {'ssl_configuration': None, 'protocol': 'HTTP', 'name': 'listerner1', 'default_backend_set_name': 'backend1', 'connection_configuration': {'idle_timeout': 1200}, 'port': 80}}</td>
-        </tr>
-
-        <tr>
-        <td>hostnames</td>
-        <td>
-            <div>The details of a hostname resource associated with a load balancer.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'ansible_hostname': {'hostname': 'app.example.com', 'name': 'ansible_hostname'}}</td>
-        </tr>
-
-        <tr>
-        <td>certificates</td>
-        <td>
-            <div>The configuration details for a listener certificate bundle.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'certs1': {'certificate_name': 'certs1', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n -----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n -----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}}</td>
-        </tr>
-
-        <tr>
-        <td>subnet_ids</td>
-        <td>
-            <div>An array of subnet OCIDs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>['ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx']</td>
-        </tr>
-
-        <tr>
-        <td>backend_sets</td>
-        <td>
-            <div>The configuration details for a load balancer backend set</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'backend1': {'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'name': 'backend1', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'ssl_configuration': None, 'timeout_in_millis': 6000, 'policy': 'LEAST_CONNECTIONS', 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080, 'session_persistence_configuration': None}}}</td>
-        </tr>
-
-        <tr>
-        <td>path_route_sets</td>
-        <td>
-            <div>The path route sets configuration details.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center></td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>load_balancer</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated Load Balancer. For delete, deleted Load Balancer description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'ACTIVE', 'display_name': 'ansible_lb955', 'shape_name': '100Mbps', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'ip_addresses': [{'is_public': True, 'ip_address': '129.213.72.32'}], 'time_created': '2018-01-06T18:22:17.198000+00:00', 'id': 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx', 'listeners': {'listerner1': {'ssl_configuration': None, 'protocol': 'HTTP', 'name': 'listerner1', 'default_backend_set_name': 'backend1', 'connection_configuration': {'idle_timeout': 1200}, 'port': 80}}, 'hostnames': {'ansible_hostname': {'hostname': 'app.example.com', 'name': 'ansible_hostname'}}, 'certificates': {'certs1': {'certificate_name': 'certs1', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n- ----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n-----END CERTIFICATE -----\n-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}}, 'subnet_ids': ['ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx'], 'backend_sets': {'backend1': {'ssl_configuration': None, 'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'timeout_in_millis': 6000, 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080}, 'name': 'backend1', 'policy': 'LEAST_CONNECTIONS', 'session_persistence_configuration': None}}, 'path_route_sets': {'ansible_path_route_set': {'path_routes': [{'path': '/example/user', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]}}, 'is_private': False}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Load Balancer</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Load Balancer during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_lb</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>shape_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A template that determines the total pre-provisioned bandwidth (ingress plus egress).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">100Mbps</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the Load Balancer</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Load Balancer was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Load Balancer</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>sample</b>
+                    <br/><div style="font-size: small; color: red"></div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                                    <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>listeners</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The listener configuration details.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'listerner1': {'ssl_configuration': None, 'protocol': 'HTTP', 'name': 'listerner1', 'default_backend_set_name': 'backend1', 'connection_configuration': {'idle_timeout': 1200}, 'port': 80}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostnames</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The details of a hostname resource associated with a load balancer.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'ansible_hostname': {'hostname': 'app.example.com', 'name': 'ansible_hostname'}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>certificates</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The configuration details for a listener certificate bundle.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'certs1': {'certificate_name': 'certs1', 'public_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n -----END CERTIFICATE-----', 'ca_certificate': '-----BEGIN CERTIFICATE-----\nMIIFKTCCBBGgAwIBAgISBIs5aiZ1fWapuAl2P9POFMXjMA0GCSqGSIb3DQEBCwUA\n -----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_ids</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>An array of subnet OCIDs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>backend_sets</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The configuration details for a load balancer backend set</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'backend1': {'backends': [{'drain': False, 'name': '10.159.34.21:8080', 'weight': 1, 'ip_address': '10.159.34.21', 'offline': False, 'backup': False, 'port': 8080}], 'health_checker': {'retries': 3, 'protocol': 'HTTP', 'name': 'backend1', 'response_body_regex': '^(500|40[1348])$', 'return_code': 200, 'ssl_configuration': None, 'timeout_in_millis': 6000, 'policy': 'LEAST_CONNECTIONS', 'interval_in_millis': 30000, 'url_path': '/healthcheck', 'port': 8080, 'session_persistence_configuration': None}}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>path_route_sets</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The path route sets configuration details.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_path_route_set_facts_module.rst
+++ b/docs/modules/oci_load_balancer_path_route_set_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_path_route_set_facts:
+:source: cloud/oracle/oci_load_balancer_path_route_set_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_path_route_set_facts_module:
 
 
 oci_load_balancer_path_route_set_facts - Fetches details of path route set(s) that are associated with a load balancer
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,144 +17,161 @@ oci_load_balancer_path_route_set_facts - Fetches details of path route set(s) th
 
 Synopsis
 --------
-
-
-* Fetches details of all path route sets, or a specific path route set, that are associated with a load balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of all path route sets, or a specific path route set, that are associated with a load balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer where the Path Route Set belongs</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>path_route_set_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the Path Route Set</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer where the Path Route Set belongs</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>path_route_set_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the Path Route Set</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch Load Balancer Path Route Set
@@ -169,95 +187,83 @@ Examples
            load_balancer_id: 'ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>path_route_sets</td>
-    <td>
-        <div>Attributes of the  Load Balancer Path Route Set.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'name': 'ansible_path_route_set', 'path_routes': [{'path': '/admin', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>path_routes</td>
-        <td>
-            <div>A list of all path route sets associated with the specified load balancer.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'path': '/admin', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name assigned to the Load Balancer Path Route Set during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_path_route_set</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>path_route_sets</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the  Load Balancer Path Route Set.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'name': 'ansible_path_route_set', 'path_routes': [{'path': '/admin', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>path_routes</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of all path route sets associated with the specified load balancer.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'path': '/admin', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Load Balancer Path Route Set during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_path_route_set</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_path_route_set_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_path_route_set_module.rst
+++ b/docs/modules/oci_load_balancer_path_route_set_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_path_route_set:
+:source: cloud/oracle/oci_load_balancer_path_route_set.py
+
+:orphan:
+
+.. _oci_load_balancer_path_route_set_module:
 
 
 oci_load_balancer_path_route_set - Create, update and delete a path route set of a load balancer.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,224 +17,269 @@ oci_load_balancer_path_route_set - Create, update and delete a path route set of
 
 Synopsis
 --------
-
-
-* Create an OCI Load Balancer Path Route Set
-* Update OCI Load Balancers Path Route Set, if present.
-* Delete OCI Load Balancers Path Route Set, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Create an OCI Load Balancer Path Route Set
+- Update OCI Load Balancers Path Route Set, if present.
+- Delete OCI Load Balancers Path Route Set, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer. Mandatory for create,delete and update.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name for this set of path route rules. It must be unique and it can not be changed.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">path_routes<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The set of path route rules. Mandatory for create and update.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object path_routes</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>load_balancer_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer. Mandatory for create,delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name for this set of path route rules. It must be unique and it can not be changed.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>path_routes</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The set of path route rules. Mandatory for create and update.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>path</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path string to match against the incoming URI path. - Path strings are case-insensitive. - Asterisk (*) wildcards are not supported. - Regular expressions are not supported.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>backend_set_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The name of the target backend set for requests where the incoming URI matches the specified path.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>path_match_type</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The type of matching to apply to incoming URIs. This should be a dict/hash that consists of the key [match_type describes how the load balancing service compares a PathRoute object's path string against the incoming URI. The choices for the value are EXACT_MATCH, FORCE_LONGEST_PREFIX_MATCH, PREFIX_MATCH, SUFFIX_MATCH. required - true]</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>purge_path_routes</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Purge any Path Route in the  Path Route Set named <em>name</em> that is not specified in <em>path_routes</em>. This is only applicable in case of updating path route set.If <em>purge_path_routes=no</em>, provided path_routes would be appended to existing path_routes.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete Load Balancer Path Route Set. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>path<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The path string to match against the incoming URI path. - Path strings are case-insensitive. - Asterisk (*) wildcards are not supported. - Regular expressions are not supported.</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>backend_set_name<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The name of the target backend set for requests where the incoming URI matches the specified path.</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        <tr>
-        <td>path_match_type<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The type of matching to apply to incoming URIs. This should be a dict/hash that consists of the key [match_type describes how the load balancing service compares a PathRoute object's path string against the incoming URI. The choices for the value are EXACT_MATCH, FORCE_LONGEST_PREFIX_MATCH, PREFIX_MATCH, SUFFIX_MATCH. required - true]</div>
-        </td>
-        </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>purge_path_routes<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>yes</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Purge any Path Route in the  Path Route Set named <em>name</em> that is not specified in <em>path_routes</em>. This is only applicable in case of updating path route set.If <em>purge_path_routes=no</em>, provided path_routes would be appended to existing path_routes.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete Load Balancer Path Route Set. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -282,95 +328,83 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>path_route_set</td>
-    <td>
-        <div>Attributes of the created/updated Load Balancer Path Route Set. For delete, deleted Load Balancer Path Route Set description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'name': 'ansible_path_route_set', 'path_routes': [{'path': '/admin', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>path_routes</td>
-        <td>
-            <div>The set of path route rules.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'path': '/admin', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name assigned to the Load Balancer Path Route Set during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_path_route_set</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>path_route_set</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated Load Balancer Path Route Set. For delete, deleted Load Balancer Path Route Set description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'name': 'ansible_path_route_set', 'path_routes': [{'path': '/admin', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>path_routes</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The set of path route rules.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'path': '/admin', 'backend_set_name': 'ansible_backend_set', 'path_match_type': {'match_type': 'EXACT_MATCH'}}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Load Balancer Path Route Set during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_path_route_set</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_path_route_set.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_policy_facts_module.rst
+++ b/docs/modules/oci_load_balancer_policy_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_policy_facts:
+:source: cloud/oracle/oci_load_balancer_policy_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_policy_facts_module:
 
 
 oci_load_balancer_policy_facts - Fetches details of all load balancer policies supported in the OCI Load Balancer Service.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,198 +17,147 @@ oci_load_balancer_policy_facts - Fetches details of all load balancer policies s
 
 Synopsis
 --------
-
-
-* Fetches details of all load balancer policies supported in the OCI Load Balancer Service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of all load balancer policies supported in the OCI Load Balancer Service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Compartment containing all Load Balancer</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    #Fetch details of policy of all load balancer
-    - name: List all Load Balancer Policy in a Compartment
-      oci_load_balancer_policy_facts:
-          compartment_id: 'ocid1.compartment..xcds'
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>load_balancer_policies</td>
-    <td>
-        <div>Attributes of all Load Balancer Policy</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'name': 'IP_HASH'}, {'name': 'LEAST_CONNECTIONS'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name of the load balancer policy.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IP_HASH</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Compartment containing all Load Balancer</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -217,19 +167,81 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Debayan Gupta(@debayan_gupta)
+.. code-block:: yaml+jinja
+
+    
+    #Fetch details of policy of all load balancer
+    - name: List all Load Balancer Policy in a Compartment
+      oci_load_balancer_policy_facts:
+          compartment_id: 'ocid1.compartment..xcds'
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>load_balancer_policies</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of all Load Balancer Policy</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'name': 'IP_HASH'}, {'name': 'LEAST_CONNECTIONS'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the load balancer policy.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IP_HASH</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_policy_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_protocol_facts_module.rst
+++ b/docs/modules/oci_load_balancer_protocol_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_protocol_facts:
+:source: cloud/oracle/oci_load_balancer_protocol_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_protocol_facts_module:
 
 
 oci_load_balancer_protocol_facts - Fetches details of all the traffic protocols supported in the OCI Load Balancer Service.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,198 +17,147 @@ oci_load_balancer_protocol_facts - Fetches details of all the traffic protocols 
 
 Synopsis
 --------
-
-
-* Fetches details of all the traffic protocols supported in the OCI Load Balancer Service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of all the traffic protocols supported in the OCI Load Balancer Service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Compartment containing all Load Balancer</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    #Fetch details of protocol of all load balancer
-    - name: List all Load Balancer Protocol in a Compartment
-      oci_load_balancer_protocol_facts:
-          compartment_id: 'ocid1.compartment..xcds'
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>load_balancer_protocols</td>
-    <td>
-        <div>Attributes of all Load Balancer Protocol</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'name': 'HTTP'}, {'name': 'HTTP2'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name of the load balancer protocol.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>HTTP</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Compartment containing all Load Balancer</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -217,19 +167,81 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Debayan Gupta(@debayan_gupta)
+.. code-block:: yaml+jinja
+
+    
+    #Fetch details of protocol of all load balancer
+    - name: List all Load Balancer Protocol in a Compartment
+      oci_load_balancer_protocol_facts:
+          compartment_id: 'ocid1.compartment..xcds'
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>load_balancer_protocols</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of all Load Balancer Protocol</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'name': 'HTTP'}, {'name': 'HTTP2'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the load balancer protocol.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">HTTP</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_protocol_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_shape_facts_module.rst
+++ b/docs/modules/oci_load_balancer_shape_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_shape_facts:
+:source: cloud/oracle/oci_load_balancer_shape_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_shape_facts_module:
 
 
 oci_load_balancer_shape_facts - Fetches details of all valid load balancer shapes supported in the OCI Load Balancer Service.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,198 +17,147 @@ oci_load_balancer_shape_facts - Fetches details of all valid load balancer shape
 
 Synopsis
 --------
-
-
-* Fetches details of all valid load balancer shapes supported in the OCI Load Balancer Service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of all valid load balancer shapes supported in the OCI Load Balancer Service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Compartment containing all Load Balancer</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    #Fetch details of shape of all load balancer
-    - name: List all Load Balancer shape in a Compartment
-      oci_load_balancer_shape_facts:
-          compartment_id: 'ocid1.compartment..xcds'
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>load_balancer_shapes</td>
-    <td>
-        <div>Attributes of all Load Balancer Shape</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'name': '100Mbps'}, {'name': '400Mbps'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name of the load balancer Shape.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>100Mbps</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Compartment containing all Load Balancer</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -217,19 +167,81 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Debayan Gupta(@debayan_gupta)
+.. code-block:: yaml+jinja
+
+    
+    #Fetch details of shape of all load balancer
+    - name: List all Load Balancer shape in a Compartment
+      oci_load_balancer_shape_facts:
+          compartment_id: 'ocid1.compartment..xcds'
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>load_balancer_shapes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of all Load Balancer Shape</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'name': '100Mbps'}, {'name': '400Mbps'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the load balancer Shape.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">100Mbps</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_shape_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_work_request_facts_module.rst
+++ b/docs/modules/oci_load_balancer_work_request_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_load_balancer_work_request_facts:
+:source: cloud/oracle/oci_load_balancer_work_request_facts.py
+
+:orphan:
+
+.. _oci_load_balancer_work_request_facts_module:
 
 
 oci_load_balancer_work_request_facts - Fetch details of all work_requests of a load balancer
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,160 @@ oci_load_balancer_work_request_facts - Fetch details of all work_requests of a l
 
 Synopsis
 --------
-
-
-* Fetch details of all work_requests of a load balancer.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetch details of all work_requests of a load balancer.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Load Balancer to which the Work Requests belongs. Mutually exclusive with work_request_id.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>work_request_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Work Request whose details needs to be fetched.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>load_balancer_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Load Balancer to which the Work Requests belongs. Mutually exclusive with work_request_id.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>work_request_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Work Request whose details needs to be fetched.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch details of all Work Request of a Load Balancer
@@ -166,155 +184,165 @@ Examples
           work_request_id: 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>work_requests</td>
-    <td>
-        <div>Attributes of the Work Requests fetched.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center></td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Load Balancer</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACCEPTED</td>
-        </tr>
-
-        <tr>
-        <td>time_finished</td>
-        <td>
-            <div>The date and time the work request was completed, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2018-06-26T21:112:29.600Z</td>
-        </tr>
-
-        <tr>
-        <td>time_accepted</td>
-        <td>
-            <div>The date and time the work request was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2018-06-26 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>error_details</td>
-        <td>
-            <div>Error details of the work request</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'errorCode': 'BAD_INPUT', 'message': "Default Listener on port '80' refer to VIP 'private-vip' twice"}]</td>
-        </tr>
-
-        <tr>
-        <td>load_balancer_id</td>
-        <td>
-            <div>The OCID of the load balancer the Work Request is associated with.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>message</td>
-        <td>
-            <div>A collection of data, related to the load balancer provisioning process, that helps with debugging in the event of failure. Possible data elements include - workflow name - event ID - work request ID - load balancer ID - workflow completion message</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>{'eventId': '43644f81-8724-1324', 'workRequestId': 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx', 'workflowName': 'AddHostnameWorkflow', 'loadBalancerId': 'ocid1.loadbalancer..aaaa', 'message': 'OK', 'type': 'SUCCESS'}</td>
-        </tr>
-
-        <tr>
-        <td>type</td>
-        <td>
-            <div>The type of action the work request represents.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>[{'lifecycle_state': 'SUCCEEDED', 'time_finished': '2018-06-22T09:02:54.687000+00:00', 'time_accepted': '2018-06-22T09:02:38.505000+00:00', 'error_details': [], 'load_balancer_id': 'ocid1.loadbalancer..aaaa', 'message': {'eventId': '43644f81-8724-44b0-a13', 'workRequestId': 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx', 'workflowName': 'AddHostnameWorkflow', 'loadBalancerId': 'ocid1.loadbalancer..aaaa', 'message': 'OK', 'type': 'SUCCESS'}, 'type': 'CreateHostname', 'id': 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'SUCCEEDED', 'time_finished': '2018-06-22T09:02:54.687000+00:00', 'time_accepted': '2018-06-22T09:02:38.505000+00:00', 'error_details': [], 'load_balancer_id': 'ocid1.loadbalancer..aaaa', 'message': {'eventId': '43644f81-8724-44b0-a14', 'workRequestId': 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx', 'workflowName': 'AddHostnameWorkflow', 'loadBalancerId': 'ocid1.loadbalancer..aaaa', 'message': 'OK', 'type': 'SUCCESS'}, 'type': 'CreateHostname', 'id': 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Work Request</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.loadbalancerworkrequest.oc1.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>work_requests</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Work Requests fetched.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Load Balancer</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACCEPTED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_finished</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the work request was completed, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-06-26T21:112:29.600Z</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_accepted</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the work request was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-06-26 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>error_details</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Error details of the work request</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'errorCode': 'BAD_INPUT', 'message': &quot;Default Listener on port '80' refer to VIP 'private-vip' twice&quot;}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>load_balancer_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the load balancer the Work Request is associated with.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>message</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A collection of data, related to the load balancer provisioning process, that helps with debugging in the event of failure. Possible data elements include - workflow name - event ID - work request ID - load balancer ID - workflow completion message</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'eventId': '43644f81-8724-1324', 'workRequestId': 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx', 'workflowName': 'AddHostnameWorkflow', 'loadBalancerId': 'ocid1.loadbalancer..aaaa', 'message': 'OK', 'type': 'SUCCESS'}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of action the work request represents.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'SUCCEEDED', 'time_finished': '2018-06-22T09:02:54.687000+00:00', 'time_accepted': '2018-06-22T09:02:38.505000+00:00', 'error_details': [], 'load_balancer_id': 'ocid1.loadbalancer..aaaa', 'message': {'eventId': '43644f81-8724-44b0-a13', 'workRequestId': 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx', 'workflowName': 'AddHostnameWorkflow', 'loadBalancerId': 'ocid1.loadbalancer..aaaa', 'message': 'OK', 'type': 'SUCCESS'}, 'type': 'CreateHostname', 'id': 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'SUCCEEDED', 'time_finished': '2018-06-22T09:02:54.687000+00:00', 'time_accepted': '2018-06-22T09:02:38.505000+00:00', 'error_details': [], 'load_balancer_id': 'ocid1.loadbalancer..aaaa', 'message': {'eventId': '43644f81-8724-44b0-a14', 'workRequestId': 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx', 'workflowName': 'AddHostnameWorkflow', 'loadBalancerId': 'ocid1.loadbalancer..aaaa', 'message': 'OK', 'type': 'SUCCESS'}, 'type': 'CreateHostname', 'id': 'ocid1.loadbalancerworkrequest.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Work Request</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.loadbalancerworkrequest.oc1.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_load_balancer_work_request_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_node_pool_facts_module.rst
+++ b/docs/modules/oci_node_pool_facts_module.rst
@@ -1,0 +1,435 @@
+:source: cloud/oracle/oci_node_pool_facts.py
+
+:orphan:
+
+.. _oci_node_pool_facts_module:
+
+
+oci_node_pool_facts - Retrieve facts of node pools in OCI Container Engine for Kubernetes Service
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves information of a specific node pool or of all the node pools in OCI Container Engine for Kubernetes Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cluster_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the cluster.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. <em>compartment_id</em> is required to list all the node pools in a compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>node_pool_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the node pool. <em>node_pool_id</em> is required to get the details of a node pool.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get all the node pools in a compartment
+      oci_node_pool_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Get all the node pools in a compartment and filter by cluster
+      oci_node_pool_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Get a specific node pool
+      oci_node_pool_facts:
+        id: ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>node_pools</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of node pool details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'node_shape': 'VM.Standard1.1', 'name': 'test_node_pool', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'initial_node_labels': [{'key': 'type', 'value': 'standard'}, {'key': 'stage', 'value': 'prod'}], 'node_image_id': 'ocid1.image.oc1..xxxxxEXAMPLExxxxx', 'id': 'ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx', 'cluster_id': 'ocid1.cluster.oc1..xxxxxEXAMPLExxxxx', 'quantity_per_subnet': 1, 'node_image_name': 'Oracle-Linux-7.4', 'ssh_public_key': '', 'subnet_ids': ['ocid1.subnet..xxxxxEXAMPLExxxxx'], 'kubernetes_version': 'v1.9.7', 'nodes': [{'lifecycle_state': 'UPDATING', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'name': 'oke-c3dsodfgezw-n3wiztggrrt-st2au5vefpq-0', 'subnet_id': 'ocid1.subnet.oc1..xxxxxEXAMPLExxxxx', 'public_ip': '129.213.129.26', 'node_pool_id': 'ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx', 'node_error': None, 'lifecycle_details': 'waiting for running compute instance', 'id': 'ocid1.instance.oc1..xxxxxEXAMPLExxxxx'}]}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>node_shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the node shape of the nodes in the node pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">VM.Standard1.1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the node pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">sample_node_pool</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment in which the node pool exists.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>initial_node_labels</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of key/value pairs to add to nodes after they join the Kubernetes cluster.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'key': 'type', 'value': 'standard'}, {'key': 'stage', 'value': 'prod'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the node pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cluster_id</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the cluster to which this node pool is attached.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.cluster.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>quantity_per_subnet</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The number of nodes in each subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>node_image_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the image running on the nodes in the node pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ssh_public_key</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The SSH public key on each node in the node pool.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_ids</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCIDs of the subnets in which to place nodes for this node pool.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>kubernetes_version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The version of Kubernetes running on the nodes in the node pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">v1.9.7</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>nodes</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when retrieving a specific node pool</td>
+                <td>
+                                            <div>The nodes in the node pool.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Details about the state of the cluster masters.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_node_pool_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_node_pool_module.rst
+++ b/docs/modules/oci_node_pool_module.rst
@@ -1,0 +1,730 @@
+:source: cloud/oracle/oci_node_pool.py
+
+:orphan:
+
+.. _oci_node_pool_module:
+
+
+oci_node_pool - Manage node pools in OCI Container Engine for Kubernetes Service
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module allows the user to create, delete and update node pools in OCI Container Engine for Kubernetes Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>cluster_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the cluster to which this node pool is attached. Required to create a node pool.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment in which the node pool exists. Required to create a node pool.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>initial_node_labels</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A list of key/value pairs to add to nodes after they join the Kubernetes cluster.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>key</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The key of the pair.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>value</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The value of the pair.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>kubernetes_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The version of Kubernetes to install on the nodes in the node pool. Required to create a node pool.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the node pool. Avoid entering confidential information. Required to create a node pool.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>node_image_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the image running on the nodes in the node pool. Required to create a node pool.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>node_pool_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the node pool. Required to update or delete a node pool.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>node_shape</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the node shape of the nodes in the node pool. Required to create a node pool.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>quantity_per_subnet</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The number of nodes to create in each subnet.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>ssh_public_key</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The SSH public key to add to each node in the node pool.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a node pool with <em>state=present</em>. Use <em>state=absent</em> to delete a node pool.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>subnet_ids</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCIDs of the subnets in which to place nodes for this node pool. Required to create a node pool.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create a node pool
+      oci_node_pool:
+        cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        name: test_node_pool
+        kubernetes_version: "v1.9.7"
+        node_image_name: "Oracle-Linux-7.4"
+        node_shape: "VM.Standard1.1"
+        quantity_per_subnet: 1
+        subnet_ids: ["ocid1.subnet.oc1..xxxxxEXAMPLExxxxx"]
+        initial_node_labels:
+          - key: "vm_type"
+            value: "standard"
+          - key: "stage"
+            value: "dev"
+
+    - name: Update node pool
+      oci_node_pool:
+        id: ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx
+        name: ansible_node_pool
+        kubernetes_version: "v1.10.3"
+        initial_node_labels:
+          - key: "vm_type"
+            value: "standard"
+          - key: "stage"
+            value: "prod"
+
+    - name: Delete node pool
+      oci_node_pool:
+        id: ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>node_pool</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful create, delete &amp; update operations on node pool</td>
+                <td>
+                                            <div>Information about the node pool</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'node_shape': 'VM.Standard1.1', 'name': 'test_node_pool', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'initial_node_labels': [{'key': 'vm_type', 'value': 'standard'}, {'key': 'stage', 'value': 'prod'}], 'node_image_id': 'ocid1.image.oc1..xxxxxEXAMPLExxxxx', 'id': 'ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx', 'cluster_id': 'ocid1.cluster.oc1..xxxxxEXAMPLExxxxx', 'quantity_per_subnet': 1, 'node_image_name': 'Oracle-Linux-7.4', 'ssh_public_key': '', 'subnet_ids': ['ocid1.subnet..xxxxxEXAMPLExxxxx'], 'kubernetes_version': 'v1.9.7', 'nodes': [{'lifecycle_state': 'UPDATING', 'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'name': 'oke-c3dsodfgezw-n3wiztggrrt-st2au5vefpq-0', 'subnet_id': 'ocid1.subnet.oc1..xxxxxEXAMPLExxxxx', 'public_ip': '129.213.129.26', 'node_pool_id': 'ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx', 'node_error': None, 'lifecycle_details': 'waiting for running compute instance', 'id': 'ocid1.instance.oc1..xxxxxEXAMPLExxxxx'}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>node_shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the node shape of the nodes in the node pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">VM.Standard1.1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the node pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">sample_node_pool</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment in which the node pool exists.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>initial_node_labels</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of key/value pairs to add to nodes after they join the Kubernetes cluster.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'key': 'vm_type', 'value': 'standard'}, {'key': 'stage', 'value': 'prod'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the node pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cluster_id</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the cluster to which this node pool is attached.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.cluster.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>quantity_per_subnet</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The number of nodes in each subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>node_image_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the image running on the nodes in the node pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.image.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ssh_public_key</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The SSH public key on each node in the node pool.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_ids</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCIDs of the subnets in which to place nodes for this node pool.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>kubernetes_version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The version of Kubernetes running on the nodes in the node pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">v1.9.7</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>nodes</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The nodes in the node pool.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_details</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Details about the state of the cluster masters.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                <td colspan="2">
+                    <b>work_request</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>When a new work request is created</td>
+                <td>
+                                            <div>Information of work request</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'status': 'SUCCEEDED', 'time_finished': '2018-08-02T10:24:13+00:00', 'time_started': '2018-08-02T10:24:09+00:00', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'operation_type': 'NODEPOOL_UPDATE', 'time_accepted': '2018-08-02T10:22:22+00:00', 'id': 'ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx', 'resources': [{'entity_uri': '/nodePools/ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx', 'identifier': 'ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx', 'action_type': 'UPDATED', 'entity_type': 'nodepool'}, {'entity_uri': '/clusters/ocid1.cluster.oc1..xxxxxEXAMPLExxxxx', 'identifier': 'ocid1.cluster.oc1..xxxxxEXAMPLExxxxx', 'action_type': 'RELATED', 'entity_type': 'cluster'}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current status of the work request.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_finished</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was finished.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_started</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was started.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment in which the work request exists.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>operation_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of work the work request is doing.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_accepted</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was accepted.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the work request.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>resources</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The resources this work request affects.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_node_pool.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_node_pool_options_facts_module.rst
+++ b/docs/modules/oci_node_pool_options_facts_module.rst
@@ -1,0 +1,262 @@
+:source: cloud/oracle/oci_node_pool_options_facts.py
+
+:orphan:
+
+.. _oci_node_pool_options_facts_module:
+
+
+oci_node_pool_options_facts - Retrieve options available for node pools in OCI Container Engine for Kubernetes Service
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves options available for node pools in OCI Container Engine for Kubernetes Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>node_pool_option_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The id of the option set to retrieve. Use &quot;all&quot; to get all options, or use a cluster ID to get options specific to the provided cluster.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get all the node pool options available for node pools
+      oci_node_pool_options_facts:
+        node_pool_option_id: all
+
+    - name: Get all the node pool options available for a specific cluster
+      oci_node_pool_options_facts:
+        node_pool_option_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>node_pool_options</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Options available for node pools</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'images': ['Oracle-Linux-7.4', 'Oracle-Linux-7.5'], 'shapes': ['VM.Standard2.1', 'VM.Standard2.2', 'VM.Standard1.1', 'VM.Standard1.2', 'VM.DenseIO1.4'], 'kubernetes_versions': ['v1.8.11', 'v1.9.7', 'v1.10.3', 'v1.11.1']}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>images</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Available images for nodes</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>shapes</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Available shapes for nodes.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>kubernetes_versions</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Available Kubernetes versions.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_node_pool_options_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_object_facts_module.rst
+++ b/docs/modules/oci_object_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_object_facts:
+:source: cloud/oracle/oci_object_facts.py
+
+:orphan:
+
+.. _oci_object_facts_module:
 
 
 oci_object_facts - Retrieve details of an object or all the objects in a specific namespace and bucket in OCI Object                     Storage Service
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,155 +17,172 @@ oci_object_facts - Retrieve details of an object or all the objects in a specifi
 
 Synopsis
 --------
-
-
-* This module retrieves details of an object or all the objects present in a specified namespace and bucket in OCI       Object Storage Service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details of an object or all the objects present in a specified namespace and bucket in OCI       Object Storage Service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>bucket_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the bucket from which facts of objects need to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: bucket</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>namespace_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the namespace from which facts of objects need to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: namespace</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>object_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the object. Required to fetch details of a specific object.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: object, name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>bucket_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the bucket from which facts of objects need to be fetched.</div>
-        </br><div style="font-size: small;">aliases: bucket</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>namespace_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the namespace from which facts of objects need to be fetched.</div>
-        </br><div style="font-size: small;">aliases: namespace</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>object_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the object. Required to fetch details of a specific object.</div>
-        </br><div style="font-size: small;">aliases: object, name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the objects in namespace 'mynamespace' and bucket 'mybucket'
@@ -179,115 +197,111 @@ Examples
         object: myobject
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>objects</td>
-    <td>
-        <div>List of object details</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'md5': '3zBENq6MBnedDrpl2+SttQ==', 'name': 'image2a343.png', 'time_created': '2017-10-09T10:27:53.688000+00:00', 'size': 165661}, {'md5': 'LWX13se0YFa6VVlv0R3hqA==', 'name': 'info1.txt', 'time_created': '2017-10-09T08:39:17.411000+00:00', 'size': 1084}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>md5</td>
-        <td>
-            <div>Base64-encoded MD5 hash of the object data</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>3zBENq6MBnedDrpl2+SttQ==</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name of the object</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>image2a343.png</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time of object creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2017-10-09 08:39:17.411000</td>
-        </tr>
-
-        <tr>
-        <td>size</td>
-        <td>
-            <div>Size of the object in bytes</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>165661</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>objects</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>List of object details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'md5': '3zBENq6MBnedDrpl2+SttQ==', 'name': 'image2a343.png', 'time_created': '2017-10-09T10:27:53.688000+00:00', 'size': 165661}, {'md5': 'LWX13se0YFa6VVlv0R3hqA==', 'name': 'info1.txt', 'time_created': '2017-10-09T08:39:17.411000+00:00', 'size': 1084}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>md5</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Base64-encoded MD5 hash of the object data</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3zBENq6MBnedDrpl2+SttQ==</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the object</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">image2a343.png</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time of object creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-10-09 08:39:17.411000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>size</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Size of the object in bytes</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">165661</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_object_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_object_module.rst
+++ b/docs/modules/oci_object_module.rst
@@ -1,13 +1,14 @@
-.. _oci_object:
+:source: cloud/oracle/oci_object.py
+
+:orphan:
+
+.. _oci_object_module:
 
 
 oci_object - Manage objects in OCI Object Storage Service
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,267 +17,293 @@ oci_object - Manage objects in OCI Object Storage Service
 
 Synopsis
 --------
-
-
-* Create, read, update or delete an object in OCI. This module allows the user to store a file as an object in OCI or download an object from OCI to a local file.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Create, read, update or delete an object in OCI. This module allows the user to store a file as an object in OCI or download an object from OCI to a local file.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>bucket_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the bucket in which the object exists.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: bucket</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>content_encoding</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The content encoding of the object to be uploaded.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>content_language</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The content language of the object to be uploaded.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>content_length</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The content length of the object body to be uploaded.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>content_md5</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The base-64 encoded MD5 hash of the body to be uploaded.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>content_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">application/octet-stream</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The content type of the object to be uploaded.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>dest</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The destination file path when downloading an object. Use with <em>state=present</em> to download an object. This option is mutually exclusive with <em>src</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Force overwriting existing local file when downloading or existing remote object when uploading.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: overwrite</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>namespace_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the namespace in which the object exists.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: namespace</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>object_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the object. For naming convention, refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingobjects.htm#namerequirements'>https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingobjects.htm#namerequirements</a>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name, object</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>opc_client_request_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The client request ID for tracing.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>opc_meta</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>User-defined metadata dict(str,str) for the object to be uploaded.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: metadata</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>src</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The source file path when uploading an object. Use with <em>state=present</em> to upload an object. This option is mutually exclusive with <em>dest</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The final state of the object after the task. Use <em>state=absent</em> with <em>object</em> to delete a specific object. Use <em>state=present</em> with <em>dest</em> to download an object. Use <em>state=present</em> with <em>src</em> to upload an object.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>bucket_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the bucket in which the object exists.</div>
-        </br><div style="font-size: small;">aliases: bucket</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>content_encoding<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The content encoding of the object to be uploaded.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>content_language<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The content language of the object to be uploaded.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>content_length<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The content length of the object body to be uploaded.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>content_md5<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The base-64 encoded MD5 hash of the body to be uploaded.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>content_type<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>application/octet-stream</td>
-    <td></td>
-    <td>
-        <div>The content type of the object to be uploaded.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>dest<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The destination file path when downloading an object. Use with <em>state=present</em> to download an object. This option is mutually exclusive with <em>src</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Force overwriting existing local file when downloading or existing remote object when uploading.</div>
-        </br><div style="font-size: small;">aliases: overwrite</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>namespace_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the namespace in which the object exists.</div>
-        </br><div style="font-size: small;">aliases: namespace</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>object_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the object. For naming convention, refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingobjects.htm#namerequirements'>https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingobjects.htm#namerequirements</a>.</div>
-        </br><div style="font-size: small;">aliases: name, object</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>opc_client_request_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The client request ID for tracing.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>opc_meta<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>User-defined metadata dict(str,str) for the object to be uploaded.</div>
-        </br><div style="font-size: small;">aliases: metadata</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>src<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The source file path when uploading an object. Use with <em>state=present</em> to upload an object. This option is mutually exclusive with <em>dest</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>The final state of the object after the task. Use <em>state=absent</em> with <em>object</em> to delete a specific object. Use <em>state=present</em> with <em>dest</em> to download an object. Use <em>state=present</em> with <em>src</em> to upload an object.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create/upload an object
@@ -311,58 +338,54 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>object</td>
-    <td>
-        <div>OCI object details</div>
-    </td>
-    <td align=center>On successful operation</td>
-    <td align=center>dict</td>
-    <td align=center>{'Content-Length': '165661', 'opc-request-id': '79bcd894-8a9d-fbfe-3717-fd92d518d0a1', 'Access-Control-Expose-Headers': 'Access-Control-Allow-Credentials,Access-Control-Allow-Methods, Access-Control-Allow-Origin,Content-Length,Content-MD5,Content-Type,ETag,Last-Modified,opc-client-info, opc-meta-author,opc-meta-doc-genre,opc-request-id', 'opc-meta-author': 'RC', 'Content-MD5': '3zBENq6MBnedDrpl2+SttQ==', 'Last-Modified': 'Tue, 10 Oct 2017 13:57:20 GMT', 'Connection': 'keep-alive', 'ETag': '5B3287C054A51CB6E053824310AC257B', 'Access-Control-Allow-Credentials': 'true', 'Date': 'Tue, 10 Oct 2017 13:58:02 GMT', 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST,PUT,GET,HEAD,DELETE,OPTIONS', 'Content-Type': 'image/png'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>object</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful operation</td>
+                <td>
+                                            <div>OCI object details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'Content-Length': '165661', 'opc-request-id': '79bcd894-8a9d-fbfe-3717-fd92d518d0a1', 'Access-Control-Expose-Headers': 'Access-Control-Allow-Credentials,Access-Control-Allow-Methods, Access-Control-Allow-Origin,Content-Length,Content-MD5,Content-Type,ETag,Last-Modified,opc-client-info, opc-meta-author,opc-meta-doc-genre,opc-request-id', 'opc-meta-author': 'RC', 'Content-MD5': '3zBENq6MBnedDrpl2+SttQ==', 'Last-Modified': 'Tue, 10 Oct 2017 13:57:20 GMT', 'Connection': 'keep-alive', 'ETag': '5B3287C054A51CB6E053824310AC257B', 'Access-Control-Allow-Credentials': 'true', 'Date': 'Tue, 10 Oct 2017 13:58:02 GMT', 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST,PUT,GET,HEAD,DELETE,OPTIONS', 'Content-Type': 'image/png'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_object.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_oke_work_request_error_facts_module.rst
+++ b/docs/modules/oci_oke_work_request_error_facts_module.rst
@@ -1,0 +1,268 @@
+:source: cloud/oracle/oci_oke_work_request_error_facts.py
+
+:orphan:
+
+.. _oci_oke_work_request_error_facts_module:
+
+
+oci_oke_work_request_error_facts - Retrieve errors of a work request in OCI Container Engine for Kubernetes Service
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves errors of a work request in OCI Container Engine for Kubernetes Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>work_request_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the work request.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get the errors of a work request
+      oci_oke_work_request_error_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        work_request_id: "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx"
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>work_request_errors</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of work request errors</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'timestamp': '2018-08-16T12:20:48Z', 'message': 'failed to get DNS record from OCI API', 'code': 'GetWorkRequestGeneric'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>timestamp</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the error occurred.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>message</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A human-readable error string.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>code</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A short error code that defines the error, meant for programmatic parsing.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_oke_work_request_error_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_oke_work_request_facts_module.rst
+++ b/docs/modules/oci_oke_work_request_facts_module.rst
@@ -1,0 +1,377 @@
+:source: cloud/oracle/oci_oke_work_request_facts.py
+
+:orphan:
+
+.. _oci_oke_work_request_facts_module:
+
+
+oci_oke_work_request_facts - Retrieve facts of work requests in OCI Container Engine for Kubernetes Service
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves information of a specified work request or lists work requests in a compartment.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cluster_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the cluster. Use <em>cluster_id</em> with <em>compartment_id</em> to filter work requests related to a cluster in the specified compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. Required to list all the work requests in a compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>resource_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the resource associated with a work request. Use <em>resource_id</em> with <em>compartment_id</em> to filter work requests related to a resource in the specified compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>resource_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>CLUSTER</li>
+                                                                                                                                                                                                <li>NODEPOOL</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Type of the resource associated with a work request. Use <em>resource_type</em> with <em>compartment_id</em> to filter work requests related to the resource type in the specified compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>work_request_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the work request. <em>work_request_id</em> is required to get a specific work request's information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get all the work requests in a specific compartment
+      oci_oke_work_request_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Get a specific work request
+      oci_oke_work_request_facts:
+        id: ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Get all the work requests in compartment associated with a particular cluster
+      oci_oke_work_request_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Get all work requests in a compartment for a specified cluster in which resource of type NODEPOOL is associated
+      oci_oke_work_request_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+        resource_type: NODEPOOL
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>work_requests</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of work request details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'status': 'ACCEPTED', 'time_finished': '2018-07-26T18:44:13+00:00', 'time_started': '2018-07-26T18:43:26+00:00', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'operation_type': 'CLUSTER_CREATE', 'time_accepted': '2018-07-26T18:42:26+00:00', 'id': 'ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx', 'resources': [{'entity_uri': '/clusters/ocid1.cluster.oc1..xxxxxEXAMPLExxxxx', 'identifier': 'ocid1.cluster.oc1..xxxxxEXAMPLExxxxx', 'action_type': 'IN_PROGRESS', 'entity_type': 'cluster'}]}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current status of the work request.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_finished</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was finished.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_started</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was started.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment in which the work request exists.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>operation_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of work the work request is doing.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_accepted</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was accepted.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the work request.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>resources</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The resources this work request affects.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_oke_work_request_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_oke_work_request_log_entry_facts_module.rst
+++ b/docs/modules/oci_oke_work_request_log_entry_facts_module.rst
@@ -1,0 +1,256 @@
+:source: cloud/oracle/oci_oke_work_request_log_entry_facts.py
+
+:orphan:
+
+.. _oci_oke_work_request_log_entry_facts_module:
+
+
+oci_oke_work_request_log_entry_facts - Retrieve logs of a work request in OCI Container Engine for Kubernetes Service
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves logs of a work request in OCI Container Engine for Kubernetes Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>work_request_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the work request.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get the logs of a work request
+      oci_oke_work_request_log_entry_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        work_request_id: "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx"
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>work_request_log_entries</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of work request log entries</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'timestamp': '2018-08-16T12:20:48Z', 'message': 'extending job lease time'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>timestamp</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the log entry occurred.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>message</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description of an action that occurred.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_oke_work_request_log_entry_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_oke_work_request_module.rst
+++ b/docs/modules/oci_oke_work_request_module.rst
@@ -1,0 +1,366 @@
+:source: cloud/oracle/oci_oke_work_request.py
+
+:orphan:
+
+.. _oci_oke_work_request_module:
+
+
+oci_oke_work_request - Manage work requests in OCI Container Engine for Kubernetes Service
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module allows the user to cancel a work request that has not started in OCI Container Engine for Kubernetes Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>absent</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>state=absent</em> to delete a work request.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>work_request_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the work request. Required to delete a work request.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Cancel a work request
+      oci_oke_work_request:
+        id: "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx"
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>work_request</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful delete</td>
+                <td>
+                                            <div>Information of work request</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'status': 'CANCELED', 'time_finished': '2018-07-26T18:44:13+00:00', 'time_started': '2018-07-26T18:43:26+00:00', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'operation_type': 'CLUSTER_CREATE', 'time_accepted': '2018-07-26T18:42:26+00:00', 'id': 'ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx', 'resources': []}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current status of the work request.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_finished</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was finished.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_started</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was started.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment in which the work request exists.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>operation_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of work the work request is doing.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_accepted</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The time the work request was accepted.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the work request.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>resources</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The resources this work request affects.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_oke_work_request.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_policy_facts_module.rst
+++ b/docs/modules/oci_policy_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_policy_facts:
+:source: cloud/oracle/oci_policy_facts.py
+
+:orphan:
+
+.. _oci_policy_facts_module:
 
 
 oci_policy_facts - Retrieve details about a policy or policies attached to a compartment or tenancy in OCI Identity and Access Management service
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,170 @@ oci_policy_facts - Retrieve details about a policy or policies attached to a com
 
 Synopsis
 --------
-
-
-* This module retrieves a specific policy or all the policies attached to a specified compartment in OCI Identity and Access Management service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves a specific policy or all the policies attached to a specified compartment in OCI Identity and Access Management service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment (remember that the tenancy is simply the root compartment). Required to list all the policies in a compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>policy_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the policy. Required when retrieving a specific policy.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment (remember that the tenancy is simply the root compartment). Required to list all the policies in a compartment.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>policy_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the policy. Required when retrieving a specific policy.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get all the policies attached to a compartment or tenancy
@@ -164,165 +192,181 @@ Examples
         id: ocid1.policy.oc1..xxxxxEXAMPLExxxxx
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>policies</td>
-    <td>
-        <div>Information of one or more policies</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'statements': ['Allow group GroupAdmins to manage users in compartment Project-A'], 'name': 'mypolicy', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-11-01T14:59:51.728000+00:00', 'version_date': '2017-11-01T00:00:00+00:00', 'id': 'ocid1.policy.oc1..xxxxxEXAMPLExxxxx', 'description': 'GroupAdmins can add/remove users in Project-A compartment'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The policy's current state.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>inactive_status</td>
-        <td>
-            <div>The detailed status of INACTIVE lifecycleState.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>5</td>
-        </tr>
-
-        <tr>
-        <td>statements</td>
-        <td>
-            <div>A list of one or more policy statements written in the policy language.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list[string]</td>
-        <td align=center>['Allow group GroupAdmins to manage users in compartment Project-A']</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name assigned to the policy during creation.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>mypolicy</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment containing the policy (either the tenancy or another compartment).</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time the policy was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2017-11-01 14:59:51.728000</td>
-        </tr>
-
-        <tr>
-        <td>version_date</td>
-        <td>
-            <div>The version of the policy. If null or set to an empty string, when a request comes in for                         authorization, the policy will be evaluated according to the current behavior of the services                         at that moment. If set to a particular date (YYYY-MM-DD), the policy will be evaluated                         according to the behavior of the services on that date.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2017-11-01 00:00:00</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the policy.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.policy.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The description assigned to the policy.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>GroupAdmins can add/remove users in Project-A compartment</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>policies</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information of one or more policies</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'statements': ['Allow group GroupAdmins to manage users in compartment Project-A'], 'name': 'mypolicy', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-11-01T14:59:51.728000+00:00', 'version_date': '2017-11-01T00:00:00+00:00', 'id': 'ocid1.policy.oc1..xxxxxEXAMPLExxxxx', 'description': 'GroupAdmins can add/remove users in Project-A compartment'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The policy's current state.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The detailed status of INACTIVE lifecycleState.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">5</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>statements</b>
+                    <br/><div style="font-size: small; color: red">list[string]</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A list of one or more policy statements written in the policy language.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['Allow group GroupAdmins to manage users in compartment Project-A']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name assigned to the policy during creation.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">mypolicy</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the policy (either the tenancy or another compartment).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time the policy was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-01 14:59:51.728000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>version_date</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The version of the policy. If null or set to an empty string, when a request comes in for                         authorization, the policy will be evaluated according to the current behavior of the services                         at that moment. If set to a particular date (YYYY-MM-DD), the policy will be evaluated                         according to the behavior of the services on that date.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-01 00:00:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the policy.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.policy.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description assigned to the policy.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">GroupAdmins can add/remove users in Project-A compartment</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_policy_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_policy_module.rst
+++ b/docs/modules/oci_policy_module.rst
@@ -1,13 +1,14 @@
-.. _oci_policy:
+:source: cloud/oracle/oci_policy.py
+
+:orphan:
+
+.. _oci_policy_module:
 
 
 oci_policy - Manage policies in OCI Identity and Access Management
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,253 +17,279 @@ oci_policy - Manage policies in OCI Identity and Access Management
 
 Synopsis
 --------
-
-
-* This module allows the user to create, delete and update policies in OCI Identity and Access Management service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create, delete and update policies in OCI Identity and Access Management service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment containing the policy (either the tenancy or another compartment). Required when creating a policy with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>description</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The description you assign to the policy. Does not have to be unique, and it's changeable. Required when creating a policy with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name you assign to the policy during creation. The name must be unique across all policies in the tenancy and cannot be changed. Required when creating a policy with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>policy_document</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The path to the policy file. This option is mutually exclusive with <em>statements</em>. Either <em>statements</em> or <em>policy_document</em> must be specified when creating a policy with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>policy_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the policy. Required to update or delete a policy.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a policy with <em>state=present</em>. Delete a policy with <em>state=absent</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>statements</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>An array of policy statements written in the policy language. This option is mutually exclusive with <em>policy_document</em>. Either <em>statements</em> or <em>policy_document</em> must be specified when creating a policy with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>version_date</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The version of the policy. The version of the policy. If null or set to an empty string, when a request comes in for authorization, the policy will be evaluated according to the current behavior of the services at that moment. If set to a particular date (YYYY-MM-DD), the policy will be evaluated according to the behavior of the services on that date.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment containing the policy (either the tenancy or another compartment). Required when creating a policy with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>description<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The description you assign to the policy. Does not have to be unique, and it's changeable. Required when creating a policy with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name you assign to the policy during creation. The name must be unique across all policies in the tenancy and cannot be changed. Required when creating a policy with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>policy_document<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The path to the policy file. This option is mutually exclusive with <em>statements</em>. Either <em>statements</em> or <em>policy_document</em> must be specified when creating a policy with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>policy_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the policy. Required to update or delete a policy.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create or update a policy with <em>state=present</em>. Delete a policy with <em>state=absent</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>statements<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>An array of policy statements written in the policy language. This option is mutually exclusive with <em>policy_document</em>. Either <em>statements</em> or <em>policy_document</em> must be specified when creating a policy with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>version_date<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The version of the policy. The version of the policy. If null or set to an empty string, when a request comes in for authorization, the policy will be evaluated according to the current behavior of the services at that moment. If set to a particular date (YYYY-MM-DD), the policy will be evaluated according to the behavior of the services on that date.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a policy
@@ -285,58 +312,54 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>policy</td>
-    <td>
-        <div>OCI policy details</div>
-    </td>
-    <td align=center>On successful operation</td>
-    <td align=center>dict</td>
-    <td align=center>{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'statements': ['Allow group GroupAdmins to manage users in compartment Project-A'], 'name': 'mypolicy', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-11-01T19:19:36.700000+00:00', 'version_date': '2017-11-01T00:00:00+00:00', 'id': 'ocid1.policy.oc1..xxxxxEXAMPLExxxxx', 'description': 'GroupAdmins can add/remove users in Project-A compartment'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>policy</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful operation</td>
+                <td>
+                                            <div>OCI policy details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'statements': ['Allow group GroupAdmins to manage users in compartment Project-A'], 'name': 'mypolicy', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-11-01T19:19:36.700000+00:00', 'version_date': '2017-11-01T00:00:00+00:00', 'id': 'ocid1.policy.oc1..xxxxxEXAMPLExxxxx', 'description': 'GroupAdmins can add/remove users in Project-A compartment'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_policy.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_private_ip_facts_module.rst
+++ b/docs/modules/oci_private_ip_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_private_ip_facts:
+:source: cloud/oracle/oci_private_ip_facts.py
+
+:orphan:
+
+.. _oci_private_ip_facts_module:
 
 
 oci_private_ip_facts - Retrieve facts of private IPs
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,170 @@ oci_private_ip_facts - Retrieve facts of private IPs
 
 Synopsis
 --------
-
-
-* This module retrieves information of a specified private IP or lists all the private IPs in a subnet.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves information of a specified private IP or lists all the private IPs in a subnet.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>private_ip_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the private IP. <em>private_ip_id</em> is required to get a specific private IP's information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>subnet_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the subnet. Required to list all the private IPs in a subnet.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>private_ip_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the private IP. <em>private_ip_id</em> is required to get a specific private IP's information.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>subnet_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the subnet. Required to list all the private IPs in a subnet.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get all the private IPs
@@ -164,195 +192,221 @@ Examples
         private_ip_id: ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>private_ips</td>
-    <td>
-        <div>List of private IP details</div>
-    </td>
-    <td align=center>always</td>
-    <td align=center>complex</td>
-    <td align=center>[{'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'ansible_private_ip', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'hostname_label': 'db', 'subnet_id': 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-03-28T18:37:56.190000+00:00', 'vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'is_primary': False, 'ip_address': '10.0.0.114', 'id': 'ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The private IP's Availability Domain.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IwGV:US-ASHBURN-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_private_ip</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment containing the private IP.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>hostname_label</td>
-        <td>
-            <div>The hostname for the private IP. Used for DNS. The value is the hostname portion of the private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>webserver</td>
-        </tr>
-
-        <tr>
-        <td>subnet_id</td>
-        <td>
-            <div>The OCID of the subnet the VNIC is in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>defined_tags</td>
-        <td>
-            <div>Defined tags for this resource. Each key is predefined and scoped to a namespace.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>{'Operations': {'CostCenter': '42'}}</td>
-        </tr>
-
-        <tr>
-        <td>freeform_tags</td>
-        <td>
-            <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>{'Department': 'Finance'}</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the private IP was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-03-28 18:37:56.190000</td>
-        </tr>
-
-        <tr>
-        <td>vnic_id</td>
-        <td>
-            <div>The OCID of the VNIC the private IP is assigned to. The VNIC and private IP must be in the same subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>is_primary</td>
-        <td>
-            <div>Whether this private IP is the primary one on the VNIC. Primary private IPs are unassigned and deleted automatically when the VNIC is terminated.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>False</td>
-        </tr>
-
-        <tr>
-        <td>ip_address</td>
-        <td>
-            <div>The private IP address of the privateIp object. The address is within the CIDR of the VNIC's subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>10.0.0.114</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The private IP's Oracle ID (OCID).</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>private_ips</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of private IP details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'ansible_private_ip', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'hostname_label': 'db', 'subnet_id': 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-03-28T18:37:56.190000+00:00', 'vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'is_primary': False, 'ip_address': '10.0.0.114', 'id': 'ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The private IP's Availability Domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ASHBURN-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_private_ip</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the private IP.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostname_label</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The hostname for the private IP. Used for DNS. The value is the hostname portion of the private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">webserver</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the subnet the VNIC is in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>defined_tags</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Defined tags for this resource. Each key is predefined and scoped to a namespace.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'Operations': {'CostCenter': '42'}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>freeform_tags</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'Department': 'Finance'}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the private IP was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-03-28 18:37:56.190000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vnic_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VNIC the private IP is assigned to. The VNIC and private IP must be in the same subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_primary</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether this private IP is the primary one on the VNIC. Primary private IPs are unassigned and deleted automatically when the VNIC is terminated.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ip_address</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The private IP address of the privateIp object. The address is within the CIDR of the VNIC's subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.0.0.114</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The private IP's Oracle ID (OCID).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_private_ip_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_private_ip_module.rst
+++ b/docs/modules/oci_private_ip_module.rst
@@ -1,13 +1,14 @@
-.. _oci_private_ip:
+:source: cloud/oracle/oci_private_ip.py
+
+:orphan:
+
+.. _oci_private_ip_module:
 
 
 oci_private_ip - Manage private IPs in OCI
 ++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,204 +17,225 @@ oci_private_ip - Manage private IPs in OCI
 
 Synopsis
 --------
-
-
-* This module allows the user to create, delete and update private IPs in OCI.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create, delete and update private IPs in OCI.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>hostname_label</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The hostname for the private IP. Used for DNS. The value is the hostname portion of the private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>ip_address</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A private IP address of your choice. Must be an available IP address within the subnet's CIDR. If you don't specify a value, Oracle automatically assigns a private IP address from the subnet.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>private_ip_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the private IP. Required to update a private IP using <em>state=present</em> or delete a private IP using <em>state=absent</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a private IP with <em>state=present</em>. Use <em>state=absent</em> to delete a private IP.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vnic_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the VNIC to assign the private IP to. The VNIC and private IP must be in the same subnet. Required when creating a private IP using <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>hostname_label<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The hostname for the private IP. Used for DNS. The value is the hostname portion of the private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>ip_address<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A private IP address of your choice. Must be an available IP address within the subnet's CIDR. If you don't specify a value, Oracle automatically assigns a private IP address from the subnet.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>private_ip_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the private IP. Required to update a private IP using <em>state=present</em> or delete a private IP using <em>state=absent</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create or update a private IP with <em>state=present</em>. Use <em>state=absent</em> to delete a private IP.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vnic_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the VNIC to assign the private IP to. The VNIC and private IP must be in the same subnet. Required when creating a private IP using <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a private IP
@@ -234,58 +256,54 @@ Examples
         state: absent
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>private_ip</td>
-    <td>
-        <div>Information about the private IP</div>
-    </td>
-    <td align=center>On successful create, delete & update operation</td>
-    <td align=center>dict</td>
-    <td align=center>{'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'ansible_private_ip', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'hostname_label': 'db', 'subnet_id': 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-03-28T18:37:56.190000+00:00', 'vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'is_primary': False, 'ip_address': '10.0.0.114', 'id': 'ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>private_ip</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful create, delete &amp; update operation</td>
+                <td>
+                                            <div>Information about the private IP</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'availability_domain': 'IwGV:US-ASHBURN-AD-1', 'display_name': 'ansible_private_ip', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'hostname_label': 'db', 'subnet_id': 'ocid1.subnet.oc1.iad.xxxxxEXAMPLExxxxx', 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-03-28T18:37:56.190000+00:00', 'vnic_id': 'ocid1.vnic.oc1.iad.xxxxxEXAMPLExxxxx', 'is_primary': False, 'ip_address': '10.0.0.114', 'id': 'ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_private_ip.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_public_ip_facts_module.rst
+++ b/docs/modules/oci_public_ip_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_public_ip_facts:
+:source: cloud/oracle/oci_public_ip_facts.py
+
+:orphan:
+
+.. _oci_public_ip_facts_module:
 
 
 oci_public_ip_facts - Retrieve facts of public IPs
 ++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,183 +17,214 @@ oci_public_ip_facts - Retrieve facts of public IPs
 
 Synopsis
 --------
-
-
-* This module retrieves information of the specified public IP or all public IPs in the specified compartment.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves information of the specified public IP or all public IPs in the specified compartment.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the Availability Domain. <em>availability_domain</em> is required to list all the ephemeral public IPs in the specified <em>compartment_id</em> and <em>availability_domain</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. <em>compartment_id</em> is required to list all the public IPs in a compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>ip_address</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The public IP address. Use <em>ip_address</em> to get the public IP based on the public IP address.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>private_ip_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of the private IP that the public IP is assigned to. Use <em>private_ip_id</em> to retrieve information of a public IP assigned to it.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>public_ip_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of the public IP. Use <em>public_ip_id</em> to retrieve a specific public IP's information using its OCID.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>scope</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>REGION</li>
+                                                                                                                                                                                                <li>AVAILABILITY_DOMAIN</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether the public IP is regional or specific to a particular Availability Domain. Reserved public IPs have <em>scope=REGION</em>. Ephemeral public IPs have <em>scope=AVAILABILITY_DOMAIN</em>. <em>scope</em> is required to list all the public IPs in a compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the Availability Domain. <em>availability_domain</em> is required to list all the ephemeral public IPs in the specified <em>compartment_id</em> and <em>availability_domain</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment. <em>compartment_id</em> is required to list all the public IPs in a compartment.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>ip_address<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The public IP address. Use <em>ip_address</em> to get the public IP based on the public IP address.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>private_ip_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of the private IP that the public IP is assigned to. Use <em>private_ip_id</em> to retrieve information of a public IP assigned to it.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>public_ip_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of the public IP. Use <em>public_ip_id</em> to retrieve a specific public IP's information using its OCID.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>scope<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>REGION</li><li>AVAILABILITY_DOMAIN</li></ul></td>
-    <td>
-        <div>Whether the public IP is regional or specific to a particular Availability Domain. Reserved public IPs have <em>scope=REGION</em>. Ephemeral public IPs have <em>scope=AVAILABILITY_DOMAIN</em>. <em>scope</em> is required to list all the public IPs in a compartment.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get all the reserved public IPs in a compartment
@@ -219,195 +251,223 @@ Examples
         ip_address: 129.146.2.1
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>public_ips</td>
-    <td>
-        <div>List of public IP details</div>
-    </td>
-    <td align=center>always</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'availability_domain': None, 'display_name': 'ansible_public_ip', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2018-06-22T15:25:25.569000+00:00', 'lifetime': 'RESERVED', 'scope': 'REGION', 'private_ip_id': None, 'ip_address': '129.213.14.148', 'id': 'ocid1.publicip.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The public IP's current state.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ASSIGNED</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The public IP's Availability Domain. This property is set only for ephemeral public IPs (that is, when the scope of the public IP is set to AVAILABILITY_DOMAIN). The value is the Availability Domain of the assigned private IP.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IwGV:US-ASHBURN-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_public_ip</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment containing the public IP. For an ephemeral public IP, this is the same compartment as the private IP's. For a reserved public IP that is currently assigned, this can be a different compartment than the assigned private IP's.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>defined_tags</td>
-        <td>
-            <div>Defined tags for this resource. Each key is predefined and scoped to a namespace.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>{'Operations': {'CostCenter': '42'}}</td>
-        </tr>
-
-        <tr>
-        <td>freeform_tags</td>
-        <td>
-            <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>{'Department': 'Finance'}</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the private IP was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2018-06-22 15:25:25.569000</td>
-        </tr>
-
-        <tr>
-        <td>lifetime</td>
-        <td>
-            <div>Defines when the public IP is deleted and released back to Oracle's public IP pool.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>EPHEMERAL</td>
-        </tr>
-
-        <tr>
-        <td>scope</td>
-        <td>
-            <div>Whether the public IP is regional or specific to a particular Availability Domain.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>REGION</td>
-        </tr>
-
-        <tr>
-        <td>private_ip_id</td>
-        <td>
-            <div>The OCID of the private IP that the public IP is currently assigned to, or in the process of being assigned to.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>ip_address</td>
-        <td>
-            <div>The public IP address of the publicIp object.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>129.146.2.1</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The public IP's Oracle ID (OCID).</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>public_ips</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of public IP details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'availability_domain': None, 'display_name': 'ansible_public_ip', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2018-06-22T15:25:25.569000+00:00', 'lifetime': 'RESERVED', 'scope': 'REGION', 'private_ip_id': None, 'ip_address': '129.213.14.148', 'id': 'ocid1.publicip.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The public IP's current state.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ASSIGNED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The public IP's Availability Domain. This property is set only for ephemeral public IPs (that is, when the scope of the public IP is set to AVAILABILITY_DOMAIN). The value is the Availability Domain of the assigned private IP.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ASHBURN-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_public_ip</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the public IP. For an ephemeral public IP, this is the same compartment as the private IP's. For a reserved public IP that is currently assigned, this can be a different compartment than the assigned private IP's.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>defined_tags</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Defined tags for this resource. Each key is predefined and scoped to a namespace.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'Operations': {'CostCenter': '42'}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>freeform_tags</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'Department': 'Finance'}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the private IP was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-06-22 15:25:25.569000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifetime</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Defines when the public IP is deleted and released back to Oracle's public IP pool.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">EPHEMERAL</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>scope</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether the public IP is regional or specific to a particular Availability Domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">REGION</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>private_ip_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the private IP that the public IP is currently assigned to, or in the process of being assigned to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ip_address</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The public IP address of the publicIp object.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">129.146.2.1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The public IP's Oracle ID (OCID).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.privateip.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_public_ip_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_public_ip_module.rst
+++ b/docs/modules/oci_public_ip_module.rst
@@ -1,13 +1,14 @@
-.. _oci_public_ip:
+:source: cloud/oracle/oci_public_ip.py
+
+:orphan:
+
+.. _oci_public_ip_module:
 
 
 oci_public_ip - Manage public IPs in OCI
 ++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,254 +17,288 @@ oci_public_ip - Manage public IPs in OCI
 
 Synopsis
 --------
-
-
-* This module allows the user to create, delete and update public IPs in OCI.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create, delete and update public IPs in OCI.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment to contain the public IP. For ephemeral public IPs, you must set this to the private IP's compartment OCID. Required to create a public IP.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>lifetime</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>EPHEMERAL</li>
+                                                                                                                                                                                                <li>RESERVED</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Defines when the public IP is deleted and released back to the Oracle Cloud Infrastructure public IP pool. Required to create a public IP.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>private_ip_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the private IP to assign the public IP to. Required for an ephemeral public IP because it must always be assigned to a private IP (specifically a primary private IP). Optional for a reserved public IP. If you don't provide it, the public IP is created but not assigned to a private IP.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>public_ip_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the public IP. Required to delete or update a public IP.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a public IP with <em>state=present</em>. Use <em>state=absent</em> to delete a public IP.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment to contain the public IP. For ephemeral public IPs, you must set this to the private IP's compartment OCID. Required to create a public IP.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>lifetime<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>EPHEMERAL</li><li>RESERVED</li></ul></td>
-    <td>
-        <div>Defines when the public IP is deleted and released back to the Oracle Cloud Infrastructure public IP pool. Required to create a public IP.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>private_ip_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the private IP to assign the public IP to. Required for an ephemeral public IP because it must always be assigned to a private IP (specifically a primary private IP). Optional for a reserved public IP. If you don't provide it, the public IP is created but not assigned to a private IP.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>public_ip_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the public IP. Required to delete or update a public IP.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create or update a public IP with <em>state=present</em>. Use <em>state=absent</em> to delete a public IP.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a public IP with lifetime as RESERVED
@@ -295,58 +330,54 @@ Examples
         state: absent
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>public_ip</td>
-    <td>
-        <div>Information about the public IP</div>
-    </td>
-    <td align=center>On successful create, delete & update operation</td>
-    <td align=center>dict</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'availability_domain': None, 'display_name': 'ansible_public_ip', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2018-06-22T15:25:25.569000+00:00', 'lifetime': 'RESERVED', 'scope': 'REGION', 'private_ip_id': None, 'ip_address': '129.213.14.148', 'id': 'ocid1.publicip.oc1.iad.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>public_ip</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful create, delete &amp; update operation</td>
+                <td>
+                                            <div>Information about the public IP</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'availability_domain': None, 'display_name': 'ansible_public_ip', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2018-06-22T15:25:25.569000+00:00', 'lifetime': 'RESERVED', 'scope': 'REGION', 'private_ip_id': None, 'ip_address': '129.213.14.148', 'id': 'ocid1.publicip.oc1.iad.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_public_ip.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_region_facts_module.rst
+++ b/docs/modules/oci_region_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_region_facts:
+:source: cloud/oracle/oci_region_facts.py
+
+:orphan:
+
+.. _oci_region_facts_module:
 
 
 oci_region_facts - Retrieve details about all Regions offered by Oracle Cloud Infrastructure
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,195 +17,136 @@ oci_region_facts - Retrieve details about all Regions offered by Oracle Cloud In
 
 Synopsis
 --------
-
-
-* This module retrieves details about all Regions offered by Oracle Cloud Infrastructure.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details about all Regions offered by Oracle Cloud Infrastructure.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    - name: Get details of all regions offered by OCI
-      oci_region_facts:
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>regions</td>
-    <td>
-        <div>Information about regions offered by OCI</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'name': 'eu-frankfurt-1', 'key': 'FRA'}, {'name': 'us-ashburn-1', 'key': 'IAD'}, {'name': 'us-phoenix-1', 'key': 'PHX'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name of the region.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>us-phoenix-1</td>
-        </tr>
-
-        <tr>
-        <td>key</td>
-        <td>
-            <div>The key of the region.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>PHX</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -214,19 +156,93 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Sivakumar Thyagarajan (@sivakumart)
+.. code-block:: yaml+jinja
+
+    
+    - name: Get details of all regions offered by OCI
+      oci_region_facts:
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>regions</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about regions offered by OCI</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'name': 'eu-frankfurt-1', 'key': 'FRA'}, {'name': 'us-ashburn-1', 'key': 'IAD'}, {'name': 'us-phoenix-1', 'key': 'PHX'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the region.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">us-phoenix-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>key</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The key of the region.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PHX</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_region_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_region_subscription_facts_module.rst
+++ b/docs/modules/oci_region_subscription_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_region_subscription_facts:
+:source: cloud/oracle/oci_region_subscription_facts.py
+
+:orphan:
+
+.. _oci_region_subscription_facts_module:
 
 
 oci_region_subscription_facts - Retrieve details of the region subscriptions for the specified tenancy.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,227 +17,137 @@ oci_region_subscription_facts - Retrieve details of the region subscriptions for
 
 Synopsis
 --------
-
-
-* This module retrieves details about the region subscriptions of the specified tenancy in Oracle Cloud Infrastructure.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details about the region subscriptions of the specified tenancy in Oracle Cloud Infrastructure.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the tenancy for which region subscriptions needs to be retrieved</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    - name: Get region subscription details of the specified tenancy
-      oci_region_subscription_facts:
-        id: "ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx...o244pucq"
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>region_subscriptions</td>
-    <td>
-        <div>Region subscription information about the specified tenancy</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'status': 'READY', 'region_key': 'IAD', 'region_name': 'us-ashburn-1', 'is_home_region': True}, {'status': 'READY', 'region_key': 'PHX', 'region_name': 'us-phoenix-1', 'is_home_region': False}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>status</td>
-        <td>
-            <div>The region subscription status.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>READY</td>
-        </tr>
-
-        <tr>
-        <td>region_key</td>
-        <td>
-            <div>The region's key.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>PHX</td>
-        </tr>
-
-        <tr>
-        <td>region_name</td>
-        <td>
-            <div>The name of the region</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>us-ashburn-1</td>
-        </tr>
-
-        <tr>
-        <td>is_home_region</td>
-        <td>
-            <div>Indicates if the region is the home region or not.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>True</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the tenancy for which region subscriptions needs to be retrieved</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -246,19 +157,122 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Sivakumar Thyagarajan (@sivakumart)
+.. code-block:: yaml+jinja
+
+    
+    - name: Get region subscription details of the specified tenancy
+      oci_region_subscription_facts:
+        id: "ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx...o244pucq"
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>region_subscriptions</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Region subscription information about the specified tenancy</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'status': 'READY', 'region_key': 'IAD', 'region_name': 'us-ashburn-1', 'is_home_region': True}, {'status': 'READY', 'region_key': 'PHX', 'region_name': 'us-phoenix-1', 'is_home_region': False}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The region subscription status.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">READY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>region_key</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The region's key.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PHX</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>region_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the region</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">us-ashburn-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_home_region</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Indicates if the region is the home region or not.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_region_subscription_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_route_table_facts_module.rst
+++ b/docs/modules/oci_route_table_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_route_table_facts:
+:source: cloud/oracle/oci_route_table_facts.py
+
+:orphan:
+
+.. _oci_route_table_facts_module:
 
 
 oci_route_table_facts - Fetches details of a specific Route Table or a list of Route tables in the specified VCN and compartment
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,153 +17,180 @@ oci_route_table_facts - Fetches details of a specific Route Table or a list of R
 
 Synopsis
 --------
-
-
-* Fetches details of a specific Route Table or a list of Route tables in the specified VCN and compartment.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of a specific Route Table or a list of Route tables in the specified VCN and compartment.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment details about whose Route Table must be retrived</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>rt_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Route Table. Required if the detailsof a specific Route Table details needs to be fetched. Mutually exclusive with compartment_id and vcn_id.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Cloud Network to which the Route Table is attached.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment details about whose Route Table must be retrived</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>rt_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Route Table. Required if the detailsof a specific Route Table details needs to be fetched. Mutually exclusive with compartment_id and vcn_id.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Virtual Cloud Network to which the Route Table is attached.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Fetch details of all route tables in the specified compartment and VCN
@@ -177,145 +205,153 @@ Examples
           id: 'ocid1.routetable..xcds'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>route_tables</td>
-    <td>
-        <div>Attributes of the fetched Route Table(s).</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_route_table_two', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.aaa', 'route_rules': [{'cidr_block': '0.0.0.0/0', 'network_entity_id': 'ocid1.internetgateway.aaaa'}, {'cidr_block': '10.0.0.0/8', 'network_entity_id': 'ocid1.internetgateway.aaaa'}], 'defined_tags': {'features': {'capacity': 'large'}}, 'freeform_tags': {'region': 'west'}, 'time_created': '2017-11-17T17:39:41.522000+00:00', 'id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'AVAILABLE', 'display_name': 'updated_ansible_route_table', 'compartment_id': 'ocid1.compartment.aaaa', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'route_rules': [{'cidr_block': '0.0.0.0/0', 'network_entity_id': 'ocid1.internetgateway.aaaa'}], 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-17T17:39:33.190000+00:00', 'id': 'ocid1.routetable.aaaa'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>vcn_id</td>
-        <td>
-            <div>Identifier of the Virtual Cloud Network to which the Route Table is attached.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn..ixcd</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name assigned to the Route Table during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_route_table</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the Route Table</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Route Table</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>route_rules</td>
-        <td>
-            <div>The collection of rules for routing destination IPs to network devices.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>[{'cidr_block': '0.0.0.0/0', 'network_entity_id': 'ocid1.internetgateway.aaa'}]</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Route Table</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.routetable.oc1.axdf</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Route Table was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>route_tables</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the fetched Route Table(s).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_route_table_two', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.aaa', 'route_rules': [{'cidr_block': '0.0.0.0/0', 'network_entity_id': 'ocid1.internetgateway.aaaa'}, {'cidr_block': '10.0.0.0/8', 'network_entity_id': 'ocid1.internetgateway.aaaa'}], 'defined_tags': {'features': {'capacity': 'large'}}, 'freeform_tags': {'region': 'west'}, 'time_created': '2017-11-17T17:39:41.522000+00:00', 'id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'AVAILABLE', 'display_name': 'updated_ansible_route_table', 'compartment_id': 'ocid1.compartment.aaaa', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'route_rules': [{'cidr_block': '0.0.0.0/0', 'network_entity_id': 'ocid1.internetgateway.aaaa'}], 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-17T17:39:33.190000+00:00', 'id': 'ocid1.routetable.aaaa'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Virtual Cloud Network to which the Route Table is attached.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn..ixcd</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Route Table during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_route_table</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the Route Table</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Route Table</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>route_rules</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The collection of rules for routing destination IPs to network devices.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'cidr_block': '0.0.0.0/0', 'network_entity_id': 'ocid1.internetgateway.aaa'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Route Table</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.routetable.oc1.axdf</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Route Table was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_route_table_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_route_table_module.rst
+++ b/docs/modules/oci_route_table_module.rst
@@ -1,13 +1,14 @@
-.. _oci_route_table:
+:source: cloud/oracle/oci_route_table.py
+
+:orphan:
+
+.. _oci_route_table_module:
 
 
 oci_route_table - Create,update and delete OCI Route Table
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,307 +17,325 @@ oci_route_table - Create,update and delete OCI Route Table
 
 Synopsis
 --------
-
-
-* Creates OCI Route Table
-* Update OCI Route Table, if present, with a new display name
-* Update OCI Route Table, if present, by appending new Route Rules to existing Route Rules
-* Update OCI Route Table, if present, by purging existing Route Rules and replacing them with specified ones
-* Delete OCI Route Table, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Creates OCI Route Table
+- Update OCI Route Table, if present, with a new display name
+- Update OCI Route Table, if present, by appending new Route Rules to existing Route Rules
+- Update OCI Route Table, if present, by purging existing Route Rules and replacing them with specified ones
+- Delete OCI Route Table, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment under which this Route Table would be created. Mandatory for create operation.Optional for delete and update. Mutually exclusive with rt_id.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the Route Table. A user friendly name. Does not have to be unique, and could be changed. If not specified, a default name would be provided.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>purge_route_rules<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>yes</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Purge route rules in existing Route Table which are not present in the provided Route Rules. If <em>purge_route_rules=no</em>, provided route rules would be appended to existing route rules.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">route_rules<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>List containing dictionaries describing a route rule. Suboptions should be the CIDR block which is destination ip address in CIDR notation and the identifier of the target entity such as Internet Getway.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object route_rules</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which this Route Table would be created. Mandatory for create operation.Optional for delete and update. Mutually exclusive with rt_id.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the Route Table. A user friendly name. Does not have to be unique, and could be changed. If not specified, a default name would be provided.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>purge_route_rules</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Purge route rules in existing Route Table which are not present in the provided Route Rules. If <em>purge_route_rules=no</em>, provided route rules would be appended to existing route rules.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>route_rules</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>List containing dictionaries describing a route rule. Suboptions should be the CIDR block which is destination ip address in CIDR notation and the identifier of the target entity such as Internet Getway.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>cidr_block</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A destination IP address range in CIDR notation. Matching packets will be routed to the indicated network entity (the target).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>network_entity_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The identifier  for the target of route rules, such as identifier of the Internet Gateway.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>rt_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Route Table. Mandatory for delete and update, if compartment_id and vcn_id is not specified. Mutually exclusive with compartment_id and vcn_id.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete Route Table. For <em>state=present</em>, if it does not exist, it gets created. If it exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Cloud Network to which the Route Table should be attached. Mandatory for create operation. Optional for delete and update. Mutually exclusive with rt_id.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>cidr_block<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A destination IP address range in CIDR notation. Matching packets will be routed to the indicated network entity (the target).</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>network_entity_id<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The identifier  for the target of route rules, such as identifier of the Internet Gateway.</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        </table>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>rt_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Route Table. Mandatory for delete and update, if compartment_id and vcn_id is not specified. Mutually exclusive with compartment_id and vcn_id.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete Route Table. For <em>state=present</em>, if it does not exist, it gets created. If it exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Virtual Cloud Network to which the Route Table should be attached. Mandatory for create operation. Optional for delete and update. Mutually exclusive with rt_id.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -362,145 +381,153 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>route_table</td>
-    <td>
-        <div>Attributes of the created/updated Route Table. For delete, deleted Route Table description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_route_table', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'route_rules': [{'cidr_block': '0.0.0.0/0', 'network_entity_id': 'ocid1.internetgateway.oc1.phx.xxxxxEXAMPLExxxxx'}], 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-17T17:39:33.190000+00:00', 'id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>vcn_id</td>
-        <td>
-            <div>Identifier of the Virtual Cloud Network to which the Route Table is attached.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn..ixcd</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name assigned to the Route Table during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_route_table</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the Route Table</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Route Table</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>route_rules</td>
-        <td>
-            <div>The collection of rules for routing destination IPs to network devices.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>[{'cidr_block': '0.0.0.0/0', 'network_entity_id': 'ocid1.internetgateway.aaa'}]</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Route Table</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.routetable.oc1.axdf</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Route Table was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>route_table</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated Route Table. For delete, deleted Route Table description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'display_name': 'ansible_route_table', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'route_rules': [{'cidr_block': '0.0.0.0/0', 'network_entity_id': 'ocid1.internetgateway.oc1.phx.xxxxxEXAMPLExxxxx'}], 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-17T17:39:33.190000+00:00', 'id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Virtual Cloud Network to which the Route Table is attached.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn..ixcd</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Route Table during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_route_table</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the Route Table</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Route Table</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>route_rules</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The collection of rules for routing destination IPs to network devices.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'cidr_block': '0.0.0.0/0', 'network_entity_id': 'ocid1.internetgateway.aaa'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Route Table</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.routetable.oc1.axdf</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Route Table was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_route_table.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_rrset_facts_module.rst
+++ b/docs/modules/oci_rrset_facts_module.rst
@@ -1,0 +1,373 @@
+:source: cloud/oracle/oci_rrset_facts.py
+
+:orphan:
+
+.. _oci_rrset_facts_module:
+
+
+oci_rrset_facts - Retrieve facts of a RRSet in a specified zone in Oracle Cloud Infrastructure DNS Service
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module gets a list of all records in the specified RRSet. The results are sorted by recordHash by default.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment the resource belongs to. Use <em>zone_id</em> or <em>zone_name</em> to retrieve a specific zone's information using its OCID.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>domain</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Search by domain. Will match any record whose domain (case-insensitive) equals the provided value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A case-sensitive filter for zone names. Will match any zone with a name that equals the provided value.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: zone_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>rtype</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of the target RRSet within the target zone.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>zone_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of the target zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>zone_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The version of the zone for which data is requested.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get a list of all records in the specified RRSet
+      oci_rrset_facts:
+        zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+        domain: "test_zone_1.com"
+        rtype: "TXT"
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>rrset</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A collection of DNS resource record objects.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'domain': 'test_zone_1.com', 'is_protected': True, 'rrset_version': '1', 'rtype': 'NS', 'ttl': 86400, 'record_hash': '9be3279d81b5e8430fd94c70cfa5f0a8', 'rdata': 'ns2.p68.dns.oraclecloud.net.'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">test_zone_1.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_protected</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rrset_version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rtype</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NS</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ttl</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">86400</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>record_hash</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">f439fa9a087ff74757485953fe0a8c7d</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rdata</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ns1.p68.dns.oraclecloud.net. hostmaster.test_zone_1.com. 1 3600 600 604800 1800</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_rrset_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_rrset_module.rst
+++ b/docs/modules/oci_rrset_module.rst
@@ -1,0 +1,621 @@
+:source: cloud/oracle/oci_rrset.py
+
+:orphan:
+
+.. _oci_rrset_module:
+
+
+oci_rrset - Update, Patch or Delete a collection of DNS records of the same domain and type in the specified zone in OCI DNS Service
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module allows the user to update, patch or delete a collection of DNS records of the same domain and type in the specified DNS zone in OCI DNS Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment the resource belongs to.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>domain</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The target fully-qualified domain name (FQDN) within the target zone.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the zone. Required to create a zone. Either <em>name</em> or <em>zone_id</em> must be specified to update or patch the collection of records in the specified zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: zone_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>patch_items</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The record operations to patch the RRSet collection. Updates records in the specified zone at a domain. You can update one record or all records for the specified zone depending on the changes provided in the request body. You can also add or remove records using this option. Required to patch a RRSet.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rtype</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rr_set_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rdata</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>is_protected</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ttl</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>operation</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>REQUIRE</li>
+                                                                                                                                                                                                <li>PROHIBIT</li>
+                                                                                                                                                                                                <li>ADD</li>
+                                                                                                                                                                                                <li>REMOVE</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>A description of how a record relates to a PATCH operation. REQUIRE indicates a precondition that record data must already exist. PROHIBIT indicates a precondition that record data must not already exist. ADD indicates that record data must exist after successful application. REMOVE indicates that record data must not exist after successful application. Note - ADD and REMOVE operations can succeed even if they require no changes when applied, such as when the described records are already present or absent. Note - ADD and REMOVE operations can describe changes for more than one record. Example - { &quot;domain&quot; - &quot;www.example.com&quot;, &quot;rtype&quot; - &quot;AAAA&quot;, &quot;ttl&quot; - 60 } specifies a new TTL for every record in the www.example.com AAAA RRSet.'</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>record_hash</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>rtype</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of the target RRSet within the target zone.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>State of the RRSet. Use <em>state='absent'</em> to delete all records in the specified RRSet.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>update_items</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The items to update the RRSet collection to. Replaces records in the specified zone at a domain with the records specified in the request body. If a specified record does not exist, it will be created. If the record exists, then it will be updated to represent the record in the body of the request. If a record in the zone does not exist in the request body, the record will be removed from the zone. Required to update a RRSet.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>domain</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>is_protected</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rtype</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rr_set_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ttl</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>record_hash</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rdata</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>zone_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the target zone. Either <em>name</em> or <em>zone_id</em> must be specified to update or patch the collection of records in the specified zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Update a RRSet by adding a new record. This operation replaces DNS records in the specified RRSet with the
+            specified records. So ensure that you include the original RRSet records, if you want to retain existing
+            records.
+      oci_rrset:
+        name: "test_zone_1.com"
+        domain: "test_zone_1.com"
+        rtype: 'TXT'
+        update_items: [ <original zone's TXT records...> , { domain: "test_zone_1.com", ttl: 30, rtype='TXT',
+                        rdata='some textual data' } ]
+
+    - name: Patch a RRSet
+      oci_rrset:
+        name: test_zone1.com
+        domain: "test_zone_1.com"
+        rtype: "TXT"
+        patch_items: [{
+                        domain: "test_zone_1.com",
+                        is_protected: false,
+                        rdata: "some textual data",
+                        rtype: "TXT",
+                        ttl: 30,
+                        operation: "REMOVE"
+                        }]
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>rrset</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful update or patch of the RRSet</td>
+                <td>
+                                            <div>Information about all the DNS records in the RRSet</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'domain': 'test_zone_1.com', 'is_protected': True, 'rrset_version': '1', 'rtype': 'NS', 'ttl': 86400, 'record_hash': '9be3279d81b5e8430fd94c70cfa5f0a8', 'rdata': 'ns2.p68.dns.oraclecloud.net.'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">test_zone_1.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_protected</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rrsetVersion</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">5</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rtype</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NS</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ttl</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">86400</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>record_hash</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">722af089872ffe65ba909fc8fea1867e</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rdata</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ns3.p68.dns.oraclecloud.net.</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_rrset.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_security_list_facts_module.rst
+++ b/docs/modules/oci_security_list_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_security_list_facts:
+:source: cloud/oracle/oci_security_list_facts.py
+
+:orphan:
+
+.. _oci_security_list_facts_module:
 
 
 oci_security_list_facts - Fetches details of a specific Security List or a list of Security Lists in the specified VCN and compartment
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,153 +17,180 @@ oci_security_list_facts - Fetches details of a specific Security List or a list 
 
 Synopsis
 --------
-
-
-* Fetches details of a specific Security List or a list of Security Lists in the specified VCN and compartment.oc
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of a specific Security List or a list of Security Lists in the specified VCN and compartment.oc
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment details about whose Security List must be retrieved</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>security_list_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Security List. Required if the details of a specific Security List details needs to be fetched. Mutually exclusive with compartment_id and vcn_id.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Cloud Network to which the Security List is attached.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment details about whose Security List must be retrieved</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>security_list_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Security List. Required if the details of a specific Security List details needs to be fetched. Mutually exclusive with compartment_id and vcn_id.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Virtual Cloud Network to which the Security List is attached.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -178,155 +206,167 @@ Examples
         id: 'ocid1.securitylist.aa'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>security_lists</td>
-    <td>
-        <div>Attributes of the fetched Security List(s).</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'egress_security_rules': [{'icmp_options': None, 'udp_options': None, 'is_stateless': None, 'tcp_options': None, 'destination': '0.0.0.0/0', 'protocol': 'all'}], 'display_name': 'ansible_security_list_one', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-24T05:33:44.779000+00:00', 'ingress_security_rules': [{'source': '0.0.0.0/0', 'icmp_options': None, 'udp_options': None, 'is_stateless': False, 'tcp_options': {'source_port_range': None, 'destination_port_range': {'max': 22, 'min': 22}}, 'protocol': '6'}, {'source': '0.0.0.0/0', 'icmp_options': {'code': 4, 'type': 3}, 'udp_options': None, 'is_stateless': False, 'tcp_options': None, 'protocol': '1'}, {'source': '10.0.0.0/16', 'icmp_options': {'code': None, 'type': 3}, 'udp_options': None, 'is_stateless': False, 'tcp_options': None, 'protocol': '1'}], 'id': 'ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'AVAILABLE', 'egress_security_rules': [{'icmp_options': None, 'udp_options': None, 'is_stateless': True, 'tcp_options': None, 'destination': '10.0.0.0/8', 'protocol': 'all'}], 'display_name': 'ansible_security_list_two', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'large'}}, 'freeform_tags': {'region': 'west'}, 'time_created': '2017-11-24T05:33:44.779000+00:00', 'ingress_security_rules': [{'source': '0.0.0.0/0', 'icmp_options': None, 'udp_options': None, 'is_stateless': False, 'tcp_options': {'source_port_range': None, 'destination_port_range': {'max': 45, 'min': 50}}, 'protocol': '6'}, {'source': '0.0.0.0/0', 'icmp_options': {'code': 4, 'type': 3}, 'udp_options': None, 'is_stateless': False, 'tcp_options': None, 'protocol': '1'}], 'id': 'ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>vcn_id</td>
-        <td>
-            <div>Identifier of the Virtual Cloud Network to which the Security List is attached.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn..ixcd</td>
-        </tr>
-
-        <tr>
-        <td>egress_security_rules</td>
-        <td>
-            <div>Rules for allowing egress IP packets</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'tcp-options': None, 'protocol': 'all', 'icmp-options': None, 'udp-options': None, 'destination': '0.0.0.0/0', 'is-stateless': None}]</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name assigned to the Security List during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_security_list</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the Security List</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Security List</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Security List was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>ingress_security_rules</td>
-        <td>
-            <div>Rules for allowing ingress IP packets</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'source': '0.0.0.0/0', 'protocol': '6', 'icmp-options': None, 'udp-options': None, 'tcp-options': {'destination-port-range': {'max': 22, 'min': 22}, 'source-port-range': None}, 'is-stateless': None}]</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Security List</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.securitylist.oc1.axdf</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>security_lists</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the fetched Security List(s).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'egress_security_rules': [{'icmp_options': None, 'udp_options': None, 'is_stateless': None, 'tcp_options': None, 'destination': '0.0.0.0/0', 'protocol': 'all'}], 'display_name': 'ansible_security_list_one', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-24T05:33:44.779000+00:00', 'ingress_security_rules': [{'source': '0.0.0.0/0', 'icmp_options': None, 'udp_options': None, 'is_stateless': False, 'tcp_options': {'source_port_range': None, 'destination_port_range': {'max': 22, 'min': 22}}, 'protocol': '6'}, {'source': '0.0.0.0/0', 'icmp_options': {'code': 4, 'type': 3}, 'udp_options': None, 'is_stateless': False, 'tcp_options': None, 'protocol': '1'}, {'source': '10.0.0.0/16', 'icmp_options': {'code': None, 'type': 3}, 'udp_options': None, 'is_stateless': False, 'tcp_options': None, 'protocol': '1'}], 'id': 'ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'AVAILABLE', 'egress_security_rules': [{'icmp_options': None, 'udp_options': None, 'is_stateless': True, 'tcp_options': None, 'destination': '10.0.0.0/8', 'protocol': 'all'}], 'display_name': 'ansible_security_list_two', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'large'}}, 'freeform_tags': {'region': 'west'}, 'time_created': '2017-11-24T05:33:44.779000+00:00', 'ingress_security_rules': [{'source': '0.0.0.0/0', 'icmp_options': None, 'udp_options': None, 'is_stateless': False, 'tcp_options': {'source_port_range': None, 'destination_port_range': {'max': 45, 'min': 50}}, 'protocol': '6'}, {'source': '0.0.0.0/0', 'icmp_options': {'code': 4, 'type': 3}, 'udp_options': None, 'is_stateless': False, 'tcp_options': None, 'protocol': '1'}], 'id': 'ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Virtual Cloud Network to which the Security List is attached.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn..ixcd</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>egress_security_rules</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Rules for allowing egress IP packets</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'tcp-options': None, 'protocol': 'all', 'icmp-options': None, 'udp-options': None, 'destination': '0.0.0.0/0', 'is-stateless': None}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Security List during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_security_list</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the Security List</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Security List</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Security List was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ingress_security_rules</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Rules for allowing ingress IP packets</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'source': '0.0.0.0/0', 'protocol': '6', 'icmp-options': None, 'udp-options': None, 'tcp-options': {'destination-port-range': {'max': 22, 'min': 22}, 'source-port-range': None}, 'is-stateless': None}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Security List</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.securitylist.oc1.axdf</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_security_list_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_security_list_module.rst
+++ b/docs/modules/oci_security_list_module.rst
@@ -1,13 +1,14 @@
-.. _oci_security_list:
+:source: cloud/oracle/oci_security_list.py
+
+:orphan:
+
+.. _oci_security_list_module:
 
 
 oci_security_list - Create,update and delete OCI Security List
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,435 +17,463 @@ oci_security_list - Create,update and delete OCI Security List
 
 Synopsis
 --------
-
-
-* Creates OCI Security List
-* Update OCI Security List, if present, with a new display name
-* Update OCI Security List, if present, with ingress/egress security rules
-* Delete OCI Security List, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Creates OCI Security List
+- Update OCI Security List, if present, with a new display name
+- Update OCI Security List, if present, with ingress/egress security rules
+- Delete OCI Security List, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the compartment under which this security List would be created. Mandatory for create operation.Optional for delete and update. Mutually exclusive with <em>security_list_id</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the Security List. A user friendly name. Does not have to be unique, and could be changed. If not specified, a default name would be provided.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">egress_security_rules<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Rules for allowing egress IP packets.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object egress_security_rules</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which this security List would be created. Mandatory for create operation.Optional for delete and update. Mutually exclusive with <em>security_list_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the Security List. A user friendly name. Does not have to be unique, and could be changed. If not specified, a default name would be provided.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>egress_security_rules</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Rules for allowing egress IP packets.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>icmp_options</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Valid only for ICMP. Use to specify a particular ICMP type and code as defined in <a href='u'https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml''>u'https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml'</a>. If you specify ICMP as the protocol but omit this object, then all ICMP types and codes are allowed. If you do provide this object, the type is required and the code is optional. To enable MTU negotiation for ingress internet traffic, make sure to allow type 3 Destination Unreachable code 4 Fragmentation Needed and Do not Fragment was Set. If you need to specify multiple codes for a single type, create a separate security list rule for each.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>udp_options</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Valid only for UDP. Use to specify particular destination ports for UDP rules. If UDP specified as the protocol but omit this object, then all destination ports are allowed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>is_stateless</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>yes</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>A stateless rule allows traffic in one direction. Remember to add a corresponding stateless rule in the other direction if you need to support bidirectional traffic. For example, if egress traffic allows TCP destination port 80, there should be an ingress rule to allow TCP source port 80. Defaults to false, which means the rule is stateful and a corresponding rule is not necessary for bidirectional traffic.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>tcp_options</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Valid only for TCP. Use to specify particular destination ports for TCP rules. If TCP specified as the protocol but omit this object, then all destination ports are allowed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>destination</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The destination CIDR block for the egress rule. This is the range of IP addresses that a packet originating from the instance can go to.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>protocol</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>1</li>
+                                                                                                                                                                                                <li>6</li>
+                                                                                                                                                                                                <li>17</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specify either all or an IPv4 protocol number as defined in <a href='u'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml''>u'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'</a> Options are supported only for ICMP 1, TCP 6, and UDP 17.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>ingress_security_rules</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Rules for allowing ingress IP packets.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>source</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The source CIDR block for the ingress rule. This is the range of IP addresses that a packet coming into the instance can come from.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>icmp_options</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Valid only for ICMP. Use to specify a particular ICMP type and code as defined in <a href='u'https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml''>u'https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml'</a>. If you specify ICMP as the protocol but omit this object, then all ICMP types and codes are allowed. If you do provide this object, the type is required and the code is optional. To enable MTU negotiation for ingress internet traffic, make sure to allow type 3 Destination Unreachable code 4 Fragmentation Needed and Do not Fragment was Set. If you need to specify multiple codes for a single type, create a separate security list rule for each.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>udp_options</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Valid only for UDP. Use to specify particular destination ports for UDP rules. If UDP specified as the protocol but omit this object, then all destination ports are allowed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>is_stateless</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>yes</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>A stateless rule allows traffic in one direction. Remember to add a corresponding stateless rule in the other direction if you need to support bidirectional traffic. For example, if ingress traffic allows TCP destination port 80, there should be an egress rule to allow TCP source port 80. Defaults to false, which means the rule is stateful and a corresponding rule is not necessary for bidirectional traffic.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>tcp_options</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Valid only for TCP. Use to specify particular destination ports for TCP rules. If TCP specified as the protocol but omit this object, then all destination ports are allowed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>protocol</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>1</li>
+                                                                                                                                                                                                <li>6</li>
+                                                                                                                                                                                                <li>17</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specify either all or an IPv4 protocol number as defined in <a href='u'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml''>u'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'</a> Options are supported only for ICMP 1, TCP 6, and UDP 17.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>purge_security_rules</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Purge security rules  from security list which are not present in the provided group security list. If <em>purge_security_rules=no</em>, provided security rules would be appended to existing security rules.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>security_list_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Security List. Mandatory for delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete Security List. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Cloud Network to which the security List should be attached. Mandatory for create operation. Optional for delete and update. Mutually exclusive with <em>security_list_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>icmp_options<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Valid only for ICMP. Use to specify a particular ICMP type and code as defined in <a href='u'https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml''>u'https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml'</a>. If you specify ICMP as the protocol but omit this object, then all ICMP types and codes are allowed. If you do provide this object, the type is required and the code is optional. To enable MTU negotiation for ingress internet traffic, make sure to allow type 3 Destination Unreachable code 4 Fragmentation Needed and Do not Fragment was Set. If you need to specify multiple codes for a single type, create a separate security list rule for each.</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>udp_options<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Valid only for UDP. Use to specify particular destination ports for UDP rules. If UDP specified as the protocol but omit this object, then all destination ports are allowed.</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        <tr>
-        <td>is_stateless<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>no</td>
-        <td><ul><li>yes</li><li>no</li></ul></td>
-        <td>
-        <div>A stateless rule allows traffic in one direction. Remember to add a corresponding stateless rule in the other direction if you need to support bidirectional traffic. For example, if egress traffic allows TCP destination port 80, there should be an ingress rule to allow TCP source port 80. Defaults to false, which means the rule is stateful and a corresponding rule is not necessary for bidirectional traffic.</div>
-        </td>
-        </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-        <tr>
-        <td>tcp_options<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Valid only for TCP. Use to specify particular destination ports for TCP rules. If TCP specified as the protocol but omit this object, then all destination ports are allowed.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>destination<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The destination CIDR block for the egress rule. This is the range of IP addresses that a packet originating from the instance can go to.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>protocol<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td><ul><li>1</li><li>6</li><li>17</li></ul></td>
-        <td>
-        <div>Specify either all or an IPv4 protocol number as defined in <a href='u'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml''>u'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'</a> Options are supported only for ICMP 1, TCP 6, and UDP 17.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">ingress_security_rules<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Rules for allowing ingress IP packets.</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object ingress_security_rules</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>source<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The source CIDR block for the ingress rule. This is the range of IP addresses that a packet coming into the instance can come from.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>icmp_options<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Valid only for ICMP. Use to specify a particular ICMP type and code as defined in <a href='u'https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml''>u'https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml'</a>. If you specify ICMP as the protocol but omit this object, then all ICMP types and codes are allowed. If you do provide this object, the type is required and the code is optional. To enable MTU negotiation for ingress internet traffic, make sure to allow type 3 Destination Unreachable code 4 Fragmentation Needed and Do not Fragment was Set. If you need to specify multiple codes for a single type, create a separate security list rule for each.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>udp_options<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Valid only for UDP. Use to specify particular destination ports for UDP rules. If UDP specified as the protocol but omit this object, then all destination ports are allowed.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>is_stateless<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>no</td>
-        <td><ul><li>yes</li><li>no</li></ul></td>
-        <td>
-        <div>A stateless rule allows traffic in one direction. Remember to add a corresponding stateless rule in the other direction if you need to support bidirectional traffic. For example, if ingress traffic allows TCP destination port 80, there should be an egress rule to allow TCP source port 80. Defaults to false, which means the rule is stateful and a corresponding rule is not necessary for bidirectional traffic.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>tcp_options<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Valid only for TCP. Use to specify particular destination ports for TCP rules. If TCP specified as the protocol but omit this object, then all destination ports are allowed.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>protocol<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td><ul><li>1</li><li>6</li><li>17</li></ul></td>
-        <td>
-        <div>Specify either all or an IPv4 protocol number as defined in <a href='u'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml''>u'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'</a> Options are supported only for ICMP 1, TCP 6, and UDP 17.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>purge_security_rules<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>yes</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Purge security rules  from security list which are not present in the provided group security list. If <em>purge_security_rules=no</em>, provided security rules would be appended to existing security rules.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>security_list_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Security List. Mandatory for delete and update.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete Security List. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the Virtual Cloud Network to which the security List should be attached. Mandatory for create operation. Optional for delete and update. Mutually exclusive with <em>security_list_id</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -499,155 +528,167 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>security_list</td>
-    <td>
-        <div>Attributes of the created/updated Security List. For delete, deleted Security List description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'egress_security_rules': [{'icmp_options': None, 'udp_options': None, 'is_stateless': None, 'tcp_options': None, 'destination': '0.0.0.0/0', 'protocol': 'all'}], 'display_name': 'ansible_security_list_one', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-24T05:33:44.779000+00:00', 'ingress_security_rules': [{'source': '0.0.0.0/0', 'icmp_options': None, 'udp_options': None, 'is_stateless': False, 'tcp_options': {'source_port_range': None, 'destination_port_range': {'max': 22, 'min': 22}}, 'protocol': '6'}, {'source': '0.0.0.0/0', 'icmp_options': {'code': 4, 'type': 3}, 'udp_options': None, 'is_stateless': False, 'tcp_options': None, 'protocol': '1'}, {'source': '10.0.0.0/16', 'icmp_options': {'code': None, 'type': 3}, 'udp_options': None, 'is_stateless': False, 'tcp_options': None, 'protocol': '1'}], 'id': 'ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>vcn_id</td>
-        <td>
-            <div>Identifier of the Virtual Cloud Network to which the Security List is attached.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn..ixcd</td>
-        </tr>
-
-        <tr>
-        <td>egress_security_rules</td>
-        <td>
-            <div>Rules for allowing egress IP packets</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'icmp_options': None, 'udp_options': None, 'is_stateless': None, 'tcp_options': None, 'destination': '0.0.0.0/0', 'protocol': 'all'}]</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name assigned to the Security List during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_security_list</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the compartment containing the Security List</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the Security List</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the Security List was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>ingress_security_rules</td>
-        <td>
-            <div>Rules for allowing ingress IP packets</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list</td>
-        <td align=center>[{'source': '0.0.0.0/0', 'icmp_options': None, 'udp_options': None, 'is_stateless': None, 'tcp_options': {'source_port_range': None, 'destination_port_range': {'max': 22, 'min': 22}}, 'protocol': '6'}]</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the Security List</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.securitylist.oc1.axdf</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>security_list</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated Security List. For delete, deleted Security List description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'egress_security_rules': [{'icmp_options': None, 'udp_options': None, 'is_stateless': None, 'tcp_options': None, 'destination': '0.0.0.0/0', 'protocol': 'all'}], 'display_name': 'ansible_security_list_one', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'defined_tags': {'features': {'capacity': 'medium'}}, 'freeform_tags': {'region': 'east'}, 'time_created': '2017-11-24T05:33:44.779000+00:00', 'ingress_security_rules': [{'source': '0.0.0.0/0', 'icmp_options': None, 'udp_options': None, 'is_stateless': False, 'tcp_options': {'source_port_range': None, 'destination_port_range': {'max': 22, 'min': 22}}, 'protocol': '6'}, {'source': '0.0.0.0/0', 'icmp_options': {'code': 4, 'type': 3}, 'udp_options': None, 'is_stateless': False, 'tcp_options': None, 'protocol': '1'}, {'source': '10.0.0.0/16', 'icmp_options': {'code': None, 'type': 3}, 'udp_options': None, 'is_stateless': False, 'tcp_options': None, 'protocol': '1'}], 'id': 'ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Virtual Cloud Network to which the Security List is attached.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn..ixcd</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>egress_security_rules</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Rules for allowing egress IP packets</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'icmp_options': None, 'udp_options': None, 'is_stateless': None, 'tcp_options': None, 'destination': '0.0.0.0/0', 'protocol': 'all'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the Security List during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_security_list</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the compartment containing the Security List</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Security List</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Security List was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ingress_security_rules</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Rules for allowing ingress IP packets</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'source': '0.0.0.0/0', 'icmp_options': None, 'udp_options': None, 'is_stateless': None, 'tcp_options': {'source_port_range': None, 'destination_port_range': {'max': 22, 'min': 22}}, 'protocol': '6'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Security List</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.securitylist.oc1.axdf</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_security_list.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_shape_facts_module.rst
+++ b/docs/modules/oci_shape_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_shape_facts:
+:source: cloud/oracle/oci_shape_facts.py
+
+:orphan:
+
+.. _oci_shape_facts_module:
 
 
 oci_shape_facts - Retrieve details about shapes that can be used to launch instances in OCI Compute Service
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,142 +17,159 @@ oci_shape_facts - Retrieve details about shapes that can be used to launch insta
 
 Synopsis
 --------
-
-
-* This module retrieves details about shapes that can be used to launch instances within a specified Compartment in OCI Compute Service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details about shapes that can be used to launch instances within a specified Compartment in OCI Compute Service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the Availability Domain.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the Availability Domain.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the shapes available to a Tenancy
@@ -163,85 +181,69 @@ Examples
         availability_domain: "BnQb:PHX-AD-1"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>shapes</td>
-    <td>
-        <div>Information about one or more shapes available in the specified compartment</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'shape': 'VM.DenseIO1.16'}, {'shape': 'VM.DenseIO1.8'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>shape</td>
-        <td>
-            <div>The name of the shape</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>VM.DenseIO1.16</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>shapes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more shapes available in the specified compartment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'shape': 'VM.DenseIO1.16'}, {'shape': 'VM.DenseIO1.8'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>shape</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the shape</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">VM.DenseIO1.16</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_shape_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_subnet_facts_module.rst
+++ b/docs/modules/oci_subnet_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_subnet_facts:
+:source: cloud/oracle/oci_subnet_facts.py
+
+:orphan:
+
+.. _oci_subnet_facts_module:
 
 
 oci_subnet_facts - Retrieve facts of subnets
 ++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,152 +17,179 @@ oci_subnet_facts - Retrieve facts of subnets
 
 Synopsis
 --------
-
-
-* This module allows the user to retrieve information of the specified subnet or all the subnets in the specified VCN and the specified compartment.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to retrieve information of the specified subnet or all the subnets in the specified VCN and the specified compartment.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. <em>compartment_id</em> is required to retrieve all the subnets in the specified VCN and the specified compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>subnet_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the subnet. <em>subnet_id</em> is required to get a particular subnet's information. Whenever a <em>subnet_id</em> is specified with any other options, information of only the subnet pointed by <em>subnet_id</em> is retrieved.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the VCN. <em>vcn_id</em> is required to retrieve all the subnets in the specified VCN and the specified compartment.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment. <em>compartment_id</em> is required to retrieve all the subnets in the specified VCN and the specified compartment.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>subnet_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the subnet. <em>subnet_id</em> is required to get a particular subnet's information. Whenever a <em>subnet_id</em> is specified with any other options, information of only the subnet pointed by <em>subnet_id</em> is retrieved.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the VCN. <em>vcn_id</em> is required to retrieve all the subnets in the specified VCN and the specified compartment.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get all the subnets in the specified VCN and the specified compartment
@@ -174,235 +202,279 @@ Examples
         subnet_id: ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>subnets</td>
-    <td>
-        <div>List of subnet details</div>
-    </td>
-    <td align=center>always</td>
-    <td align=center>complex</td>
-    <td align=center>[{'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'subnet_domain_name': 'ansiblesubnet.ansiblevcn.oraclevcn.com', 'availability_domain': 'BnQb:PHX-AD-1', 'time_created': '2017-11-16T07:25:47.234000+00:00', 'route_table_id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx', 'cidr_block': '10.0.1.0/24', 'id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx', 'virtual_router_ip': '10.0.2.1', 'lifecycle_state': 'AVAILABLE', 'dns_label': 'ansiblesubnet', 'display_name': 'ansible_subnet', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'security_list_ids': ['ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'], 'prohibit_public_ip_on_vnic': True, 'virtual_router_mac': '00:00:17:D1:27:79', 'dhcp_options_id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>vcn_id</td>
-        <td>
-            <div>The OCID of the VCN the subnet is in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>subnet_domain_name</td>
-        <td>
-            <div>The subnet's domain name, which consists of the subnet's DNS label, the VCN's DNS label, and the oraclevcn.com domain.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansiblesubnet.ansiblevcn.oraclevcn.com</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The subnet's Availability Domain.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BnQb:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the subnet was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-13 20:22:40.626000</td>
-        </tr>
-
-        <tr>
-        <td>route_table_id</td>
-        <td>
-            <div>The OCID of the route table the subnet is using.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>cidr_block</td>
-        <td>
-            <div>The subnet's CIDR block.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>10.0.1.0/24</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>OCID of the subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>virtual_router_ip</td>
-        <td>
-            <div>The IP address of the virtual router.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>10.0.1.1</td>
-        </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The subnet's current state.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>dns_label</td>
-        <td>
-            <div>A DNS label for the subnet, used in conjunction with the VNIC's hostname and VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansiblesubnet</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name of the subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_subnet</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment containing the subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>security_list_ids</td>
-        <td>
-            <div>OCIDs for the security lists to use for VNICs in this subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>list of strings</td>
-        <td align=center>['ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx']</td>
-        </tr>
-
-        <tr>
-        <td>prohibit_public_ip_on_vnic</td>
-        <td>
-            <div>Whether VNICs within this subnet can have public IP addresses. Defaults to false, which means VNICs created in this subnet will automatically be assigned public IP addresses unless specified otherwise during instance launch or VNIC creation (with the assignPublicIp flag in CreateVnicDetails). If prohibitPublicIpOnVnic is set to true, VNICs created in this subnet cannot have public IP addresses (that is, it's a private subnet).</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>True</td>
-        </tr>
-
-        <tr>
-        <td>virtual_router_mac</td>
-        <td>
-            <div>The MAC address of the virtual router.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>00:00:17:D1:27:79</td>
-        </tr>
-
-        <tr>
-        <td>dhcp_options_id</td>
-        <td>
-            <div>The OCID of the set of DHCP options associated with the subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>subnets</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of subnet details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'subnet_domain_name': 'ansiblesubnet.ansiblevcn.oraclevcn.com', 'availability_domain': 'BnQb:PHX-AD-1', 'time_created': '2017-11-16T07:25:47.234000+00:00', 'route_table_id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx', 'cidr_block': '10.0.1.0/24', 'id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx', 'virtual_router_ip': '10.0.2.1', 'lifecycle_state': 'AVAILABLE', 'dns_label': 'ansiblesubnet', 'display_name': 'ansible_subnet', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'security_list_ids': ['ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'], 'prohibit_public_ip_on_vnic': True, 'virtual_router_mac': '00:00:17:D1:27:79', 'dhcp_options_id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VCN the subnet is in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_domain_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The subnet's domain name, which consists of the subnet's DNS label, the VCN's DNS label, and the oraclevcn.com domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansiblesubnet.ansiblevcn.oraclevcn.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The subnet's Availability Domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the subnet was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-13 20:22:40.626000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>route_table_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the route table the subnet is using.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cidr_block</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The subnet's CIDR block.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.0.1.0/24</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>OCID of the subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>virtual_router_ip</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The IP address of the virtual router.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.0.1.1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The subnet's current state.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>dns_label</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A DNS label for the subnet, used in conjunction with the VNIC's hostname and VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansiblesubnet</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_subnet</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>security_list_ids</b>
+                    <br/><div style="font-size: small; color: red">list of strings</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>OCIDs for the security lists to use for VNICs in this subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>prohibit_public_ip_on_vnic</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether VNICs within this subnet can have public IP addresses. Defaults to false, which means VNICs created in this subnet will automatically be assigned public IP addresses unless specified otherwise during instance launch or VNIC creation (with the assignPublicIp flag in CreateVnicDetails). If prohibitPublicIpOnVnic is set to true, VNICs created in this subnet cannot have public IP addresses (that is, it's a private subnet).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>virtual_router_mac</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The MAC address of the virtual router.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">00:00:17:D1:27:79</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>dhcp_options_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the set of DHCP options associated with the subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_subnet_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_subnet_module.rst
+++ b/docs/modules/oci_subnet_module.rst
@@ -1,13 +1,14 @@
-.. _oci_subnet:
+:source: cloud/oracle/oci_subnet.py
+
+:orphan:
+
+.. _oci_subnet_module:
 
 
 oci_subnet - Manage subnets in a VCN in OCI
 +++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,314 +17,348 @@ oci_subnet - Manage subnets in a VCN in OCI
 
 Synopsis
 --------
-
-
-* This module allows the user to create, delete and update subnets in a VCN in OCI.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create, delete and update subnets in a VCN in OCI.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Availability Domain to contain the subnet. Required when creating a subnet with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cidr_block</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The CIDR IP address range of the subnet. Required when creating a subnet with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment to contain the subnet. Required when creating a subnet with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>dhcp_options_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the set of DHCP options the subnet will use. If you don't provide a value, the subnet will use the VCN's default set of DHCP options.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>dns_label</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A DNS label for the subnet, used in conjunction with the VNIC's hostname and VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet (for example, bminstance-1.subnet123.vcn1.oraclevcn.com). Must be an alphanumeric string that begins with a letter and is unique within the VCN. The value cannot be changed. This value must be set if you want to use the Internet and VCN Resolver to resolve the hostnames of instances in the subnet. It can only be set if the VCN itself was created with a DNS label.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>prohibit_public_ip_on_vnic</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether VNICs within this subnet can have public IP addresses. If <em>prohibit_public_ip_on_vnic=false</em>, VNICs created in this subnet will automatically be assigned public IP addresses unless specified otherwise during instance launch or VNIC creation (with the assignPublicIp flag in CreateVnicDetails). If <em>prohibit_public_ip_on_vnic=true</em>, VNICs created in this subnet cannot have public IP addresses (that is, it's a private subnet).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>route_table_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the route table the subnet will use. If you don't provide a value, the subnet will use the VCN's default route table.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>security_list_ids</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>List of OCIDs of security lists to associate with the subnet. If you don't provide a value, the VCN's default security list will be associated with the subnet. Remember that security lists are associated at the subnet level, but the rules are applied to the individual VNICs in the subnet.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a subnet with <em>state=present</em>. Delete a subnet with <em>state=absent</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>subnet_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the subnet. Required when deleting a subnet with <em>state=absent</em> or updating a subnet with <em>state=present</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the VCN to contain the subnet. Required when creating a subnet with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Availability Domain to contain the subnet. Required when creating a subnet with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>cidr_block<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The CIDR IP address range of the subnet. Required when creating a subnet with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment to contain the subnet. Required when creating a subnet with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>dhcp_options_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the set of DHCP options the subnet will use. If you don't provide a value, the subnet will use the VCN's default set of DHCP options.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>dns_label<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A DNS label for the subnet, used in conjunction with the VNIC's hostname and VCN's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet (for example, bminstance-1.subnet123.vcn1.oraclevcn.com). Must be an alphanumeric string that begins with a letter and is unique within the VCN. The value cannot be changed. This value must be set if you want to use the Internet and VCN Resolver to resolve the hostnames of instances in the subnet. It can only be set if the VCN itself was created with a DNS label.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>prohibit_public_ip_on_vnic<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether VNICs within this subnet can have public IP addresses. If <em>prohibit_public_ip_on_vnic=false</em>, VNICs created in this subnet will automatically be assigned public IP addresses unless specified otherwise during instance launch or VNIC creation (with the assignPublicIp flag in CreateVnicDetails). If <em>prohibit_public_ip_on_vnic=true</em>, VNICs created in this subnet cannot have public IP addresses (that is, it's a private subnet).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>route_table_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the route table the subnet will use. If you don't provide a value, the subnet will use the VCN's default route table.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>security_list_ids<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>List of OCIDs of security lists to associate with the subnet. If you don't provide a value, the VCN's default security list will be associated with the subnet. Remember that security lists are associated at the subnet level, but the rules are applied to the individual VNICs in the subnet.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create or update a subnet with <em>state=present</em>. Delete a subnet with <em>state=absent</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>subnet_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the subnet. Required when deleting a subnet with <em>state=absent</em> or updating a subnet with <em>state=present</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the VCN to contain the subnet. Required when creating a subnet with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a subnet
@@ -345,58 +380,54 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>subnet</td>
-    <td>
-        <div>Information about the subnet</div>
-    </td>
-    <td align=center>On successful create and update operation</td>
-    <td align=center>dict</td>
-    <td align=center>{'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'subnet_domain_name': 'ansiblesubnet.ansiblevcn.oraclevcn.com', 'availability_domain': 'BnQb:PHX-AD-1', 'time_created': '2017-11-16T03:05:50.992000+00:00', 'route_table_id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx', 'cidr_block': '10.0.1.0/24', 'id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx', 'virtual_router_ip': '10.0.1.1', 'lifecycle_state': 'AVAILABLE', 'dns_label': 'ansiblesubnet', 'display_name': 'ansible_subnet', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'security_list_ids': ['ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'], 'prohibit_public_ip_on_vnic': True, 'virtual_router_mac': '00:00:17:D1:27:79', 'dhcp_options_id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>subnet</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful create and update operation</td>
+                <td>
+                                            <div>Information about the subnet</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'vcn_id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'subnet_domain_name': 'ansiblesubnet.ansiblevcn.oraclevcn.com', 'availability_domain': 'BnQb:PHX-AD-1', 'time_created': '2017-11-16T03:05:50.992000+00:00', 'route_table_id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx', 'cidr_block': '10.0.1.0/24', 'id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx', 'virtual_router_ip': '10.0.1.1', 'lifecycle_state': 'AVAILABLE', 'dns_label': 'ansiblesubnet', 'display_name': 'ansible_subnet', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'security_list_ids': ['ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'], 'prohibit_public_ip_on_vnic': True, 'virtual_router_mac': '00:00:17:D1:27:79', 'dhcp_options_id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_subnet.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_swift_password_facts_module.rst
+++ b/docs/modules/oci_swift_password_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_swift_password_facts:
+:source: cloud/oracle/oci_swift_password_facts.py
+
+:orphan:
+
+.. _oci_swift_password_facts_module:
 
 
 oci_swift_password_facts - Retrieve details of swift passwords for a specified user
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,160 @@ oci_swift_password_facts - Retrieve details of swift passwords for a specified u
 
 Synopsis
 --------
-
-
-* This module retrieves details of swift passwords of a specified user. The returned object contains the swift password's OCID, but not the password itself. The actual password is returned only upon creation of a swift password using the :ref:`oci_swift_password <oci_swift_password>` module.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details of swift passwords of a specified user. The returned object contains the swift password's OCID, but not the password itself. The actual password is returned only upon creation of a swift password using the :ref:`oci_swift_password <oci_swift_password_module>` module.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>swift_password_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the swift password. Required when facts about a specific swift password for the specified user needs to be obtained.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>user_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>swift_password_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the swift password. Required when facts about a specific swift password for the specified user needs to be obtained.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>user_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the swift passwords of the specified user
@@ -165,145 +183,151 @@ Examples
         id: "ocid1.credential.oc1..xxxxxEXAMPLExxxxx"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>swift_passwords</td>
-    <td>
-        <div>Information about one or more swift passwords in the specified user</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>{'swift_passwords': [{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'description': 'My first swift password description', 'time_created': '2018-01-03T13:15:53.082000+00:00', 'password': None, 'id': 'ocid1.credential.oc1..xxxxxEXAMPLExxxxx', 'expires_on': None}]}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The password's current state.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>inactive_status</td>
-        <td>
-            <div>The detailed status of INACTIVE lifecycleState.</div>
-        </td>
-        <td align=center>only when the I(lifecycle_state) is 'INACTIVE'</td>
-        <td align=center>string</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>user_id</td>
-        <td>
-            <div>The OCID of the user the password belongs to.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.user.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The description that was assigned to the Swift password.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>My first swift password description</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the Swift password.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.credential.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time the SwiftPassword object was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>expires_on</td>
-        <td>
-            <div>Date and time when this password will expire, in the format defined by RFC3339. Null if it never expires.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>swift_passwords</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more swift passwords in the specified user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'swift_passwords': [{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'description': 'My first swift password description', 'time_created': '2018-01-03T13:15:53.082000+00:00', 'password': None, 'id': 'ocid1.credential.oc1..xxxxxEXAMPLExxxxx', 'expires_on': None}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The password's current state.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>only when the <em>lifecycle_state</em> is 'INACTIVE'</td>
+                <td>
+                                            <div>The detailed status of INACTIVE lifecycleState.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>user_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the user the password belongs to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.user.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description that was assigned to the Swift password.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My first swift password description</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the Swift password.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.credential.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time the SwiftPassword object was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>expires_on</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when this password will expire, in the format defined by RFC3339. Null if it never expires.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_swift_password_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_swift_password_module.rst
+++ b/docs/modules/oci_swift_password_module.rst
@@ -1,13 +1,14 @@
-.. _oci_swift_password:
+:source: cloud/oracle/oci_swift_password.py
+
+:orphan:
+
+.. _oci_swift_password_module:
 
 
 oci_swift_password - Create, update and delete Swift (OpenStack Object Store Service) passwords in OCI
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,183 +17,208 @@ oci_swift_password - Create, update and delete Swift (OpenStack Object Store Ser
 
 Synopsis
 --------
-
-
-* This module allows the user to create, update and delete Swift passwords in OCI. Swift is the OpenStack object storage service. A SwiftPassword is an Oracle-provided password for using a Swift client with the Oracle Cloud Infrastructure Object Storage Service. This password is associated with the user's Console login. Swift passwords never expire. A user can have up to two Swift passwords at a time. Note: The password is always an Oracle-generated string; you can't change it to a string of your choice.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create, update and delete Swift passwords in OCI. Swift is the OpenStack object storage service. A SwiftPassword is an Oracle-provided password for using a Swift client with the Oracle Cloud Infrastructure Object Storage Service. This password is associated with the user's Console login. Swift passwords never expire. A user can have up to two Swift passwords at a time. Note: The password is always an Oracle-generated string; you can't change it to a string of your choice.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>description</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The description you assign to the Swift password during creation. Does not have to be unique, and it's changeable. Required when creating a swift password. The length of the description must be between 1 and 400 characters.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The state of the swift password that must be asserted to. When <em>state=present</em>, and the swift password doesn't exist, the swift password is created. When <em>state=absent</em>, the swift password is deleted.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>swift_password_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the swift password. Required when the password's description needs to be updated with <em>state=present</em> and for deleting a swift password with <em>state=absent</em></div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>user_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>description<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The description you assign to the Swift password during creation. Does not have to be unique, and it's changeable. Required when creating a swift password. The length of the description must be between 1 and 400 characters.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>The state of the swift password that must be asserted to. When <em>state=present</em>, and the swift password doesn't exist, the swift password is created. When <em>state=absent</em>, the swift password is deleted.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>swift_password_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the swift password. Required when the password's description needs to be updated with <em>state=present</em> and for deleting a swift password with <em>state=absent</em></div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>user_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a new swift password
@@ -213,58 +239,54 @@ Examples
             state: "absent"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>oci_swift_password</td>
-    <td>
-        <div>Details of the Swift password</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>dict</td>
-    <td align=center>{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'description': 'My first swift password description', 'time_created': '2018-01-03T12:47:25.759000+00:00', 'password': '+)UWHJK8UMgMvo5Qv!md', 'id': 'ocid1.credential.oc1..xxxxxEXAMPLExxxxx', 'expires_on': None}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>oci_swift_password</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>Details of the Swift password</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'ACTIVE', 'inactive_status': None, 'user_id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'description': 'My first swift password description', 'time_created': '2018-01-03T12:47:25.759000+00:00', 'password': '+)UWHJK8UMgMvo5Qv!md', 'id': 'ocid1.credential.oc1..xxxxxEXAMPLExxxxx', 'expires_on': None}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_swift_password.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_tag_facts_module.rst
+++ b/docs/modules/oci_tag_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_tag_facts:
+:source: cloud/oracle/oci_tag_facts.py
+
+:orphan:
+
+.. _oci_tag_facts_module:
 
 
 oci_tag_facts - Retrieve details of tag key definitions for a specified tag namespace in OCI
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,160 @@ oci_tag_facts - Retrieve details of tag key definitions for a specified tag name
 
 Synopsis
 --------
-
-
-* This module retrieves details of all tag key definitions of a specified tag namespace, or a specific tag key definition in OCI.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details of all tag key definitions of a specified tag namespace, or a specific tag key definition in OCI.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tag_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the tag, whose details must be retrieved</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tag_namespace_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the tag namespace whose tag definitions must be retrieved</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tag_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the tag, whose details must be retrieved</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tag_namespace_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the tag namespace whose tag definitions must be retrieved</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the tag key definitions of the specified tag namespace
@@ -165,135 +183,137 @@ Examples
         name: "CostCenter"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>tags</td>
-    <td>
-        <div>Information about one or more tag key definitions</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>{'tags': [{'description': 'This tag will show the cost center that will be used for billing of resources.', 'compartment_id': None, 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-01-16T04:55:22.600000+00:00', 'is_retired': False, 'id': 'ocid1.tagdefinition.oc1..xxxxxEXAMPLExxxxx', 'name': 'CostCenter'}]}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The description that was assigned to the tag key definition.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>This tag will show the cost center that will be used for billing of resources.</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the tag definition.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>is_retired</td>
-        <td>
-            <div>Whether the tag key definition is retired.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>True</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the tag key definition.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.tagdefinition.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time the Tag key definition object was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name of the tag. The name must be unique across all tags in the namespace and can't be changed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>CostCenter</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>tags</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more tag key definitions</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'tags': [{'description': 'This tag will show the cost center that will be used for billing of resources.', 'compartment_id': None, 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-01-16T04:55:22.600000+00:00', 'is_retired': False, 'id': 'ocid1.tagdefinition.oc1..xxxxxEXAMPLExxxxx', 'name': 'CostCenter'}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description that was assigned to the tag key definition.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">This tag will show the cost center that will be used for billing of resources.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the tag definition.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_retired</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether the tag key definition is retired.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the tag key definition.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.tagdefinition.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time the Tag key definition object was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the tag. The name must be unique across all tags in the namespace and can't be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CostCenter</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_tag_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_tag_module.rst
+++ b/docs/modules/oci_tag_module.rst
@@ -1,13 +1,14 @@
-.. _oci_tag:
+:source: cloud/oracle/oci_tag.py
+
+:orphan:
+
+.. _oci_tag_module:
 
 
 oci_tag - Create, retire and reactivate tag key definitions in OCI
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,173 +17,198 @@ oci_tag - Create, retire and reactivate tag key definitions in OCI
 
 Synopsis
 --------
-
-
-* This module allows the user to create, retire and reactivate tag key definitions in OCI. A key definition defines the schema of a tag and includes a namespace, tag key, and tag value type. Currently the only tag value type supported is "string", and hence is not specified during creation. Defined tag keys are case insensitive. However note that defined tag values are case sensitive.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create, retire and reactivate tag key definitions in OCI. A key definition defines the schema of a tag and includes a namespace, tag key, and tag value type. Currently the only tag value type supported is "string", and hence is not specified during creation. Defined tag keys are case insensitive. However note that defined tag values are case sensitive.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>description</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A description to be associated with the tag definition during creation. This does not have to be unique, and can be changed later. Required when creating a tag definition with <em>state=present</em> The length of the description must be between 1 and 400 characters.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>reactivate</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether a retired tag definition needs to be reactivated</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The state of the tag key definition that must be asserted to. When <em>state=present</em>, and the tag definition doesn't exist, the tag definition is created. When <em>state=absent</em>, the tag namespace is retired. To reactivate a retired tag key definition, use <em>reactivate=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tag_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name assigned to the tag key definition during creation. It must be unique across all tags in the specified tag namespace and cannot be changed. All ascii characters are allowed except spaces and dots. Note that names are case insenstive, that means you can not have two different tags with same name but with different casing in one tag namespace.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tag_namespace_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the tag namespace that will contain this tag key definition.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>description<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A description to be associated with the tag definition during creation. This does not have to be unique, and can be changed later. Required when creating a tag definition with <em>state=present</em> The length of the description must be between 1 and 400 characters.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>reactivate<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether a retired tag definition needs to be reactivated</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>The state of the tag key definition that must be asserted to. When <em>state=present</em>, and the tag definition doesn't exist, the tag definition is created. When <em>state=absent</em>, the tag namespace is retired. To reactivate a retired tag key definition, use <em>reactivate=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tag_name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name assigned to the tag key definition during creation. It must be unique across all tags in the specified tag namespace and cannot be changed. All ascii characters are allowed except spaces and dots. Note that names are case insenstive, that means you can not have two different tags with same name but with different casing in one tag namespace.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tag_namespace_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the tag namespace that will contain this tag key definition.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a new tag key definition
@@ -210,58 +236,54 @@ Examples
         reactivate: "yes"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>tag</td>
-    <td>
-        <div>Details of the tag key definition</div>
-    </td>
-    <td align=center>On successful create or update of a tag key definition</td>
-    <td align=center>dict</td>
-    <td align=center>{'tag_namespace_id': 'ocid1.tagnamespace.oc1..xxxxxEXAMPLExxxxx', 'description': 'This tag will show the cost center that will be used for billing of resources.', 'compartment_id': None, 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-01-16T04:55:22.600000+00:00', 'tag_namespace_name': None, 'is_retired': False, 'id': 'ocid1.tagdefinition.oc1..xxxxxEXAMPLExxxxx', 'name': 'CostCenter'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>tag</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful create or update of a tag key definition</td>
+                <td>
+                                            <div>Details of the tag key definition</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'tag_namespace_id': 'ocid1.tagnamespace.oc1..xxxxxEXAMPLExxxxx', 'description': 'This tag will show the cost center that will be used for billing of resources.', 'compartment_id': None, 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-01-16T04:55:22.600000+00:00', 'tag_namespace_name': None, 'is_retired': False, 'id': 'ocid1.tagdefinition.oc1..xxxxxEXAMPLExxxxx', 'name': 'CostCenter'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_tag.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_tag_namespace_facts_module.rst
+++ b/docs/modules/oci_tag_namespace_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_tag_namespace_facts:
+:source: cloud/oracle/oci_tag_namespace_facts.py
+
+:orphan:
+
+.. _oci_tag_namespace_facts_module:
 
 
 oci_tag_namespace_facts - Retrieve details of tag namespaces for a specified compartment or tenancy in OCI
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,170 @@ oci_tag_namespace_facts - Retrieve details of tag namespaces for a specified com
 
 Synopsis
 --------
-
-
-* This module retrieves details of tag namespaces of a specified tenancy or compartment in OCI.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details of tag namespaces of a specified tenancy or compartment in OCI.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment whose tag namespaces must be retrieved. To get the tag namespaces of the tenancy, provide the tenancy's root compartment OCID as the <em>compartment_id</em></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tag_namespace_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of a tag namespace for which details must be retrieved. Required when facts about a specific tag namespace needs to be obtained.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment whose tag namespaces must be retrieved. To get the tag namespaces of the tenancy, provide the tenancy's root compartment OCID as the <em>compartment_id</em></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tag_namespace_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of a tag namespace for which details must be retrieved. Required when facts about a specific tag namespace needs to be obtained.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the tag namespaces of the specified user
@@ -164,135 +192,139 @@ Examples
         id: "ocid1.namespace.oc1..xxxxxEXAMPLExxxxx"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>tag_namespaces</td>
-    <td>
-        <div>Information about one or more tag namespaces in the specified user</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>{'tag_namespaces': [{'name': 'BillingTags', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-01-15T17:36:10.388000+00:00', 'is_retired': False, 'id': 'ocid1.tagnamespace.oc1..xxxxxEXAMPLExxxxx', 'description': 'This namespace contains tags that will be used in billing.'}]}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The description that was assigned to the tag namespace.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>This namespace contains tags that will be used in billing.</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the tag namespace.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>is_retired</td>
-        <td>
-            <div>Whether the tag namespace is retired.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>True</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the tag namespace.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.tagnamespace.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time the tag namespace object was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name of the tag namespace. It must be unique across all tag namespaces in the tenancy and cannot be changed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BillingTags</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>tag_namespaces</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more tag namespaces in the specified user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'tag_namespaces': [{'name': 'BillingTags', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-01-15T17:36:10.388000+00:00', 'is_retired': False, 'id': 'ocid1.tagnamespace.oc1..xxxxxEXAMPLExxxxx', 'description': 'This namespace contains tags that will be used in billing.'}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description that was assigned to the tag namespace.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">This namespace contains tags that will be used in billing.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the tag namespace.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_retired</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether the tag namespace is retired.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the tag namespace.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.tagnamespace.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time the tag namespace object was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the tag namespace. It must be unique across all tag namespaces in the tenancy and cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BillingTags</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_tag_namespace_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_tag_namespace_module.rst
+++ b/docs/modules/oci_tag_namespace_module.rst
@@ -1,13 +1,14 @@
-.. _oci_tag_namespace:
+:source: cloud/oracle/oci_tag_namespace.py
+
+:orphan:
+
+.. _oci_tag_namespace_module:
 
 
 oci_tag_namespace - Create, retire and reactivate tag namespaces in OCI
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,223 +17,252 @@ oci_tag_namespace - Create, retire and reactivate tag namespaces in OCI
 
 Synopsis
 --------
-
-
-* This module allows the user to create, retire and reactivate tag namespaces in OCI. A tag namespace is a container for tag keys. It consists of a name, and zero or more tag key definitions. Tag namespaces are not case sensitive, and must be unique across the tenancy.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create, retire and reactivate tag namespaces in OCI. A tag namespace is a container for tag keys. It consists of a name, and zero or more tag key definitions. Tag namespaces are not case sensitive, and must be unique across the tenancy.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment containing the tag namespace (the compartment may also be the root compartment of the Tenancy). Required for creating a tag namespace with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>description</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A description to be associated with the tag namespace during creation. This does not have to be unique, and can be changed later. Required when creating a tag namespace with <em>state=present</em> The length of the description must be between 1 and 400 characters.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name assigned to the tag namespace during creation. It must be unique across all tag namespaces in the tenancy and cannot be changed. All ascii characters are allowed except spaces and dots. Note that names are case insenstive, that means you can not have two different namespaces with same name but with different casing in one tenancy. Required when a tag namespace is created using <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>reactivate</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether a retired tag namespace needs to be reactivated</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The state of the tag namespace that must be asserted to. When <em>state=present</em>, and the tag namespace doesn't exist, the tag namespace is created. When <em>state=absent</em>, the tag namespace is retired. To reactivate a retired tag namespace, use <em>reactivate=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tag_namespace_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the tag namespace. Required when the tag namespace must be retired or reactivated.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment containing the tag namespace (the compartment may also be the root compartment of the Tenancy). Required for creating a tag namespace with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>description<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A description to be associated with the tag namespace during creation. This does not have to be unique, and can be changed later. Required when creating a tag namespace with <em>state=present</em> The length of the description must be between 1 and 400 characters.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name assigned to the tag namespace during creation. It must be unique across all tag namespaces in the tenancy and cannot be changed. All ascii characters are allowed except spaces and dots. Note that names are case insenstive, that means you can not have two different namespaces with same name but with different casing in one tenancy. Required when a tag namespace is created using <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>reactivate<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>no</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether a retired tag namespace needs to be reactivated</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>The state of the tag namespace that must be asserted to. When <em>state=present</em>, and the tag namespace doesn't exist, the tag namespace is created. When <em>state=absent</em>, the tag namespace is retired. To reactivate a retired tag namespace, use <em>reactivate=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tag_namespace_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the tag namespace. Required when the tag namespace must be retired or reactivated.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a new tag namespace
@@ -257,58 +287,54 @@ Examples
         reactivate: "yes"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>tag_namespace</td>
-    <td>
-        <div>Details of the tag namespace</div>
-    </td>
-    <td align=center>On successful create or update of a tag namespace</td>
-    <td align=center>dict</td>
-    <td align=center>{'description': 'This namespace contains tags that will be used in billing.', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-01-15T17:36:10.388000+00:00', 'is_retired': False, 'id': 'ocid1.tagnamespace.oc1..xxxxxEXAMPLExxxxx', 'name': 'BillingTags'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>tag_namespace</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful create or update of a tag namespace</td>
+                <td>
+                                            <div>Details of the tag namespace</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'description': 'This namespace contains tags that will be used in billing.', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'defined_tags': {}, 'freeform_tags': {}, 'time_created': '2018-01-15T17:36:10.388000+00:00', 'is_retired': False, 'id': 'ocid1.tagnamespace.oc1..xxxxxEXAMPLExxxxx', 'name': 'BillingTags'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_tag_namespace.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_tenancy_facts_module.rst
+++ b/docs/modules/oci_tenancy_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_tenancy_facts:
+:source: cloud/oracle/oci_tenancy_facts.py
+
+:orphan:
+
+.. _oci_tenancy_facts_module:
 
 
 oci_tenancy_facts - Retrieve details about a tenancy in Oracle Cloud Infrastructure
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,227 +17,137 @@ oci_tenancy_facts - Retrieve details about a tenancy in Oracle Cloud Infrastruct
 
 Synopsis
 --------
-
-
-* This module retrieves details about a tenancy in Oracle Cloud Infrastructure.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details about a tenancy in Oracle Cloud Infrastructure.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the tenancy for which details needs to be retrieved</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    - name: Get details of the specified tenancy
-      oci_tenancy_facts:
-        id: "ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx...o244pucq"
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>tenancy</td>
-    <td>
-        <div>Information about the specified tenancy</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>{'home_region_key': None, 'id': 'ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx...o244pucq', 'name': 'acme-corp', 'description': &quot;Acme Corp's tenancy&quot;}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the tenancy.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx...o244pucq</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The description of the tenancy.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Acme corp's tenancy</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>The name of the tenancy.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Acme corp</td>
-        </tr>
-
-        <tr>
-        <td>home_region_key</td>
-        <td>
-            <div>The region key for the tenancy's home region.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IAD</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the tenancy for which details needs to be retrieved</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -246,19 +157,122 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Sivakumar Thyagarajan (@sivakumart)
+.. code-block:: yaml+jinja
+
+    
+    - name: Get details of the specified tenancy
+      oci_tenancy_facts:
+        id: "ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx...o244pucq"
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>tenancy</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about the specified tenancy</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'home_region_key': None, 'id': 'ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx...o244pucq', 'name': 'acme-corp', 'description': &quot;Acme Corp's tenancy&quot;}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the tenancy.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx...o244pucq</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description of the tenancy.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Acme corp's tenancy</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the tenancy.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Acme corp</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>home_region_key</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The region key for the tenancy's home region.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IAD</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_tenancy_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_user_facts_module.rst
+++ b/docs/modules/oci_user_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_user_facts:
+:source: cloud/oracle/oci_user_facts.py
+
+:orphan:
+
+.. _oci_user_facts_module:
 
 
 oci_user_facts - Fetches details of all the OCI users of a tenancy and their group memberships
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,133 +17,160 @@ oci_user_facts - Fetches details of all the OCI users of a tenancy and their gro
 
 Synopsis
 --------
-
-
-* Fetches details of all the OCI users of a tenancy and the group memberships.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Fetches details of all the OCI users of a tenancy and the group memberships.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>user_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the user id whose details should be fetched</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>user_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the user id whose details should be fetched</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     #Fetch users filtered by user id
@@ -155,155 +183,167 @@ Examples
       oci_user_facts:
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>users</td>
-    <td>
-        <div>Attributes of the existing users.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'name': 'ansible_user', 'compartment_id': 'ocidv1:tenancy:oc1:arz:1461274726633:aa', 'defined_tags': {'department': {'division': 'engineering'}}, 'freeform_tags': {'user_type': 'admin'}, 'time_created': '2017-11-04T14:45:27.358000+00:00', 'member_of_groups': [{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'description': 'Group Two', 'compartment_id': 'ocidv1:tenancy:oc1:arz:146:aaa', 'defined_tags': {'product': {'type': 'server'}}, 'freeform_tags': {'group_name': 'designer'}, 'time_created': '2017-06-22T13:55:21.077000+00:00', 'id': 'ocid1.group.oc1..xxxxxEXAMPLExxxxx', 'name': 'group_two'}, {'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'description': 'Group One', 'compartment_id': 'ocidv1:tenancy:oc1:arz:145', 'defined_tags': {'product': {'type': 'server'}}, 'freeform_tags': {'group_name': 'documentation'}, 'time_created': '2016-12-20T20:29:12.093000+00:00', 'id': 'ocid1.group.oc1..xxxxxEXAMPLExxxxx', 'name': 'group_one'}], 'id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'description': 'Ansible User'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the user</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>inactive_status</td>
-        <td>
-            <div>The detailed status of INACTIVE life cycle state</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The description assigned to the user</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Ansible User</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the tenancy containing the user</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.tenancy.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the user was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>member_of_groups</td>
-        <td>
-            <div>The details of the groups the user has memberships in</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>[{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'description': 'Group Two', 'compartment_id': 'ocidv1:tenancy:oc1:arz:146:aaa', 'id': 'ocid1.group.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-06-22T13:55:21.077000+00:00', 'name': 'group_two'}]</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the user</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.user.oc1.axdf</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name assigned to the user during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_user</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>users</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the existing users.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'name': 'ansible_user', 'compartment_id': 'ocidv1:tenancy:oc1:arz:1461274726633:aa', 'defined_tags': {'department': {'division': 'engineering'}}, 'freeform_tags': {'user_type': 'admin'}, 'time_created': '2017-11-04T14:45:27.358000+00:00', 'member_of_groups': [{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'description': 'Group Two', 'compartment_id': 'ocidv1:tenancy:oc1:arz:146:aaa', 'defined_tags': {'product': {'type': 'server'}}, 'freeform_tags': {'group_name': 'designer'}, 'time_created': '2017-06-22T13:55:21.077000+00:00', 'id': 'ocid1.group.oc1..xxxxxEXAMPLExxxxx', 'name': 'group_two'}, {'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'description': 'Group One', 'compartment_id': 'ocidv1:tenancy:oc1:arz:145', 'defined_tags': {'product': {'type': 'server'}}, 'freeform_tags': {'group_name': 'documentation'}, 'time_created': '2016-12-20T20:29:12.093000+00:00', 'id': 'ocid1.group.oc1..xxxxxEXAMPLExxxxx', 'name': 'group_one'}], 'id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'description': 'Ansible User'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when user's lifecycle_state is INACTIVE</td>
+                <td>
+                                            <div>The detailed status of INACTIVE life cycle state</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">None</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description assigned to the user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Ansible User</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the tenancy containing the user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.tenancy.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the user was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>member_of_groups</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The details of the groups the user has memberships in</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'description': 'Group Two', 'compartment_id': 'ocidv1:tenancy:oc1:arz:146:aaa', 'id': 'ocid1.group.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2017-06-22T13:55:21.077000+00:00', 'name': 'group_two'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.user.oc1.axdf</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the user during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_user</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_user_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_user_module.rst
+++ b/docs/modules/oci_user_module.rst
@@ -1,13 +1,14 @@
-.. _oci_user:
+:source: cloud/oracle/oci_user.py
+
+:orphan:
+
+.. _oci_user_module:
 
 
 oci_user - Create,update and delete OCI user with specified group associations
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,271 +17,313 @@ oci_user - Create,update and delete OCI user with specified group associations
 
 Synopsis
 --------
-
-
-* Creates OCI user, if not present, without any group associations
-* Creates OCI user, if not present, with ui password
-* Creates OCI user, if not present, with specified group associations
-* Update OCI user, if present, with a new description
-* Update OCI user, if present, with new group(s) associations
-* Update OCI user, if present, removing all group associations
-* Update OCI user, if present, and reset the ui password of the user
-* Unblock a blocked user
-* Delete OCI user, if present.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- Creates OCI user, if not present, without any group associations
+- Creates OCI user, if not present, with ui password
+- Creates OCI user, if not present, with specified group associations
+- Update OCI user, if present, with a new description
+- Update OCI user, if present, with new group(s) associations
+- Update OCI user, if present, removing all group associations
+- Update OCI user, if present, and reset the ui password of the user
+- Unblock a blocked user
+- Delete OCI user, if present.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>blocked</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>yes</li>
+                                                                                                                                                                                                <li>no</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Change the state of an blocked user to unblocked.Only applied on existing blocked user. If the user is already unblocked, then <em>blocked=no</em> will not change the state. <em>blocked=yes</em> is not supported in this version.If the value is not specified explicitly, no action should be taken.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>create_or_reset_ui_password</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create UI password for an user who has no UI password or reset password of an user having UI password.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>description</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Description of the user. The value could be an empty string. If not provided explicitly while creating an user, the value defaults to an empty string. Not required for <em>state=absent</em></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>If <em>force='no'</em> and if the user is part of a group, user will not be deleted. To delete a user associated with group(s), use <em>state=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Name of the user. Must be unique for a tenancy.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>purge_group_memberships</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Purge groups from existing memberships which are not present in provided group memberships. If <em>purge_group_memberships=False</em>, provided groups would be appended to existing group memberships.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete user. For <em>state=present</em>, if the user does not exists, it gets created. If exists, it gets updated.. For <em>state=absent</em>, user gets deleted.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>user_groups</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>List of groups to which the user should be associated  with.The specified groups must exist while running this task. If a specified group does not exist, this task would fail.If a user already exists, and their current group associations are different from the specified group associations, the task would change the user to ensure that the group associations of the user reflect the specified group associations.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>user_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the User. Mandatory for delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>blocked<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Change the state of an blocked user to unblocked.Only applied on existing blocked user. If the user is already unblocked, then <em>blocked=no</em> will not change the state. <em>blocked=yes</em> is not supported in this version.If the value is not specified explicitly, no action should be taken.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>create_or_reset_ui_password<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Create UI password for an user who has no UI password or reset password of an user having UI password.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>description<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Description of the user. The value could be an empty string. If not provided explicitly while creating an user, the value defaults to an empty string. Not required for <em>state=absent</em></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>If <em>force='no'</em> and if the user is part of a group, user will not be deleted. To delete a user associated with group(s), use <em>state=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Name of the user. Must be unique for a tenancy.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>purge_group_memberships<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Purge groups from existing memberships which are not present in provided group memberships. If <em>purge_group_memberships=False</em>, provided groups would be appended to existing group memberships.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create,update or delete user. For <em>state=present</em>, if the user does not exists, it gets created. If exists, it gets updated.. For <em>state=absent</em>, user gets deleted.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>user_groups<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>List of groups to which the user should be associated  with.The specified groups must exist while running this task. If a specified group does not exist, this task would fail.If a user already exists, and their current group associations are different from the specified group associations, the task would change the user to ensure that the group associations of the user reflect the specified group associations.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>user_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Identifier of the User. Mandatory for delete and update.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     # Note: These examples do not set authentication details.
@@ -351,155 +394,167 @@ Examples
 
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>user</td>
-    <td>
-        <div>Attributes of the created/updated user. For delete, deleted user description will be returned.</div>
-    </td>
-    <td align=center>success</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'description': 'Ansible User', 'compartment_id': 'ocidv1:tenancy:oc1:arz:1461274726633:aa', 'defined_tags': {'department': {'division': 'engineering'}}, 'freeform_tags': {'user_type': 'admin'}, 'time_created': '2017-11-04T14:45:27.358000+00:00', 'password': 'PJ+p&gt;u1&amp;u', 'id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'name': 'ansible_user'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the user</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ACTIVE</td>
-        </tr>
-
-        <tr>
-        <td>inactive_status</td>
-        <td>
-            <div>The detailed status of INACTIVE life cycle state</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>None</td>
-        </tr>
-
-        <tr>
-        <td>description</td>
-        <td>
-            <div>The description assigned to the user</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Ansible User</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The identifier of the tenancy containing the user</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.tenancy.oc1.xzvf..oifds</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>Date and time when the user was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>password</td>
-        <td>
-            <div>The ui password of the user</div>
-        </td>
-        <td align=center>when I(create_or_reset_ui_password=True) and a new user created and when I(create_or_reset_ui_password=True) and new user created or an existing user is updated</td>
-        <td align=center>string</td>
-        <td align=center>_09erf4</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>Identifier of the user</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.user.oc1.axdf</td>
-        </tr>
-
-        <tr>
-        <td>name</td>
-        <td>
-            <div>Name assigned to the user during creation</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_user</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Debayan Gupta(@debayan_gupta)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>user</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created/updated user. For delete, deleted user description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'ACTIVE', 'inactive_status': 'None', 'description': 'Ansible User', 'compartment_id': 'ocidv1:tenancy:oc1:arz:1461274726633:aa', 'defined_tags': {'department': {'division': 'engineering'}}, 'freeform_tags': {'user_type': 'admin'}, 'time_created': '2017-11-04T14:45:27.358000+00:00', 'password': 'PJ+p&gt;u1&amp;u', 'id': 'ocid1.user.oc1..xxxxxEXAMPLExxxxx', 'name': 'ansible_user'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when user's lifecycle_state is INACTIVE</td>
+                <td>
+                                            <div>The detailed status of INACTIVE life cycle state</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">None</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The description assigned to the user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Ansible User</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The identifier of the tenancy containing the user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.tenancy.oc1.xzvf..oifds</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the user was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>password</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when <em>create_or_reset_ui_password=True</em> and a new user created and when <em>create_or_reset_ui_password=True</em> and new user created or an existing user is updated</td>
+                <td>
+                                            <div>The ui password of the user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">_09erf4</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the user</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.user.oc1.axdf</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name assigned to the user during creation</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_user</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_user.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_vcn_facts_module.rst
+++ b/docs/modules/oci_vcn_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_vcn_facts:
+:source: cloud/oracle/oci_vcn_facts.py
+
+:orphan:
+
+.. _oci_vcn_facts_module:
 
 
 oci_vcn_facts - Retrieve facts of Virtual Cloud Networks(VCNs)
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,310 +17,156 @@ oci_vcn_facts - Retrieve facts of Virtual Cloud Networks(VCNs)
 
 Synopsis
 --------
-
-
-* This module retrieves information of a specified virtual cloud network(VCN) or lists all the VCNs in the specified compartment.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves information of a specified virtual cloud network(VCN) or lists all the VCNs in the specified compartment.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment. <em>compartment_id</em> is required to get all the VCNs in the compartment.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the VCN. <em>vcn_id</em> is required to get a specific VCN's information.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    - name: Get all the VCNs in a compartment
-      oci_vcn_facts:
-        compartment_id: 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx'
-
-    - name: Get a specific VCN
-      oci_vcn_facts:
-        vcn_id: ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>vcns</td>
-    <td>
-        <div>List of VCN details</div>
-    </td>
-    <td align=center>always</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'dns_label': 'ansiblevcn', 'display_name': 'ansible_vcn', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'default_dhcp_options_id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx', 'time_created': '2017-11-13T20:22:40.626000+00:00', 'vcn_domain_name': 'ansiblevcn.oraclevcn.com', 'default_security_list_id': 'ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx', 'cidr_block': '10.0.0.0/16', 'id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'default_route_table_id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>Current state of the VCN.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>dns_label</td>
-        <td>
-            <div>A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS                         label to form a fully qualified domain name (FQDN) for each VNIC within this subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansiblevcn</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name of the VCN.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_vcn</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment containing the VCN.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>default_dhcp_options_id</td>
-        <td>
-            <div>The OCID for the VCN's default set of DHCP options.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the VCN was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-13 20:22:40.626000</td>
-        </tr>
-
-        <tr>
-        <td>vcn_domain_name</td>
-        <td>
-            <div>The VCN's domain name, which consists of the VCN's DNS label, and the oraclevcn.com domain.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansiblevcn.oraclevcn.com</td>
-        </tr>
-
-        <tr>
-        <td>default_security_list_id</td>
-        <td>
-            <div>The OCID for the VCN's default security list.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>cidr_block</td>
-        <td>
-            <div>The CIDR IP address block of the VCN.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>10.0.0.0/16</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>OCID of the VCN.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>default_route_table_id</td>
-        <td>
-            <div>The OCID for the VCN's default route table.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. <em>compartment_id</em> is required to get all the VCNs in the compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the VCN. <em>vcn_id</em> is required to get a specific VCN's information.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -329,19 +176,229 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Rohit Chaware (@rohitChaware)
+.. code-block:: yaml+jinja
+
+    
+    - name: Get all the VCNs in a compartment
+      oci_vcn_facts:
+        compartment_id: 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx'
+
+    - name: Get a specific VCN using its OCID
+      oci_vcn_facts:
+        vcn_id: ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx
+
+    - name: Get VCNs in a compartment having the specified display name
+      oci_vcn_facts:
+        compartment_id: 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx'
+        display_name: 'oci_ansible_vcn'
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>vcns</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of VCN details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'dns_label': 'ansiblevcn', 'display_name': 'ansible_vcn', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'default_dhcp_options_id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx', 'time_created': '2017-11-13T20:22:40.626000+00:00', 'vcn_domain_name': 'ansiblevcn.oraclevcn.com', 'default_security_list_id': 'ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx', 'cidr_block': '10.0.0.0/16', 'id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'default_route_table_id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Current state of the VCN.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>dns_label</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS                         label to form a fully qualified domain name (FQDN) for each VNIC within this subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansiblevcn</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the VCN.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_vcn</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the VCN.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>default_dhcp_options_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID for the VCN's default set of DHCP options.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the VCN was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-13 20:22:40.626000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vcn_domain_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The VCN's domain name, which consists of the VCN's DNS label, and the oraclevcn.com domain.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansiblevcn.oraclevcn.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>default_security_list_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID for the VCN's default security list.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cidr_block</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The CIDR IP address block of the VCN.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.0.0.0/16</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>OCID of the VCN.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>default_route_table_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID for the VCN's default route table.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_vcn_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_vcn_module.rst
+++ b/docs/modules/oci_vcn_module.rst
@@ -1,13 +1,14 @@
-.. _oci_vcn:
+:source: cloud/oracle/oci_vcn.py
+
+:orphan:
+
+.. _oci_vcn_module:
 
 
 oci_vcn - Manage Virtual Cloud Networks(VCN) in OCI
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,254 +17,284 @@ oci_vcn - Manage Virtual Cloud Networks(VCN) in OCI
 
 Synopsis
 --------
-
-
-* This module allows the user to create, delete and update virtual cloud networks(VCNs) in OCI.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create, delete and update virtual cloud networks(VCNs) in OCI.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cidr_block</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The CIDR IP address block of the VCN. Required when creating a VCN with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment to contain the VCN. Required when creating a VCN with <em>state=present</em>. This option is mutually exclusive with <em>vcn_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it's changeable.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>dns_label</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet (for example, bminstance-1.subnet123.vcn1.oraclevcn.com). Not required to be unique, but it's a best practice to set unique DNS labels for VCNs in your tenancy. Must be an alphanumeric string that begins with a letter. The value cannot be changed.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a VCN with <em>state=present</em>. Use <em>state=absent</em> to delete a VCN.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vcn_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the VCN. Required when deleting a VCN with <em>state=absent</em> or updating a VCN with <em>state=present</em>. This option is mutually exclusive with <em>compartment_id</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>cidr_block<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The CIDR IP address block of the VCN. Required when creating a VCN with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment to contain the VCN. Required when creating a VCN with <em>state=present</em>. This option is mutually exclusive with <em>vcn_id</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name. Does not have to be unique, and it's changeable.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>dns_label<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet (for example, bminstance-1.subnet123.vcn1.oraclevcn.com). Not required to be unique, but it's a best practice to set unique DNS labels for VCNs in your tenancy. Must be an alphanumeric string that begins with a letter. The value cannot be changed.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create or update a VCN with <em>state=present</em>. Use <em>state=absent</em> to delete a VCN.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vcn_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the VCN. Required when deleting a VCN with <em>state=absent</em> or updating a VCN with <em>state=present</em>. This option is mutually exclusive with <em>compartment_id</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a VCN
@@ -284,58 +315,54 @@ Examples
         state: absent
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>vcn</td>
-    <td>
-        <div>Information about the VCN</div>
-    </td>
-    <td align=center>On successful create and update operation</td>
-    <td align=center>dict</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'dns_label': 'ansiblevcn', 'display_name': 'ansible_vcn', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'default_dhcp_options_id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx', 'time_created': '2017-11-13T20:22:40.626000+00:00', 'vcn_domain_name': 'ansiblevcn.oraclevcn.com', 'default_security_list_id': 'ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx', 'cidr_block': '10.0.0.0/16', 'id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'default_route_table_id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>vcn</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful create and update operation</td>
+                <td>
+                                            <div>Information about the VCN</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'dns_label': 'ansiblevcn', 'display_name': 'ansible_vcn', 'default_route_table_id': 'ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx', 'default_dhcp_options_id': 'ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx', 'time_created': '2017-11-13T20:22:40.626000+00:00', 'vcn_domain_name': 'ansiblevcn.oraclevcn.com', 'compartment_id&quot;': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'cidr_block': '10.0.0.0/16', 'id': 'ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx', 'default_security_list_id': 'ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_vcn.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_vnic_attachment_facts_module.rst
+++ b/docs/modules/oci_vnic_attachment_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_vnic_attachment_facts:
+:source: cloud/oracle/oci_vnic_attachment_facts.py
+
+:orphan:
+
+.. _oci_vnic_attachment_facts_module:
 
 
 oci_vnic_attachment_facts - Retrieve details about one or more VNIC attachments in the specified compartment
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,163 +17,190 @@ oci_vnic_attachment_facts - Retrieve details about one or more VNIC attachments 
 
 Synopsis
 --------
-
-
-* This module retrieves details about a VNIC attachment, or all VNIC attachments in a specified Compartment in OCI Compute Service. A VNIC attachment resides in the same compartment as the attached instance.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details about a VNIC attachment, or all VNIC attachments in a specified Compartment in OCI Compute Service. A VNIC attachment resides in the same compartment as the attached instance.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the Availability Domain.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy). Required for retrieving information about all VNIC attachments in a Compartment/Tenancy, or a compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>instance_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the instance to which a VNIC attachment is attached to. Required for retrieving information about all VNIC attachments of a compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vnic_attachment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the VNIC attachment. Required for retrieving information about a specific VNIC attachment</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the Availability Domain.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment (either the tenancy or another compartment in the tenancy). Required for retrieving information about all VNIC attachments in a Compartment/Tenancy, or a compute instance.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instance_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the instance to which a VNIC attachment is attached to. Required for retrieving information about all VNIC attachments of a compute instance.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vnic_attachment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the VNIC attachment. Required for retrieving information about a specific VNIC attachment</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get details of all the VNIC attachments in a specified compartment
@@ -189,185 +217,205 @@ Examples
         id: 'ocid1.vnic.oc1..xxxxxEXAMPLExxxxx...vm62asdaxq'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>vnic_attachments</td>
-    <td>
-        <div>Information about one or more VNIC attachments</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'DETACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'sec_vnic_1_for_my_instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...wbvm62xq', 'subnet_id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...smpqpaoa', 'time_created': '2017-11-26T16:24:35.487000+00:00', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx...qkwr6q', 'vnic_id': 'ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...v2beqa', 'vlan_tag': 41, 'id': 'ocid1.vnicattachment.oc1.phx.xxxxxEXAMPLExxxxx...b3momq'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the VNIC attachment</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ATTACHED</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain of the instance</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Uocm:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name for the image. It does not have to be unique, and it's changeable.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>sec-vnic1-to-instance1</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment  the VNIC attachment is in, which is the same compartment the instance is in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...vm62xq'</td>
-        </tr>
-
-        <tr>
-        <td>subnet_id</td>
-        <td>
-            <div>The OCID of the VNIC's subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...5iddusmpqpaoa</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the image was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-20 04:52:54.541000</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the VNIC attachment</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...asdadv3qca</td>
-        </tr>
-
-        <tr>
-        <td>instance_id</td>
-        <td>
-            <div>The OCID of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx...asdgrrv3qca</td>
-        </tr>
-
-        <tr>
-        <td>vnic_id</td>
-        <td>
-            <div>The OCID of the VNIC. Available after the attachment process is complete.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx...5iddusmpqpasdadsaoa</td>
-        </tr>
-
-        <tr>
-        <td>vlan_tag</td>
-        <td>
-            <div>The Oracle-assigned VLAN tag of the attached VNIC. Available after the attachment process is complete.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>0</td>
-        </tr>
-
-        <tr>
-        <td>nic_index</td>
-        <td>
-            <div>The physical network interface card (NIC) the VNIC is using in a bare metal instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>0</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>vnic_attachments</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about one or more VNIC attachments</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'DETACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'sec_vnic_1_for_my_instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...wbvm62xq', 'subnet_id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...smpqpaoa', 'time_created': '2017-11-26T16:24:35.487000+00:00', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx...qkwr6q', 'vnic_id': 'ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...v2beqa', 'vlan_tag': 41, 'id': 'ocid1.vnicattachment.oc1.phx.xxxxxEXAMPLExxxxx...b3momq'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the VNIC attachment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the instance</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Uocm:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name for the image. It does not have to be unique, and it's changeable.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">sec-vnic1-to-instance1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment  the VNIC attachment is in, which is the same compartment the instance is in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...vm62xq'</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VNIC's subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...5iddusmpqpaoa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the image was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-20 04:52:54.541000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VNIC attachment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...asdadv3qca</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx...asdgrrv3qca</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vnic_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VNIC. Available after the attachment process is complete.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vcn.oc1.phx.xxxxxEXAMPLExxxxx...5iddusmpqpasdadsaoa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vlan_tag</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Oracle-assigned VLAN tag of the attached VNIC. Available after the attachment process is complete.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>nic_index</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The physical network interface card (NIC) the VNIC is using in a bare metal instance.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_vnic_attachment_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_vnic_attachment_module.rst
+++ b/docs/modules/oci_vnic_attachment_module.rst
@@ -1,13 +1,14 @@
-.. _oci_vnic_attachment:
+:source: cloud/oracle/oci_vnic_attachment.py
+
+:orphan:
+
+.. _oci_vnic_attachment_module:
 
 
 oci_vnic_attachment - Create a secondary VNIC and attach it to a compute instance, detach or delete VNIC attachments from a compute instance.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,314 +17,331 @@ oci_vnic_attachment - Create a secondary VNIC and attach it to a compute instanc
 
 Synopsis
 --------
-
-
-* This module allows the user to create a secondary VNIC and attach it to a compute instance, detach a secondary VNIC attachment from a compute instance, and delete the secondary VNIC.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to create a secondary VNIC and attach it to a compute instance, detach a secondary VNIC attachment from a compute instance, and delete the secondary VNIC.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name to be associated with the VNIC attachment. This does not have to be unique, and can be changed later.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instance_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the instance to which the secondary VNIC must be attached. Required when a secondary VNIC needs to be created and attached to an instance with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>nic_index<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Specifies the physical network interface card (NIC) the VNIC will use. Defaults to 0. Certain bare metal instance shapes have two active physical NICs (0 and 1). When a secondary VNIC is added to one of these instances, the NIC that the VNIC will use can be specified using <code>nic_index</code>. This option may be specified while creating a VNIC and attaching to an instance using <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>The state of the VNIC attachment that must be asserted to. When <em>state=present</em>, and the VNIC attachment doesn't exist, the secondary VNIC is created with the specified details, and is attached to the specified compute instance. When <em>state=absent</em>, the secondary VNIC is detached from the compute instance and deleted.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td rowspan="2">vnic<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Details for creating a new secondary VNIC. This option must be specified when a secondary VNIC needs to be created and associated with an instance using <em>state=present</em>.</div>
-        </br><div style="font-size: small;">aliases: create_vnic_details</div>
-    </tr>
-
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object vnic</b></caption>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name to be associated with the VNIC attachment. This does not have to be unique, and can be changed later.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>instance_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the instance to which the secondary VNIC must be attached. Required when a secondary VNIC needs to be created and attached to an instance with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>nic_index</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Specifies the physical network interface card (NIC) the VNIC will use. Defaults to 0. Certain bare metal instance shapes have two active physical NICs (0 and 1). When a secondary VNIC is added to one of these instances, the NIC that the VNIC will use can be specified using <code>nic_index</code>. This option may be specified while creating a VNIC and attaching to an instance using <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The state of the VNIC attachment that must be asserted to. When <em>state=present</em>, and the VNIC attachment doesn't exist, the secondary VNIC is created with the specified details, and is attached to the specified compute instance. When <em>state=absent</em>, the secondary VNIC is detached from the compute instance and deleted.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>vnic</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Details for creating a new secondary VNIC. This option must be specified when a secondary VNIC needs to be created and associated with an instance using <em>state=present</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: create_vnic_details</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A user-friendly name for the VNIC. Does not have to be unique.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>hostname_label</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The hostname for the VNIC's primary private IP. Used for DNS. The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>subnet_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCID of the subnet to create the VNIC in.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>skip_source_dest_check</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                                                                <b>Default:</b><br/><div style="color: blue">no</div>
+                                    </td>
+                                                                <td>
+                                            <div>Determines whether the source/destination check is disabled on the VNIC. Defaults to false, which means the check is performed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>private_ip</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The private IP to assign to the VNIC. Must be an available IP address within the subnet's CIDR. If you don't specify a value, Oracle automatically assigns a private IP address from the subnet. This is the VNIC's primary private IP address.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>assign_public_ip</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Determines whether the secondary VNIC should be assigned a public IP address.  If not set and the VNIC is being created in a private subnet (that is, where <em>prohibitPublicIpOnVnic = true</em> in the Subnet), then no public IP address is assigned. If not set and the subnet is public <em>prohibitPublicIpOnVnic = false</em>, then a public IP address is assigned. If set to true and <em>prohibitPublicIpOnVnic = true</em>, an error is returned.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>vnic_attachment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the VNIC attachment. Required when a secondary VNIC needs to be detached from a compute instance and deleted using <em>state=absent</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-        <tr>
-        <td>display_name<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>A user-friendly name for the VNIC. Does not have to be unique.</div>
-        </td>
-        </tr>
 
-        <tr>
-        <td>hostname_label<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The hostname for the VNIC's primary private IP. Used for DNS. The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
-        </td>
-        </tr>
+Notes
+-----
 
-        <tr>
-        <td>subnet_id<br/><div style="font-size: small;"></div></td>
-        <td>yes</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The OCID of the subnet to create the VNIC in.</div>
-        </td>
-        </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-        <tr>
-        <td>defined_tags<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>skip_source_dest_check<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Determines whether the source/destination check is disabled on the VNIC. Defaults to false, which means the check is performed.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>private_ip<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The private IP to assign to the VNIC. Must be an available IP address within the subnet's CIDR. If you don't specify a value, Oracle automatically assigns a private IP address from the subnet. This is the VNIC's primary private IP address.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>assign_public_ip<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>Determines whether the secondary VNIC should be assigned a public IP address.  If not set and the VNIC is being created in a private subnet (that is, where <em>prohibitPublicIpOnVnic = true</em> in the Subnet), then no public IP address is assigned. If not set and the subnet is public <em>prohibitPublicIpOnVnic = false</em>, then a public IP address is assigned. If set to true and <em>prohibitPublicIpOnVnic = true</em>, an error is returned.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vnic_attachment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the VNIC attachment. Required when a secondary VNIC needs to be detached from a compute instance and deleted using <em>state=absent</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a new secondary VNIC and attach it to the specified compute instance
@@ -342,175 +360,195 @@ Examples
             state: "absent"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>vnic_attachment</td>
-    <td>
-        <div>Details of the VNIC attachment</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'DETACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'sec_vnic_1_for_my_instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...m62xq', 'subnet_id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...mpqpaoa', 'time_created': '2017-11-26T16:24:35.487000+00:00', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx...qkwr6q', 'vnic_id': 'ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...mv2beqa', 'vlan_tag': 41, 'id': 'ocid1.vnicattachment.oc1.phx.xxxxxEXAMPLExxxxx...3momq'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the VNIC attachment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>DETACHED</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Uocm:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name. Does not have to be unique.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>sec_vnic1_for_my_instance</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment the VNIC attachment is in, which is the same compartment the instance is in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...m62xq</td>
-        </tr>
-
-        <tr>
-        <td>subnet_id</td>
-        <td>
-            <div>The OCID of the VNIC's subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...mpqpaoa</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the VNIC attachment was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-26 16:24:35.487000</td>
-        </tr>
-
-        <tr>
-        <td>instance_id</td>
-        <td>
-            <div>The OCID of the instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx...qkwr6q</td>
-        </tr>
-
-        <tr>
-        <td>vnic_id</td>
-        <td>
-            <div>The OCID of the VNIC. Available after the attachment process is complete.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...mv2beqa</td>
-        </tr>
-
-        <tr>
-        <td>vlan_tag</td>
-        <td>
-            <div>The Oracle-assigned VLAN tag of the attached VNIC. Available after the attachment process is complete.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>41</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the VNIC attachment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnicattachment.oc1.phx.xxxxxEXAMPLExxxxx...3momq</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>vnic_attachment</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>Details of the VNIC attachment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'DETACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'sec_vnic_1_for_my_instance', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...m62xq', 'subnet_id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...mpqpaoa', 'time_created': '2017-11-26T16:24:35.487000+00:00', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx...qkwr6q', 'vnic_id': 'ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...mv2beqa', 'vlan_tag': 41, 'id': 'ocid1.vnicattachment.oc1.phx.xxxxxEXAMPLExxxxx...3momq'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the VNIC attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">DETACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Uocm:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">sec_vnic1_for_my_instance</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment the VNIC attachment is in, which is the same compartment the instance is in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...m62xq</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VNIC's subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...mpqpaoa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the VNIC attachment was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-26 16:24:35.487000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx...qkwr6q</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vnic_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VNIC. Available after the attachment process is complete.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...mv2beqa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>vlan_tag</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Oracle-assigned VLAN tag of the attached VNIC. Available after the attachment process is complete.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">41</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VNIC attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnicattachment.oc1.phx.xxxxxEXAMPLExxxxx...3momq</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_vnic_attachment.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_vnic_facts_module.rst
+++ b/docs/modules/oci_vnic_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_vnic_facts:
+:source: cloud/oracle/oci_vnic_facts.py
+
+:orphan:
+
+.. _oci_vnic_facts_module:
 
 
 oci_vnic_facts - Retrieve details about a specific VNIC
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,317 +17,137 @@ oci_vnic_facts - Retrieve details about a specific VNIC
 
 Synopsis
 --------
-
-
-* This module retrieves details about a specific VNIC.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves details about a specific VNIC.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vnic_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the VNIC. Required for retrieving information about a specific VNIC attachment.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-
-Examples
---------
-
- ::
-
-    
-    - name: Get details of a specific VNIC
-      oci_vnic_facts:
-        id: 'ocid1.vnic.oc1..xxxxxEXAMPLExxxxx...vm62xq'
-
-
-Return Values
--------------
-
-Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
-
-.. raw:: html
-
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>vnic</td>
-    <td>
-        <div>Information about a specific VNIC</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'my-vnic-1', 'hostname_label': 'myhostname-1', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...lwbvm62xq', 'subnet_id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...dusmpqpaoa', 'is_primary': True, 'time_created': '2017-11-26T16:23:29.932000+00:00', 'public_ip': None, 'skip_source_dest_check': False, 'private_ip': '10.0.0.10', 'mac_address': '00:00:17:00:6C:A2', 'id': 'ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...u7ybd56p6a'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the VNIC.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain of the VNIC</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>Uocm:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name for the image. It does not have to be unique, and it's changeable.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>my-vnic1</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment containing the VNIC</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...vm62xq'</td>
-        </tr>
-
-        <tr>
-        <td>hostname_label</td>
-        <td>
-            <div>The hostname for the VNIC's primary private IP. Used for DNS. The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>my-host-1</td>
-        </tr>
-
-        <tr>
-        <td>subnet_id</td>
-        <td>
-            <div>The OCID of the subnet the VNIC is in.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...pbf7yux45iddusmpqpaoa</td>
-        </tr>
-
-        <tr>
-        <td>is_primary</td>
-        <td>
-            <div>Whether the VNIC is the primary VNIC</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>boolean</td>
-        <td align=center>True</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the image was created, in the format defined by RFC3339</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-11-20 04:52:54.541000</td>
-        </tr>
-
-        <tr>
-        <td>public_ip</td>
-        <td>
-            <div>The public IP address of the VNIC, if one is assigned.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>10.1.2.3</td>
-        </tr>
-
-        <tr>
-        <td>skip_source_dest_check</td>
-        <td>
-            <div>Whether the source/destination check is disabled on the VNIC. Defaults to false, which means the check is performed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>True</td>
-        </tr>
-
-        <tr>
-        <td>private_ip</td>
-        <td>
-            <div>The private IP address of the primary privateIp object on the VNIC. The address is within the CIDR of the VNIC's subnet.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>10.0.3.3</td>
-        </tr>
-
-        <tr>
-        <td>mac_address</td>
-        <td>
-            <div>The MAC address of the VNIC.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>00:00:17:B6:4D:DD</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the VNIC</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...asdadv3qca</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vnic_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the VNIC. Required for retrieving information about a specific VNIC attachment.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
 
 
 Notes
@@ -336,19 +157,248 @@ Notes
     - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
 
-Author
-~~~~~~
+Examples
+--------
 
-    * Sivakumar Thyagarajan (@sivakumart)
+.. code-block:: yaml+jinja
+
+    
+    - name: Get details of a specific VNIC
+      oci_vnic_facts:
+        id: 'ocid1.vnic.oc1..xxxxxEXAMPLExxxxx...vm62xq'
 
 
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>vnic</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>Information about a specific VNIC</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'my-vnic-1', 'hostname_label': 'myhostname-1', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...lwbvm62xq', 'subnet_id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...dusmpqpaoa', 'is_primary': True, 'time_created': '2017-11-26T16:23:29.932000+00:00', 'public_ip': None, 'skip_source_dest_check': False, 'private_ip': '10.0.0.10', 'mac_address': '00:00:17:00:6C:A2', 'id': 'ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...u7ybd56p6a'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the VNIC.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the VNIC</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Uocm:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name for the image. It does not have to be unique, and it's changeable.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">my-vnic1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the VNIC</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...vm62xq'</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>hostname_label</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The hostname for the VNIC's primary private IP. Used for DNS. The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">my-host-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>subnet_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the subnet the VNIC is in.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...pbf7yux45iddusmpqpaoa</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_primary</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether the VNIC is the primary VNIC</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the image was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-20 04:52:54.541000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>public_ip</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The public IP address of the VNIC, if one is assigned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.1.2.3</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>skip_source_dest_check</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether the source/destination check is disabled on the VNIC. Defaults to false, which means the check is performed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>private_ip</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The private IP address of the primary privateIp object on the VNIC. The address is within the CIDR of the VNIC's subnet.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.0.3.3</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>mac_address</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The MAC address of the VNIC.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">00:00:17:B6:4D:DD</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the VNIC</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...asdadv3qca</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_vnic_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_vnic_module.rst
+++ b/docs/modules/oci_vnic_module.rst
@@ -1,13 +1,14 @@
-.. _oci_vnic:
+:source: cloud/oracle/oci_vnic.py
+
+:orphan:
+
+.. _oci_vnic_module:
 
 
 oci_vnic - Update a VNIC
 ++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,174 +17,198 @@ oci_vnic - Update a VNIC
 
 Synopsis
 --------
-
-
-* This module allows the user to update a specified VNIC. To create a primary VNIC, use oci_instance. To create a secondary VNIC and attach it to an instance, use oci_vnic_attachment.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to update a specified VNIC. To create a primary VNIC, use oci_instance. To create a secondary VNIC and attach it to an instance, use oci_vnic_attachment.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>hostname_label</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The hostname for the VNIC's primary private IP. Used for DNS. The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name for the VNIC. Does not have to be unique, and it is changeable.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: display_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>skip_source_dest_check</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Determines whether the source/destination check is disabled on the VNIC. Defaults to false, which means the check is performed.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The state of the VNIC that must be asserted to. When <em>state=present</em>, the VNIC is updated</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>vnic_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the VNIC. Required when a VNIC needs to be updated.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>hostname_label<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The hostname for the VNIC's primary private IP. Used for DNS. The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name for the VNIC. Does not have to be unique, and it is changeable.</div>
-        </br><div style="font-size: small;">aliases: display_name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>skip_source_dest_check<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Determines whether the source/destination check is disabled on the VNIC. Defaults to false, which means the check is performed.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li></ul></td>
-    <td>
-        <div>The state of the VNIC that must be asserted to. When <em>state=present</em>, the VNIC is updated</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>vnic_id<br/><div style="font-size: small;"></div></td>
-    <td>yes</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the VNIC. Required when a VNIC needs to be updated.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Update the specified VNIC with a new name
@@ -197,58 +222,54 @@ Examples
         hostname_label: "newhostname"
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>vnic</td>
-    <td>
-        <div>Details of the VNIC attachment</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>dict</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'my_test_secondary_vnic_name_mod', 'hostname_label': 'ansible-test-45-1', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...lwbvm62xq', 'subnet_id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...smpqpaoa', 'is_primary': False, 'time_created': '2017-11-26T16:24:39.642000+00:00', 'public_ip': None, 'skip_source_dest_check': False, 'private_ip': '10.0.0.11', 'mac_address': '00:00:17:00:BC:6A', 'id': 'ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...2beqa'}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Sivakumar Thyagarajan (@sivakumart)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>vnic</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>Details of the VNIC attachment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'my_test_secondary_vnic_name_mod', 'hostname_label': 'ansible-test-45-1', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...lwbvm62xq', 'subnet_id': 'ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...smpqpaoa', 'is_primary': False, 'time_created': '2017-11-26T16:24:39.642000+00:00', 'public_ip': None, 'skip_source_dest_check': False, 'private_ip': '10.0.0.11', 'mac_address': '00:00:17:00:BC:6A', 'id': 'ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...2beqa'}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_vnic.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_volume_attachment_facts_module.rst
+++ b/docs/modules/oci_volume_attachment_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_volume_attachment_facts:
+:source: cloud/oracle/oci_volume_attachment_facts.py
+
+:orphan:
+
+.. _oci_volume_attachment_facts_module:
 
 
 oci_volume_attachment_facts - Retrieve facts of volume attachments in OCI
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,163 +17,190 @@ oci_volume_attachment_facts - Retrieve facts of volume attachments in OCI
 
 Synopsis
 --------
-
-
-* This module retrieves information of a specified volume attachment or all the volume attachments in a specified compartment.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves information of a specified volume attachment or all the volume attachments in a specified compartment.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. Required to get information of all the volume attachments in a specific compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>instance_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the instance. Use <em>instance_id</em> with <em>compartment_id</em> to get volume attachment information related to <em>instance_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>volume_attachment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the volume attachment. Required to get information of a specific volume attachment.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>volume_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the volume. Use <em>volume_id</em> with <em>compartment_id</em> to get volume attachment information related to <em>volume_id</em>.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment. Required to get information of all the volume attachments in a specific compartment.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instance_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the instance. Use <em>instance_id</em> with <em>compartment_id</em> to get volume attachment information related to <em>instance_id</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>volume_attachment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the volume attachment. Required to get information of a specific volume attachment.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>volume_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the volume. Use <em>volume_id</em> with <em>compartment_id</em> to get volume attachment information related to <em>volume_id</em>.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get information of all volume attachments in a compartment
@@ -194,215 +222,251 @@ Examples
         volume_attachment_id: ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>volume_attachments</td>
-    <td>
-        <div>List of information about volume attachments</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'ATTACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'ansible_volume_attachment', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-11-23T11:17:50.139000+00:00', 'id': 'ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:472a085d-41a9-4c18-ae7d-dea5b296dad3', 'ipv4': '169.254.2.2', 'volume_id': 'ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of the volume attachment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ATTACHED</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain of an instance.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>BnQb:PHX-AD-1</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>My volume attachment</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>chap_username</td>
-        <td>
-            <div>The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the volume was created, in the format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2016-08-25 21:10:29.600000</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the volume attachment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>instance_id</td>
-        <td>
-            <div>The OCID of the instance the volume is attached to.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>iqn</td>
-        <td>
-            <div>The target volume's iSCSI Qualified Name in the format defined by RFC 3720.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9</td>
-        </tr>
-
-        <tr>
-        <td>ipv4</td>
-        <td>
-            <div>The volume's iSCSI IP address.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>169.254.0.2</td>
-        </tr>
-
-        <tr>
-        <td>volume_id</td>
-        <td>
-            <div>The OCID of the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>attachment_type</td>
-        <td>
-            <div>The type of volume attachment.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>iscsi</td>
-        </tr>
-
-        <tr>
-        <td>port</td>
-        <td>
-            <div>The volume's iSCSI port.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>3260</td>
-        </tr>
-
-        <tr>
-        <td>chap_secret</td>
-        <td>
-            <div>The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the &quot;CHAP password&quot;.)</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>d6866c0d-298b-48ba-95af-309b4faux45e</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>volume_attachments</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>List of information about volume attachments</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ATTACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'ansible_volume_attachment', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-11-23T11:17:50.139000+00:00', 'id': 'ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:472a085d-41a9-4c18-ae7d-dea5b296dad3', 'ipv4': '169.254.2.2', 'volume_id': 'ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of an instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_username</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the instance the volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>iqn</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The target volume's iSCSI Qualified Name in the format defined by RFC 3720.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ipv4</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI IP address.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">169.254.0.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>attachment_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iscsi</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume's iSCSI port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3260</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_secret</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the &quot;CHAP password&quot;.)</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">d6866c0d-298b-48ba-95af-309b4faux45e</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_volume_attachment_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_volume_attachment_module.rst
+++ b/docs/modules/oci_volume_attachment_module.rst
@@ -1,13 +1,14 @@
-.. _oci_volume_attachment:
+:source: cloud/oracle/oci_volume_attachment.py
+
+:orphan:
+
+.. _oci_volume_attachment_module:
 
 
 oci_volume_attachment - Attach or detach a volume in OCI Block Volume service
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,233 +17,271 @@ oci_volume_attachment - Attach or detach a volume in OCI Block Volume service
 
 Synopsis
 --------
-
-
-* This module allows the user to attach a volume to an instance or detach a volume from an instance in OCI.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to attach a volume to an instance or detach a volume from an instance in OCI.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it cannot be changed. Avoid entering confidential information.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>instance_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the instance. Required to attach a volume to an instance with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>is_read_only</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether the attachment was created in read-only mode.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>state=present</em> to attach a volume to an instance. Use <em>state=absent</em> to detach a volume from an instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>iscsi</li>
+                                                                                                                                                                                                <li>paravirtualized</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of volume. Required to attach a volume to an instance with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>use_chap</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to use CHAP authentication for the volume attachment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>volume_attachment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the volume attachment. Required to detach a volume from an instance with <em>state=absent</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>volume_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the volume. Required to attach a volume to an instance with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name. Does not have to be unique, and it cannot be changed. Avoid entering confidential information.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>instance_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the instance. Required to attach a volume to an instance with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>is_read_only<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether the attachment was created in read-only mode.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Use <em>state=present</em> to attach a volume to an instance. Use <em>state=absent</em> to detach a volume from an instance.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>type<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>iscsi</li><li>paravirtualized</li></ul></td>
-    <td>
-        <div>The type of volume. Required to attach a volume to an instance with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>use_chap<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to use CHAP authentication for the volume attachment.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>volume_attachment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the volume attachment. Required to detach a volume from an instance with <em>state=absent</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>volume_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the volume. Required to attach a volume to an instance with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Attach a volume to an instance
@@ -257,58 +296,54 @@ Examples
         state: absent
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>volume_attachment</td>
-    <td>
-        <div>Information about the volume attachment</div>
-    </td>
-    <td align=center>On successful attach operation</td>
-    <td align=center>dict</td>
-    <td align=center>{'lifecycle_state': 'ATTACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'ansible_volume_attachment', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-11-23T11:17:50.139000+00:00', 'id': 'ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:472a085d-41a9-4c18-ae7d-dea5b296dad3', 'ipv4': '169.254.2.2', 'volume_id': 'ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}</td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <b>volume_attachment</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>On successful attach operation</td>
+                <td>
+                                            <div>Information about the volume attachment</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'ATTACHED', 'availability_domain': 'BnQb:PHX-AD-1', 'display_name': 'ansible_volume_attachment', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-11-23T11:17:50.139000+00:00', 'id': 'ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:472a085d-41a9-4c18-ae7d-dea5b296dad3', 'ipv4': '169.254.2.2', 'volume_id': 'ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_volume_attachment.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_volume_backup_facts_module.rst
+++ b/docs/modules/oci_volume_backup_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_volume_backup_facts:
+:source: cloud/oracle/oci_volume_backup_facts.py
+
+:orphan:
+
+.. _oci_volume_backup_facts_module:
 
 
 oci_volume_backup_facts - Retrieve facts of volume backups in OCI Block Volume service
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,143 +17,170 @@ oci_volume_backup_facts - Retrieve facts of volume backups in OCI Block Volume s
 
 Synopsis
 --------
-
-
-* This module retrieves information of a specified volume backup or all the volume backups in a compartment in OCI Block Volume service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves information of a specified volume backup or all the volume backups in a compartment in OCI Block Volume service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>volume_backup_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the volume backup.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>volume_backup_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the volume backup.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get information of all the volume backups in a compartment
@@ -164,185 +192,207 @@ Examples
         id: ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>volume_backups</td>
-    <td>
-        <div>List of volume backup information</div>
-    </td>
-    <td align=center>on success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'size_in_gbs': 50, 'display_name': 'ansible_backup', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'size_in_mbs': 51200, 'time_created': '2017-12-22T15:40:53.219000+00:00', 'unique_size_in_gbs': 0, 'volume_id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx', 'unique_size_in_mbs': 1, 'time_request_received': '2017-12-22T15:40:48.111000+00:00', 'id': 'ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of a volume backup. Allowed values for this property are &quot;CREATING&quot;, &quot;AVAILABLE&quot;, &quot;TERMINATING&quot;, &quot;TERMINATED&quot;, &quot;FAULTY&quot;, &quot;REQUEST_RECEIVED&quot;, 'UNKNOWN_ENUM_VALUE'.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>size_in_gbs</td>
-        <td>
-            <div>The size of the volume, in GBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>50</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name for the volume backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>test_backup</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the volume backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>size_in_mbs</td>
-        <td>
-            <div>The size of the volume, in MBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>51200</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the volume backup was created. This is the time the actual point-in-time image of the volume data was taken. Format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-12-22 15:40:53.219000</td>
-        </tr>
-
-        <tr>
-        <td>unique_size_in_gbs</td>
-        <td>
-            <div>The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space consumed on the volume and whether the backup is full or incremental.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>0</td>
-        </tr>
-
-        <tr>
-        <td>volume_id</td>
-        <td>
-            <div>The OCID of the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>unique_size_in_mbs</td>
-        <td>
-            <div>The size used by the backup, in MBs. It is typically smaller than sizeInMBs, depending on the space consumed on the volume and whether the backup is full or incremental.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>1</td>
-        </tr>
-
-        <tr>
-        <td>time_request_received</td>
-        <td>
-            <div>The date and time the request to create the volume backup was received. Format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-12-22 15:40:48.111000</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the volume backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>volume_backups</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                            <div>List of volume backup information</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'size_in_gbs': 50, 'display_name': 'ansible_backup', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'size_in_mbs': 51200, 'time_created': '2017-12-22T15:40:53.219000+00:00', 'unique_size_in_gbs': 0, 'volume_id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx', 'unique_size_in_mbs': 1, 'time_request_received': '2017-12-22T15:40:48.111000+00:00', 'id': 'ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of a volume backup. Allowed values for this property are &quot;CREATING&quot;, &quot;AVAILABLE&quot;, &quot;TERMINATING&quot;, &quot;TERMINATED&quot;, &quot;FAULTY&quot;, &quot;REQUEST_RECEIVED&quot;, 'UNKNOWN_ENUM_VALUE'.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>size_in_gbs</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the volume, in GBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">50</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name for the volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">test_backup</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>size_in_mbs</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the volume, in MBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">51200</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the volume backup was created. This is the time the actual point-in-time image of the volume data was taken. Format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-12-22 15:40:53.219000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>unique_size_in_gbs</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space consumed on the volume and whether the backup is full or incremental.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>unique_size_in_mbs</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size used by the backup, in MBs. It is typically smaller than sizeInMBs, depending on the space consumed on the volume and whether the backup is full or incremental.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_request_received</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the request to create the volume backup was received. Format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-12-22 15:40:48.111000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_volume_backup_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_volume_backup_module.rst
+++ b/docs/modules/oci_volume_backup_module.rst
@@ -1,13 +1,14 @@
-.. _oci_volume_backup:
+:source: cloud/oracle/oci_volume_backup.py
+
+:orphan:
+
+.. _oci_volume_backup_module:
 
 
 oci_volume_backup - Manage volume backups in OCI Block Volume service
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,244 +17,278 @@ oci_volume_backup - Manage volume backups in OCI Block Volume service
 
 Synopsis
 --------
-
-
-* This module allows the user to perform create, delete & update operations on volume backups in OCI Block Volume service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to perform create, delete & update operations on volume backups in OCI Block Volume service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name for the volume backup. Does not have to be unique and it's changeable. Avoid entering confidential information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>state=present</em> to create or update a volume backup. Use <em>state=absent</em> to delete a volume backup.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>FULL</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>INCREMENTAL</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of backup to create.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>volume_backup_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the volume backup. Required to update a volume backup with <em>state=present</em> or to delete a volume backup with <em>state=absent</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>volume_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the volume that needs to be backed up. Required to create a volume backup with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
 
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name for the volume backup. Does not have to be unique and it's changeable. Avoid entering confidential information.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Use <em>state=present</em> to create or update a volume backup. Use <em>state=absent</em> to delete a volume backup.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>type<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>INCREMENTAL</td>
-    <td><ul><li>FULL</li><li>INCREMENTAL</li></ul></td>
-    <td>
-        <div>The type of backup to create.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>volume_backup_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the volume backup. Required to update a volume backup with <em>state=present</em> or to delete a volume backup with <em>state=absent</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>volume_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the volume that needs to be backed up. Required to create a volume backup with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a volume backup
@@ -279,195 +314,221 @@ Examples
         state: absent
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>volume_backup</td>
-    <td>
-        <div>Information about the volume backup</div>
-    </td>
-    <td align=center>on successful create, delete and update operation</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'size_in_gbs': 50, 'display_name': 'ansible_backup', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'size_in_mbs': 51200, 'time_created': '2017-12-22T15:40:53.219000+00:00', 'id': 'ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx', 'unique_size_in_gbs': 0, 'volume_id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx', 'unique_size_in_mbs': 1, 'type': 'FULL', 'time_request_received': '2017-12-22T15:40:48.111000+00:00'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of a volume backup. Allowed values for this property are &quot;CREATING&quot;, &quot;AVAILABLE&quot;, &quot;TERMINATING&quot;, &quot;TERMINATED&quot;, &quot;FAULTY&quot;, &quot;REQUEST_RECEIVED&quot;, 'UNKNOWN_ENUM_VALUE'.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>AVAILABLE</td>
-        </tr>
-
-        <tr>
-        <td>size_in_gbs</td>
-        <td>
-            <div>The size of the volume, in GBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>50</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>A user-friendly name for the volume backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>test_backup</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the volume backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>size_in_mbs</td>
-        <td>
-            <div>The size of the volume, in MBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>51200</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the volume backup was created. This is the time the actual point-in-time image of the volume data was taken. Format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-12-22 15:40:53.219000</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the volume backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>unique_size_in_gbs</td>
-        <td>
-            <div>The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space consumed on the volume and whether the backup is full or incremental.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>0</td>
-        </tr>
-
-        <tr>
-        <td>volume_id</td>
-        <td>
-            <div>The OCID of the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>unique_size_in_mbs</td>
-        <td>
-            <div>The size used by the backup, in MBs. It is typically smaller than sizeInMBs, depending on the space consumed on the volume and whether the backup is full or incremental.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>1</td>
-        </tr>
-
-        <tr>
-        <td>type</td>
-        <td>
-            <div>The type of a volume backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>FULL</td>
-        </tr>
-
-        <tr>
-        <td>time_request_received</td>
-        <td>
-            <div>The date and time the request to create the volume backup was received. Format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>2017-12-22 15:40:48.111000</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="2">
+                    <b>volume_backup</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>on successful create, delete and update operation</td>
+                <td>
+                                            <div>Information about the volume backup</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'size_in_gbs': 50, 'display_name': 'ansible_backup', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'size_in_mbs': 51200, 'time_created': '2017-12-22T15:40:53.219000+00:00', 'id': 'ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx', 'unique_size_in_gbs': 0, 'volume_id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx', 'unique_size_in_mbs': 1, 'type': 'FULL', 'time_request_received': '2017-12-22T15:40:48.111000+00:00'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of a volume backup. Allowed values for this property are &quot;CREATING&quot;, &quot;AVAILABLE&quot;, &quot;TERMINATING&quot;, &quot;TERMINATED&quot;, &quot;FAULTY&quot;, &quot;REQUEST_RECEIVED&quot;, 'UNKNOWN_ENUM_VALUE'.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AVAILABLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>size_in_gbs</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the volume, in GBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">50</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name for the volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">test_backup</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>size_in_mbs</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the volume, in MBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">51200</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the volume backup was created. This is the time the actual point-in-time image of the volume data was taken. Format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-12-22 15:40:53.219000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>unique_size_in_gbs</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space consumed on the volume and whether the backup is full or incremental.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>unique_size_in_mbs</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size used by the backup, in MBs. It is typically smaller than sizeInMBs, depending on the space consumed on the volume and whether the backup is full or incremental.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of a volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">FULL</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_request_received</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the request to create the volume backup was received. Format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-12-22 15:40:48.111000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_volume_backup.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_volume_facts_module.rst
+++ b/docs/modules/oci_volume_facts_module.rst
@@ -1,13 +1,14 @@
-.. _oci_volume_facts:
+:source: cloud/oracle/oci_volume_facts.py
+
+:orphan:
+
+.. _oci_volume_facts_module:
 
 
 oci_volume_facts - Retrieve facts of volumes in OCI Block Volume service
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,164 +17,195 @@ oci_volume_facts - Retrieve facts of volumes in OCI Block Volume service
 
 Synopsis
 --------
-
-
-* This module retrieves information of a specified volume or all the volumes in a specified compartment and availability domain.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module retrieves information of a specified volume or all the volumes in a specified compartment and availability domain.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The name of the Availability Domain.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment. Required to get information of all the volumes in a specified compartment. This option is mutually exclusive with <em>volume_id</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>lookup_all_attached_instances<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to fetch information of compute instances attached to this volume from all the compartments in the tenancy.Fetching this information requires traversing through all the compartments in the Tenancy and therefore can potentially take a long time. This option is only supported in experimental mode.
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the Availability Domain.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment. Required to get information of all the volumes in a specified compartment. This option is mutually exclusive with <em>volume_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>lookup_all_attached_instances</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to fetch information of compute instances attached to this volume from all the compartments in the tenancy.Fetching this information requires traversing through all the compartments in the Tenancy and therefore can potentially take a long time. This option is only supported in experimental mode.
     When <em>lookup_all_attached_instances=False</em>, only attached compute instances belonging to this volume's compartment, is returned. This is useful when the volume is used within a single compartment. When <em>lookup_all_attached_instances=True</em>, all the compartments in the tenancy are searched to find out the compute instances that are attached to this volume. Fetching information about compute instances attached to this volume is an experimental feature (ie, this may or may not be supported in future releases). To use such experimental features, set the environment variable OCI_ANSIBLE_EXPERIMENTAL to True.</div>
-    </td>
-    </tr>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>volume_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the volume. Required to get information of a specific volume. This option is mutually exclusive with <em>compartment_id</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
 
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td>volume_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the volume. Required to get information of a specific volume. This option is mutually exclusive with <em>compartment_id</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Get information of all the volumes for a specific availability domain & compartment_id
@@ -186,185 +218,447 @@ Examples
         volume_id: ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>volumes</td>
-    <td>
-        <div>List of volume information</div>
-    </td>
-    <td align=center>On success</td>
-    <td align=center>complex</td>
-    <td align=center>[{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'ansible_test_volume', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'attached_instance_information': {'lifecycle_state': 'ATTACHED', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'volumeattachment20171204124856', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-12-04T12:48:56.497000+00:00', 'id': 'ocid1.volumeattachment.oc1.iad.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:8ea342ff-4687-4038-b733-d20cb1025b48', 'ipv4': '169.254.2.7', 'volume_id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}, 'size_in_mbs': 51200, 'time_created': '2017-12-05T15:35:28.747000+00:00', 'source_details': {'type': 'volume', 'id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx'}, 'size_in_gbs': 50, 'is_hydrated': True, 'id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx'}]</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="3">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of a volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>PROVISIONING</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain of the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IwGV:US-ASHBURN-AD-2</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name of the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_test_volume</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>attached_instance_information</td>
-        <td>
-            <div>Information of instance currently attached to the block volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>size_in_mbs</td>
-        <td>
-            <div>The size of the volume in MBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>51200</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the volume was created. Format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2017-11-22 19:40:08.871000</td>
-        </tr>
-
-        <tr>
-        <td>source_details</td>
-        <td>
-            <div>The volume source, either an existing volume in the same Availability Domain or a volume backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'type': 'volumeBackup', 'id': 'ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx'}</td>
-        </tr>
-
-        <tr>
-        <td>size_in_gbs</td>
-        <td>
-            <div>The size of the volume in GBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>50</td>
-        </tr>
-
-        <tr>
-        <td>is_hydrated</td>
-        <td>
-            <div>Specifies whether the cloned volume's data has finished copying from the source volume or backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>bool</td>
-        <td align=center>False</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="3">
+                    <b>volumes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On success</td>
+                <td>
+                                            <div>List of volume information</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'ansible_test_volume', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'attached_instance_information': {'lifecycle_state': 'ATTACHED', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'volumeattachment20171204124856', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-12-04T12:48:56.497000+00:00', 'id': 'ocid1.volumeattachment.oc1.iad.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:8ea342ff-4687-4038-b733-d20cb1025b48', 'ipv4': '169.254.2.7', 'volume_id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}, 'size_in_mbs': 51200, 'time_created': '2017-12-05T15:35:28.747000+00:00', 'source_details': {'type': 'volume', 'id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx'}, 'size_in_gbs': 50, 'is_hydrated': True, 'id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of a volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PROVISIONING</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ASHBURN-AD-2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_test_volume</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>attached_instance_information</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Information of instance currently attached to the block volume.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The current state of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The Availability Domain of an instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_username</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The date and time the volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the instance the volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>iqn</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The target volume's iSCSI Qualified Name in the format defined by RFC 3720.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ipv4</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The volume's iSCSI IP address.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">169.254.0.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>attachment_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The type of volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iscsi</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The volume's iSCSI port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3260</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_secret</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the &quot;CHAP password&quot;.)</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">d6866c0d-298b-48ba-95af-309b4faux45e</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>size_in_mbs</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the volume in MBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">51200</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the volume was created. Format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-22 19:40:08.871000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>source_details</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume source, either an existing volume in the same Availability Domain or a volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'type': 'volumeBackup', 'id': 'ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>When a volume is initialized from a source volume or a backup.</td>
+                <td>
+                                            <div>Type of volume source either 'volumeBackup' or 'volume'.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">volumeBackup</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>When a volume is initialized from a source volume or a backup.</td>
+                <td>
+                                            <div>The OCID of the source volume or the OCID of the volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>size_in_gbs</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the volume in GBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">50</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>is_hydrated</b>
+                    <br/><div style="font-size: small; color: red">bool</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Specifies whether the cloned volume's data has finished copying from the source volume or backup.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_volume_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_volume_module.rst
+++ b/docs/modules/oci_volume_module.rst
@@ -1,13 +1,14 @@
-.. _oci_volume:
+:source: cloud/oracle/oci_volume.py
+
+:orphan:
+
+.. _oci_volume_module:
 
 
 oci_volume - Manage volumes in OCI Block Volume service
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-.. versionadded:: 2.x
-
-
-
+.. versionadded:: 2.5
 
 .. contents::
    :local:
@@ -16,334 +17,364 @@ oci_volume - Manage volumes in OCI Block Volume service
 
 Synopsis
 --------
-
-
-* This module allows the user to perform create, delete & update operations on volumes in OCI Block Volume service.
-
-
-
-Requirements (on host that executes module)
--------------------------------------------
-
-  * python >= 2.6
-  * Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+- This module allows the user to perform create, delete & update operations on volumes in OCI Block Volume service.
 
 
 
-Options
--------
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">parameter</th>
-    <th class="head">required</th>
-    <th class="head">default</th>
-    <th class="head">choices</th>
-    <th class="head">comments</th>
-    </tr>
-
-    <tr>
-    <td>api_user<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_fingerprint<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_file<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>api_user_key_pass_phrase<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>availability_domain<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The availability domain of the volume. Required when creating a volume with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>compartment_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the compartment that contains the volume. Required when creating a volume with <em>state=present</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_file_location<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>config_profile_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>DEFAULT</td>
-    <td></td>
-    <td>
-        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>defined_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>display_name<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information. If <em>display_name</em> is not provided, it is auto-generated.</div>
-        </br><div style="font-size: small;">aliases: name</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>force_create<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>freeform_tags<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>key_by<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>lookup_all_attached_instances<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to fetch information of compute instances attached to this volume from all the compartments in the tenancy.Fetching this information requires traversing through all the compartments in the Tenancy and therefore can potentially take a long time. This option is only supported in experimental mode.
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>availability_domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The availability domain of the volume. Required when creating a volume with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment that contains the volume. Required when creating a volume with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information. If <em>display_name</em> is not provided, it is auto-generated.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>lookup_all_attached_instances</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to fetch information of compute instances attached to this volume from all the compartments in the tenancy.Fetching this information requires traversing through all the compartments in the Tenancy and therefore can potentially take a long time. This option is only supported in experimental mode.
     When <em>lookup_all_attached_instances=False</em>, only attached compute instances belonging to this volume's compartment, is returned. This is useful when the volume is used within a single compartment. When <em>lookup_all_attached_instances=True</em>, all the compartments in the tenancy are searched to find out the compute instances that are attached to this volume. Fetching information about compute instances attached to this volume is an experimental feature (ie, this may or may not be supported in future releases). To use such experimental features, set the environment variable OCI_ANSIBLE_EXPERIMENTAL to True.</div>
-    </td>
-    </tr>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>size_in_gbs</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">50</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The size of the volume in GBs.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>source_details</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Specifies the volume source details for a new Block volume. The volume source is either another Block volume in the same Availability Domain or a Block volume backup. This is an optional field. If not specified or set to null, the new Block volume will be empty. When specified, the new Block volume will contain data from the source volume or backup.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>wait_for_copy</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to wait for the operation of copying from source volume or backup to complete when <em>source_details.id</em> is specified under <code>source_details</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>volumeBackup</li>
+                                                                                                                                                                                                <li>volume</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Type of volume source details. Use <em>source_details.type=volumeBackup</em> for restoring a volume backup. Use <em>source_details.type=volume</em> for cloning a volume.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCID of the volume backup from which the data should be restored on the newly created volume when <em>source_details.type=volumeBackup</em> or the OCID of the volume to be cloned when <em>source_details.type=volume</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>copy_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1800</div>
+                                    </td>
+                                                                <td>
+                                            <div>Time, in seconds, to wait for the operation to complete when <em>wait_for_copy=yes</em>.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a volume with <em>state=present</em>. Delete a volume with <em>state=absent</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>volume_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the volume. Required when updating a volume with <em>state=present</em> or deleting a volume with <em>state=absent</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
 
-    <tr>
-    <td>region<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
-    </td>
-    </tr>
 
-    <tr>
-    <td>size_in_gbs<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>50</td>
-    <td></td>
-    <td>
-        <div>The size of the volume in GBs.</div>
-    </td>
-    </tr>
+Notes
+-----
 
-    <tr>
-    <td rowspan="2">source_details<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>Specifies the volume source details for a new Block volume. The volume source is either another Block volume in the same Availability Domain or a Block volume backup. This is an optional field. If not specified or set to null, the new Block volume will be empty. When specified, the new Block volume will contain data from the source volume or backup.</div>
-    </tr>
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
 
-    <tr>
-    <td colspan="5">
-        <table border=1 cellpadding=4>
-        <caption><b>Dictionary object source_details</b></caption>
-
-        <tr>
-        <th class="head">parameter</th>
-        <th class="head">required</th>
-        <th class="head">default</th>
-        <th class="head">choices</th>
-        <th class="head">comments</th>
-        </tr>
-
-        <tr>
-        <td>wait_for_copy<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td><ul><li>yes</li><li>no</li></ul></td>
-        <td>
-        <div>Whether to wait for the operation of copying from source volume or backup to complete when <em>source_details.id</em> is specified under <code>source_details</code>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>type<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td><ul><li>volumeBackup</li><li>volume</li></ul></td>
-        <td>
-        <div>Type of volume source details. Use <em>source_details.type=volumeBackup</em> for restoring a volume backup. Use <em>source_details.type=volume</em> for cloning a volume.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>id<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td></td>
-        <td></td>
-        <td>
-        <div>The OCID of the volume backup from which the data should be restored on the newly created volume when <em>source_details.type=volumeBackup</em> or the OCID of the volume to be cloned when <em>source_details.type=volume</em>.</div>
-        </td>
-        </tr>
-
-        <tr>
-        <td>copy_timeout<br/><div style="font-size: small;"></div></td>
-        <td>no</td>
-        <td>1800</td>
-        <td></td>
-        <td>
-        <div>Time, in seconds, to wait for the operation to complete when <em>wait_for_copy=yes</em>.</div>
-        </td>
-        </tr>
-
-        </table>
-
-    </td>
-    </tr>
-    </td>
-    </tr>
-
-    <tr>
-    <td>state<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>present</td>
-    <td><ul><li>present</li><li>absent</li></ul></td>
-    <td>
-        <div>Create or update a volume with <em>state=present</em>. Delete a volume with <em>state=absent</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>tenancy<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>volume_id<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The OCID of the volume. Required when updating a volume with <em>state=present</em> or deleting a volume with <em>state=absent</em>.</div>
-        </br><div style="font-size: small;">aliases: id</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>True</td>
-    <td><ul><li>yes</li><li>no</li></ul></td>
-    <td>
-        <div>Whether to wait for create or delete operation to complete.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_timeout<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td>1200</td>
-    <td></td>
-    <td>
-        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
-    </td>
-    </tr>
-
-    <tr>
-    <td>wait_until<br/><div style="font-size: small;"></div></td>
-    <td>no</td>
-    <td></td>
-    <td></td>
-    <td>
-        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
-    </td>
-    </tr>
-
-    </table>
-    </br>
 
 Examples
 --------
 
- ::
+.. code-block:: yaml+jinja
 
     
     - name: Create a volume
@@ -384,185 +415,447 @@ Examples
         state: 'absent'
 
 
+
+
 Return Values
 -------------
-
 Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
 
 .. raw:: html
 
-    <table border=1 cellpadding=4>
-
-    <tr>
-    <th class="head">name</th>
-    <th class="head">description</th>
-    <th class="head">returned</th>
-    <th class="head">type</th>
-    <th class="head">sample</th>
-    </tr>
-
-    <tr>
-    <td>volume</td>
-    <td>
-        <div>Information about the volume</div>
-    </td>
-    <td align=center>On successful create and update operation</td>
-    <td align=center>complex</td>
-    <td align=center>{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'ansible_test_volume', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'attached_instance_information': {'lifecycle_state': 'ATTACHED', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'volumeattachment20171204124856', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-12-04T12:48:56.497000+00:00', 'id': 'ocid1.volumeattachment.oc1.iad.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:8ea342ff-4687-4038-b733-d20cb1025b48', 'ipv4': '169.254.2.7', 'volume_id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}, 'size_in_mbs': 51200, 'time_created': '2017-12-05T15:35:28.747000+00:00', 'source_details': {'type': 'volume', 'id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx'}, 'size_in_gbs': 50, 'is_hydrated': True, 'id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx'}</td>
-    </tr>
-
-    <tr>
-    <td>contains:</td>
-    <td colspan=4>
-        <table border=1 cellpadding=2>
-
+    <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-        <th class="head">name</th>
-        <th class="head">description</th>
-        <th class="head">returned</th>
-        <th class="head">type</th>
-        <th class="head">sample</th>
+            <th colspan="3">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
         </tr>
-
-        <tr>
-        <td>lifecycle_state</td>
-        <td>
-            <div>The current state of a volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>PROVISIONING</td>
-        </tr>
-
-        <tr>
-        <td>availability_domain</td>
-        <td>
-            <div>The Availability Domain of the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>IwGV:US-ASHBURN-AD-2</td>
-        </tr>
-
-        <tr>
-        <td>display_name</td>
-        <td>
-            <div>Name of the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ansible_test_volume</td>
-        </tr>
-
-        <tr>
-        <td>compartment_id</td>
-        <td>
-            <div>The OCID of the compartment that contains the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        <tr>
-        <td>attached_instance_information</td>
-        <td>
-            <div>Information of instance currently attached to the block volume.</div>
-        </td>
-        <td align=center>In experimental mode.</td>
-        <td align=center>dict</td>
-        <td align=center></td>
-        </tr>
-
-        <tr>
-        <td>size_in_mbs</td>
-        <td>
-            <div>The size of the volume in MBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>51200</td>
-        </tr>
-
-        <tr>
-        <td>time_created</td>
-        <td>
-            <div>The date and time the volume was created. Format defined by RFC3339.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>datetime</td>
-        <td align=center>2017-11-22 19:40:08.871000</td>
-        </tr>
-
-        <tr>
-        <td>source_details</td>
-        <td>
-            <div>The volume source, either an existing volume in the same Availability Domain or a volume backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>dict</td>
-        <td align=center>{'type': 'volumeBackup', 'id': 'ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx'}</td>
-        </tr>
-
-        <tr>
-        <td>size_in_gbs</td>
-        <td>
-            <div>The size of the volume in GBs.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>int</td>
-        <td align=center>50</td>
-        </tr>
-
-        <tr>
-        <td>is_hydrated</td>
-        <td>
-            <div>Specifies whether the cloned volume's data has finished copying from the source volume or backup.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>bool</td>
-        <td align=center>False</td>
-        </tr>
-
-        <tr>
-        <td>id</td>
-        <td>
-            <div>The OCID of the volume.</div>
-        </td>
-        <td align=center>always</td>
-        <td align=center>string</td>
-        <td align=center>ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx</td>
-        </tr>
-
-        </table>
-    </td>
-    </tr>
-
-    </table>
-    </br>
-    </br>
-
-
-Notes
------
-
-.. note::
-    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
-
-
-Author
-~~~~~~
-
-    * Rohit Chaware (@rohitChaware)
-
-
+                    <tr>
+                                <td colspan="3">
+                    <b>volume</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful create and update operation</td>
+                <td>
+                                            <div>Information about the volume</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'AVAILABLE', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'ansible_test_volume', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'attached_instance_information': {'lifecycle_state': 'ATTACHED', 'availability_domain': 'IwGV:US-ASHBURN-AD-2', 'display_name': 'volumeattachment20171204124856', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'chap_username': None, 'time_created': '2017-12-04T12:48:56.497000+00:00', 'id': 'ocid1.volumeattachment.oc1.iad.xxxxxEXAMPLExxxxx', 'instance_id': 'ocid1.instance.oc1.iad.xxxxxEXAMPLExxxxx', 'iqn': 'iqn.2015-12.com.oracleiaas:8ea342ff-4687-4038-b733-d20cb1025b48', 'ipv4': '169.254.2.7', 'volume_id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx', 'attachment_type': 'iscsi', 'port': 3260, 'chap_secret': None}, 'size_in_mbs': 51200, 'time_created': '2017-12-05T15:35:28.747000+00:00', 'source_details': {'type': 'volume', 'id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx'}, 'size_in_gbs': 50, 'is_hydrated': True, 'id': 'ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of a volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PROVISIONING</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Availability Domain of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">IwGV:US-ASHBURN-AD-2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_test_volume</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment that contains the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>attached_instance_information</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>In experimental mode.</td>
+                <td>
+                                            <div>Information of instance currently attached to the block volume.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The current state of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The Availability Domain of an instance.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BnQb:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it cannot be changed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the compartment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_username</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The date and time the volume was created, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the instance the volume is attached to.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>iqn</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The target volume's iSCSI Qualified Name in the format defined by RFC 3720.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ipv4</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The volume's iSCSI IP address.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">169.254.0.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>attachment_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The type of volume attachment.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iscsi</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The volume's iSCSI port.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3260</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_secret</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>when this volume is attached to a compute instance</td>
+                <td>
+                                            <div>The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the &quot;CHAP password&quot;.)</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">d6866c0d-298b-48ba-95af-309b4faux45e</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>size_in_mbs</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the volume in MBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">51200</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the volume was created. Format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-22 19:40:08.871000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>source_details</b>
+                    <br/><div style="font-size: small; color: red">dict</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The volume source, either an existing volume in the same Availability Domain or a volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'type': 'volumeBackup', 'id': 'ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>When a volume is initialized from a source volume or a backup.</td>
+                <td>
+                                            <div>Type of volume source either 'volumeBackup' or 'volume'.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">volumeBackup</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>When a volume is initialized from a source volume or a backup.</td>
+                <td>
+                                            <div>The OCID of the source volume or the OCID of the volume backup.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumebackup.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>size_in_gbs</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The size of the volume in GBs.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">50</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>is_hydrated</b>
+                    <br/><div style="font-size: small; color: red">bool</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Specifies whether the cloned volume's data has finished copying from the source volume or backup.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the volume.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
 
 
 Status
-~~~~~~
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
 
 This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
 
 
 
-For help in developing on modules, should you be so inclined, please read :doc:`../../community`, :doc:`../../dev_guide/testing` and :doc:`../../dev_guide/developing_modules`.
+Author
+~~~~~~
+
+- Rohit Chaware (@rohitChaware)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_volume.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_zone_facts_module.rst
+++ b/docs/modules/oci_zone_facts_module.rst
@@ -1,0 +1,425 @@
+:source: cloud/oracle/oci_zone_facts.py
+
+:orphan:
+
+.. _oci_zone_facts_module:
+
+
+oci_zone_facts - Retrieve facts of zones in Oracle Cloud Infrastructure DNS Service
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves information of the specified zone or all zones in the specified compartment.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment the resource belongs to. Use <em>zone_id</em> to retrieve a specific zone's information using its OCID.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A case-sensitive filter for zone names. Will match any zone with a name that equals the provided value.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: zone_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>zone_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of the target zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>zone_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>PRIMARY</li>
+                                                                                                                                                                                                <li>SECONDARY</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Search by zone type, PRIMARY or SECONDARY. Will match any zone whose type equals the provided value.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get a list of zones in the specified compartment
+      oci_zone_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Get a zone with the specified name
+      oci_zone_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        name: test_zone_1.com
+
+    - name: Get a list of primary zones in the specified compartment
+      oci_zone_facts:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        zone_type: "PRIMARY"
+
+    - name: Gets details of a specific zone using the OCID of the zone
+      oci_zone_facts:
+        zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>zones</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>List of Zone details</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'ACTIVE', 'self_uri': 'https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/test_zone_1.com', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2018-08-23T11:36:26+00:00', 'external_masters': [], 'version': '1', 'zone_type': 'PRIMARY', 'serial': 1, 'id': 'ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx', 'name': 'test_zone_1.com'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the zone resource.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>self_uri</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The canonical absolute URL of the resource.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/test_zone_1.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the Zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>nameservers</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>optional</td>
+                <td>
+                                            <div>The authoritative nameservers for the zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'hostname': 'XXX'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the resource was created in &quot;YYYY-MM-ddThh:mmZ&quot; format with a Z offset, as defined by RFC 3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-08-23T11:36:26+00:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the zone</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Version is the never-repeating, totally-orderable, version of the zone, from which the serial field of the zone's SOA record is derived.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>zone_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of the zone. Must be either PRIMARY or SECONDARY.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PRIMARY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>serial</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current serial of the zone. As seen in the zone's SOA record.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>external_masters</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>External master servers for the zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['...']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">test_zone_1.com</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_zone_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_zone_module.rst
+++ b/docs/modules/oci_zone_module.rst
@@ -1,0 +1,584 @@
+:source: cloud/oracle/oci_zone.py
+
+:orphan:
+
+.. _oci_zone_module:
+
+
+oci_zone - Manage a Zone in OCI DNS Service
++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module allows the user to create, update and delete a Zone in OCI DNS Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="3">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="3">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment containing the zone. Required to create a zone.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>external_masters</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>External master servers for the Zone</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>address</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The server's IP address (IPv4 or IPv6).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>port</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The server's port. Port value must be a value of 53, otherwise omit the port value.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>tsig</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A <a href=' https://tools.ietf.org/html/rfc2845'>TSIG</a> key.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>secret</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A base64 string encoding the binary shared secret.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A domain name identifying the key for a given pair of hosts.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>algorithm</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>TSIG Algorithms are encoded as domain names, but most consist of only one non-empty label, which is not required to be explicitly absolute. Applicable algorithms include: hmac-sha1, hmac-sha224, hmac-sha256, hmac-sha512. For more information on these algorithms, please see <a href=' https://tools.ietf.org/html/rfc4635#section-2'>RFC 4635</a>.</div>
+                                                        </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                                <td colspan="3">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the zone. Required to create a zone. Either <em>name</em> or <em>zone_id</em> must be specified to update or delete a zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: zone_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or update a zone with <em>state=present</em>. Use <em>state=absent</em> to delete a zone.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>zone_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the target zone. Either <em>name</em> or <em>zone_id</em> must be specified to update or delete a zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="3">
+                    <b>zone_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>PRIMARY</li>
+                                                                                                                                                                                                <li>SECONDARY</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of the zone. Must be either PRIMARY or SECONDARY. Required to create a zone.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create a zone
+      oci_zone:
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        name: test_zone_1.com
+        zone_type: PRIMARY
+
+    - name: Update a zone using id
+      oci_zone:
+        id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+        external_masters: [ { address: "12.123.123.123", tsig: { name: "test_zone_1.com", secret: "XXXX",
+                                algorithm: "hmac-sha1" } } ]
+
+    - name: Update a zone using name
+      oci_zone:
+        name: test_zone1.com
+        compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        external_masters: [ { address: "12.123.123.123", tsig: { name: "test_zone_1.com", secret: "XXXX",
+                                algorithm: "hmac-sha1" } } ]
+    - name: Delete a zone
+      oci_zone:
+        id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>zone</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful create, delete &amp; update operations on zone</td>
+                <td>
+                                            <div>Information about the zone</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'ACTIVE', 'self_uri': 'https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/test_zone_1.com', 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'time_created': '2018-08-23T11:36:26+00:00', 'external_masters': [], 'version': '1', 'zone_type': 'PRIMARY', 'serial': 1, 'id': 'ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx', 'name': 'test_zone_1.com'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the zone resource.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>self_uri</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The canonical absolute URL of the resource.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/test_zone_1.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the Zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>nameservers</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>optional</td>
+                <td>
+                                            <div>The authoritative nameservers for the zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'hostname': 'XXX'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the resource was created in &quot;YYYY-MM-ddThh:mmZ&quot; format with a Z offset, as defined by RFC 3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-08-23T11:36:26+00:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the zone</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Version is the never-repeating, totally-orderable, version of the zone, from which the serial field of the zone's SOA record is derived.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>zone_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of the zone. Must be either PRIMARY or SECONDARY.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PRIMARY</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>serial</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current serial of the zone. As seen in the zone's SOA record.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>external_masters</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>External master servers for the zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'address': '12.123.123.123', 'tsig': {'secret': 'XXXX', 'name': 'test_zone_1.com', 'algorithm': 'hmac-sha1'}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">test_zone_1.com</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_zone.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_zone_records_facts_module.rst
+++ b/docs/modules/oci_zone_records_facts_module.rst
@@ -1,0 +1,391 @@
+:source: cloud/oracle/oci_zone_records_facts.py
+
+:orphan:
+
+.. _oci_zone_records_facts_module:
+
+
+oci_zone_records_facts - Retrieve facts of records in a specified zone in Oracle Cloud Infrastructure DNS Service
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module retrieves information of records in a specified zone. The results are sorted by domain in alphabetical order by default. For more information about records, please see L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment the resource belongs to. Use <em>zone_id</em> or <em>zone_name</em> to retrieve a specific zone's information using its OCID.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Search by domain. Will match any record whose domain (case-insensitive) equals the provided value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>domain_contains</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Search by domain. Will match any record whose domain (case-insensitive) contains the provided value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A case-sensitive filter for zone names. Will match any zone with a name that equals the provided value.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: zone_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>rtype</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Search by record type. Will match any record whose type (case-insensitive) equals the provided value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>zone_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of the target zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>zone_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The version of the zone for which data is requested.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get a list of zone records in the specified zone
+      oci_zone_records_facts:
+        zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+
+    - name: Get a list of zone records in a zone for a specific domain
+      oci_zone_records_facts:
+        zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+        domain: test_zone_1.com
+
+    - name: Gets a list of NS records in a specific zone
+      oci_zone_records_facts:
+        name: test_zone_1.com
+        rtype: NS
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>zone_records</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A collection of DNS resource record objects.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'domain': 'test_zone_1.com', 'is_protected': True, 'rrset_version': '1', 'rtype': 'NS', 'ttl': 86400, 'record_hash': '9be3279d81b5e8430fd94c70cfa5f0a8', 'rdata': 'ns2.p68.dns.oraclecloud.net.'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">test_zone_1.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_protected</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rrset_version</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rtype</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NS</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ttl</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">86400</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>record_hash</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">f439fa9a087ff74757485953fe0a8c7d</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rdata</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ns1.p68.dns.oraclecloud.net. hostmaster.test_zone_1.com. 1 3600 600 604800 1800</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_zone_records_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_zone_records_module.rst
+++ b/docs/modules/oci_zone_records_module.rst
@@ -1,0 +1,595 @@
+:source: cloud/oracle/oci_zone_records.py
+
+:orphan:
+
+.. _oci_zone_records_module:
+
+
+oci_zone_records - Update or Patch a collection of records in the specified zone in OCI DNS Service
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- This module allows the user to update or patch a collection of records in the specified DNS zone in OCI DNS Service.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the compartment the resource belongs to.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the zone. Required to create a zone. Either <em>name</em> or <em>zone_id</em> must be specified to update or patch the collection of recordsin the specified zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: zone_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>patch_items</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The record operations to patch the Zone's records collection. Required to patch a zone.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>domain</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rtype</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rr_set_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rdata</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>is_protected</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ttl</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>operation</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>REQUIRE</li>
+                                                                                                                                                                                                <li>PROHIBIT</li>
+                                                                                                                                                                                                <li>ADD</li>
+                                                                                                                                                                                                <li>REMOVE</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>A description of how a record relates to a PATCH operation. REQUIRE indicates a precondition that record data must already exist. PROHIBIT indicates a precondition that record data must not already exist. ADD indicates that record data must exist after successful application. REMOVE indicates that record data must not exist after successful application. Note - ADD and REMOVE operations can succeed even if they require no changes when applied, such as when the described records are already present or absent. Note - ADD and REMOVE operations can describe changes for more than one record. Example - { &quot;domain&quot; - &quot;www.example.com&quot;, &quot;rtype&quot; - &quot;AAAA&quot;, &quot;ttl&quot; - 60 } specifies a new TTL for every record in the www.example.com AAAA RRSet.'</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>record_hash</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>State of the Zone records</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>update_items</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The items to update the Zone's records collection to. Required to update a zone.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>domain</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>is_protected</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rtype</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rr_set_version</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>ttl</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>record_hash</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>rdata</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>zone_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the target zone. Either <em>name</em> or <em>zone_id</em> must be specified to update or path the collection of records in the specified zone.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Update a zone's records by adding a new record. This operation replaces records in the specified zone with the
+            specified records. So ensure that you include the original zone records, if you want to retain existing records.
+      oci_zone_records:
+        name: "test_zone_1.com"
+        update_items: [ <original zone records...> , { domain: "test_zone_1.com", ttl: 30, rtype='TXT', rdata='some textual
+                        data' } ]
+
+    - name: Patch a zone's records
+      oci_zone_records:
+        name: test_zone1.com
+        patch_items: [{
+                        domain: "test_zone_1.com",
+                        is_protected: false,
+                        rdata: "some textual data",
+                        rtype: "TXT",
+                        ttl: 30,
+                        operation: "REMOVE"
+                        }]
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>zone_records</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>On successful update or patch of zone's resource records</td>
+                <td>
+                                            <div>Information about the zone's resource records</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'domain': 'test_zone_1.com', 'is_protected': True, 'rrset_version': '1', 'rtype': 'NS', 'ttl': 86400, 'record_hash': '9be3279d81b5e8430fd94c70cfa5f0a8', 'rdata': 'ns2.p68.dns.oraclecloud.net.'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>domain</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The fully qualified domain name where the record can be located.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">test_zone_1.com</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_protected</b>
+                    <br/><div style="font-size: small; color: red">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A Boolean flag indicating whether or not parts of the record are unable to be explicitly managed.</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rrsetVersion</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The latest version of the record's zone in which its RRSet differs from the preceding version.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">5</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rtype</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The canonical name for the record's type, such as A or CNAME. For more information, see L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NS</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ttl</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Time To Live for the record, in seconds.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">86400</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>record_hash</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A unique identifier for the record within its zone.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">722af089872ffe65ba909fc8fea1867e</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>rdata</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The record's data, as whitespace-delimited tokens in type-specific presentation format.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ns3.p68.dns.oraclecloud.net.</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Sivakumar Thyagarajan (@sivakumart)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_zone_records.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/inventory-script/oci_inventory.py
+++ b/inventory-script/oci_inventory.py
@@ -125,7 +125,7 @@ try:
 except ImportError:
     HAS_OCI_PY_SDK = False
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 
 def _get_retry_strategy():
@@ -261,7 +261,7 @@ class OCIInventory(object):
         self.config = oci.config.from_file(file_location=self.params['config_file'],
                                            profile_name=self.params['profile'])
 
-        self.config["additional_user_agent"] = "Oracle-Ansible/{}".format(__version__)
+        self.config["additional_user_agent"] = "Oracle-Ansible/{0}".format(__version__)
 
         for setting in self.config:
             self.params[setting] = self.config[setting]

--- a/library/oci_ad_facts.py
+++ b/library/oci_ad_facts.py
@@ -20,7 +20,7 @@ module: oci_ad_facts
 short_description: Retrieve details of availability domains in your tenancy
 description:
     - This module retrieves details of all availability domains in your tenancy.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment (either the tenancy or another compartment in the tenancy).
@@ -106,8 +106,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
 
     result = list_availability_domains(identity_client, module)
     module.exit_json(availability_domains=result)

--- a/library/oci_api_key.py
+++ b/library/oci_api_key.py
@@ -28,7 +28,7 @@ description:
       Each user can have a maximum of three API signing keys.
       For more information about user credentials, see
       U(https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm).
-version_added: "2.x"
+version_added: "2.5"
 options:
     user_id:
         description: The OCID of the user whose API signing key needs to be created or deleted.
@@ -200,8 +200,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
     state = module.params['state']
 
     result = dict(changed=False)

--- a/library/oci_api_key_facts.py
+++ b/library/oci_api_key_facts.py
@@ -22,7 +22,7 @@ description:
     - This module retrieves details of api signing keys of a specified user. Note that this is not the SSH key for
       accessing compute instances. This is the credential for securing requests to the Oracle Cloud Infrastructure
       REST API.
-version_added: "2.x"
+version_added: "2.5"
 options:
     user_id:
         description: The OCID of the user whose API signing keys must be retrieved
@@ -137,8 +137,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
 
     user_id = module.params.get("user_id")
     api_key_id = module.params.get("api_key_id", None)

--- a/library/oci_backup.py
+++ b/library/oci_backup.py
@@ -22,7 +22,7 @@ description:
     - Create and Delete a Database Backup in OCI Database Cloud Service.
     - Since all the operations of this module takes a long time, it is recommended to set the C(wait) parameter to
       False. Use M(oci_backup_facts) to check the status of the operation as a separate task.
-version_added: "2.x"
+version_added: "2.5"
 options:
     database_id:
         description: Identifier of the  Database whose backup has to be created.
@@ -219,7 +219,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    db_client = DatabaseClient(oci_utils.get_oci_config(module))
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     state = module.params['state']
     if state == 'present':
         result = oci_utils.check_and_create_resource(resource_type='backup',

--- a/library/oci_boot_volume.py
+++ b/library/oci_boot_volume.py
@@ -21,7 +21,7 @@ module: oci_boot_volume
 short_description: Manage boot volumes in OCI Block Volume service
 description:
     - This module allows the user to perform delete & update operations on boot volumes in OCI Block Volume service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     lookup_attached_instance:
         description: Whether to fetch information of the compute instance attached to this boot volume from all the
@@ -227,11 +227,11 @@ def handle_update_boot_volume(block_storage_client, module):
 
 
 @check_mode
-def add_attached_instance_info(config, module, result, lookup_attached_instance):
-    compute_client = ComputeClient(config)
+def add_attached_instance_info(module, result, lookup_attached_instance):
+    compute_client = oci_utils.create_service_client(module, ComputeClient)
     try:
         result['boot_volume']['attached_instance_information'] = oci_utils.get_attached_instance_info(
-            config,
+            module,
             lookup_attached_instance,
             list_attachments_fn=compute_client.list_boot_volume_attachments,
             list_attachments_args={"boot_volume_id": result["boot_volume"]["id"],
@@ -262,8 +262,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    block_storage_client = BlockstorageClient(config)
+    block_storage_client = oci_utils.create_service_client(module, BlockstorageClient)
 
     state = module.params['state']
 
@@ -273,7 +272,7 @@ def main():
     else:
         result = handle_update_boot_volume(block_storage_client, module)
 
-    add_attached_instance_info(config, module, result, module.params['lookup_attached_instance'])
+    add_attached_instance_info(module, result, module.params['lookup_attached_instance'])
 
     module.exit_json(**result)
 

--- a/library/oci_boot_volume_attachment.py
+++ b/library/oci_boot_volume_attachment.py
@@ -22,7 +22,7 @@ short_description: Attach or detach a boot volume in OCI Block Volume service
 description:
     - This module allows the user to attach a boot volume to an instance or detach a boot volume from an instance in
       OCI.
-version_added: "2.x"
+version_added: "2.5"
 options:
     instance_id:
         description: The OCID of the instance. Required to attach a boot volume to an instance with I(state=present).
@@ -168,8 +168,8 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    compute_client = ComputeClient(config)
+    compute_client = oci_utils.create_service_client(module, ComputeClient)
+
     exclude_attributes = {'display_name': True}
     state = module.params['state']
 

--- a/library/oci_boot_volume_attachment_facts.py
+++ b/library/oci_boot_volume_attachment_facts.py
@@ -22,7 +22,7 @@ short_description: Retrieve facts of boot volume attachments in OCI
 description:
     - This module retrieves information of a specified boot volume attachment or all the boot volume attachments in the
       specified compartment and availability domain.
-version_added: "2.x"
+version_added: "2.5"
 options:
     availability_domain:
         description: The name of the Availability Domain. Required to get information of all the boot volume attachments
@@ -46,7 +46,7 @@ options:
                      I(availability_domain) to get boot volume attachment information related to I(boot_volume_id).
         required: false
 author: "Rohit Chaware (@rohitChaware)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -134,7 +134,7 @@ except ImportError:
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         availability_domain=dict(type='str', required=False),
         compartment_id=dict(type='str', required=False),
@@ -151,8 +151,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    compute_client = ComputeClient(config)
+    compute_client = oci_utils.create_service_client(module, ComputeClient)
 
     boot_volume_attachment_id = module.params['boot_volume_attachment_id']
 
@@ -162,7 +161,7 @@ def main():
                                                           boot_volume_attachment_id=boot_volume_attachment_id).data)]
 
         else:
-            key_list = ["availability_domain", "compartment_id", "instance_id", "boot_volume_id"]
+            key_list = ["availability_domain", "compartment_id", "instance_id", "boot_volume_id", "display_name"]
             param_map = {k: v for (k, v) in six.iteritems(module.params) if k in key_list and v is not None}
 
             result = to_dict(oci_utils.list_all_resources(compute_client.list_boot_volume_attachments, **param_map))

--- a/library/oci_bucket.py
+++ b/library/oci_bucket.py
@@ -22,7 +22,7 @@ description:
     - Creates OCI bucket if not present.
     - Update OCI bucket, if present.
     - Delete OCI bucket, if present.
-version_added: "2.x"
+version_added: "2.5"
 options:
     namespace_name:
         description: Name of the namespace in which the bucket is available or should be available
@@ -281,8 +281,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    object_storage_client = ObjectStorageClient(
-        oci_utils.get_oci_config(module))
+    object_storage_client = oci_utils.create_service_client(module, ObjectStorageClient)
     state = module.params['state']
     if state == 'present':
         result = create_or_update_bucket(object_storage_client, module)

--- a/library/oci_bucket_facts.py
+++ b/library/oci_bucket_facts.py
@@ -21,7 +21,7 @@ short_description: Fetches details of a bucket or all available buckets within a
 description:
     - This module retrieves details of a bucket or all the buckets available for specified namespace and compartment
       identifier.
-version_added: "2.x"
+version_added: "2.5"
 options:
     namespace_name:
         description: Name of the namespace from which facts of constituent buckets needs to be fetched.
@@ -165,8 +165,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    object_storage_client = ObjectStorageClient(
-        oci_utils.get_oci_config(module))
+    object_storage_client = oci_utils.create_service_client(module, ObjectStorageClient)
 
     bucket_name = module.params['name']
     if bucket_name is not None:

--- a/library/oci_cluster.py
+++ b/library/oci_cluster.py
@@ -1,0 +1,382 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_cluster
+short_description: Manage Kubernetes clusters in OCI Container Engine for Kubernetes Service
+description:
+    - This module allows the user to create, delete and update Kubernetes clusters in OCI Container Engine for
+      Kubernetes Service.
+version_added: "2.5"
+options:
+    cluster_id:
+        description: The OCID of the cluster. Required to update/delete a cluster.
+        required: false
+        aliases: [ 'id' ]
+    compartment_id:
+        description: The OCID of the compartment in which to create the cluster. Required to create a cluster.
+        required: false
+    kubernetes_version:
+        description: The version of Kubernetes to install into the cluster masters. Required to create a cluster.
+        required: false
+    name:
+        description: The name of the cluster. Avoid entering confidential information. Required to create a cluster.
+        required: false
+    options:
+        description: Optional attributes for the cluster.
+        required: false
+        suboptions:
+            add_ons:
+                description: Configurable cluster add-ons.
+                required: false
+                suboptions:
+                    is_kubernetes_dashboard_enabled:
+                       description: Whether or not to enable the Kubernetes Dashboard add-on.
+                       required: false
+                    is_tiller_enabled:
+                       description: Whether or not to enable the Tiller add-on.
+                       required: false
+            kubernetes_network_config:
+                description: Network configuration for Kubernetes.
+                required: false
+                suboptions:
+                    pods_cidr:
+                        description: The CIDR block for Kubernetes pods.
+                        required: false
+                    services_cidr:
+                        description: The CIDR block for Kubernetes services.
+                        required: false
+            service_lb_subnet_ids:
+                description: The OCIDs of the subnets used for Kubernetes services load balancers.
+                required: false
+    vcn_id:
+        description: The OCID of the virtual cloud network (VCN) in which to create the cluster. Required to create a
+                     cluster.
+        required: false
+    state:
+        description: Create or update a cluster with I(state=present). Use I(state=absent) to delete a cluster.
+        required: false
+        default: present
+        choices: ['present', 'absent']
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: [ oracle, oracle_creatable_resource, oracle_wait_options ]
+'''
+
+EXAMPLES = '''
+- name: Create a cluster
+  oci_cluster:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    name: test_cluster
+    vcn_id: ocid1.vcn.oc1..xxxxxEXAMPLExxxxx
+    kubernetes_version: "v1.9.7"
+    options:
+      service_lb_subnet_ids:
+        - ocid1.subnet.oc1..xxxxxEXAMPLExxxxx
+        - ocid1.subnet.oc1..xxxxxEXAMPLExxxxx
+
+- name: Update name and version of Kubernetes master
+  oci_cluster:
+    id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+    name: ansible_cluster
+    kubernetes_version: "v1.10.3"
+
+- name: Delete a cluster
+  oci_cluster:
+    id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+    state: absent
+'''
+
+RETURN = '''
+cluster:
+    description: Information about the cluster
+    returned: On successful create, delete & update operations on cluster
+    type: complex
+    contains:
+        available_kubernetes_upgrades:
+            description: Available Kubernetes versions to which the clusters masters may be upgraded.
+            returned: always
+            type: list
+            sample: ["v1.10.3"]
+        compartment_id:
+            description: The OCID of the compartment in which the cluster exists.
+            returned: always
+            type: string
+            sample: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        endpoints:
+            description: Endpoints served up by the cluster masters.
+            returned: always
+            type: dict
+            sample: {"kubernetes": "xxxEXAMPLExxx.us-ashburn-1.clusters.oci.oraclecloud.com:6443"}
+        id:
+            description: The OCID of the cluster.
+            returned: always
+            type: string
+            sample: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+        kubernetes_version:
+            description: The version of Kubernetes running on the cluster masters.
+            returned: always
+            type: string
+            sample: v1.9.7
+        lifecycle_details:
+            description: Details about the state of the cluster masters.
+            returned: always
+            type: string
+        lifecycle_state:
+            description: The state of the cluster masters.
+            returned: always
+            type: string
+            sample: ACTIVE
+        metadata:
+            description: Metadata about the cluster.
+            returned: always
+            type: dict
+        name:
+            description: The name of the cluster.
+            returned: always
+            type: string
+            sample: sample_cluster
+        options:
+            description: Optional attributes for the cluster.
+            returned: always
+            type: dict
+        vcn_id:
+            description: The OCID of the virtual cloud network (VCN) in which the cluster exists.
+            returned: always
+            type: string
+    sample: {
+            "available_kubernetes_upgrades": [],
+            "compartment_id": ocid1.compartment.oc1..xxxxxEXAMPLExxxxx,
+            "endpoints": {
+                "kubernetes": "xxxxxEXAMPLExxxxx.clusters.oci.oraclecloud.com:xxxx"
+            },
+            "id": "ocid1.cluster.oc1..xxxxxEXAMPLExxxxx",
+            "kubernetes_version": "v1.10.3",
+            "lifecycle_details": "",
+            "lifecycle_state": "ACTIVE",
+            "metadata": {
+                "created_by_user_id": "ocid1.user.oc1..xxxxxEXAMPLExxxxx",
+                "created_by_work_request_id": "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx",
+                "deleted_by_user_id": null,
+                "deleted_by_work_request_id": null,
+                "time_created": "2018-07-26T18:42:25+00:00",
+                "time_deleted": null,
+                "time_updated": null,
+                "updated_by_user_id": null,
+                "updated_by_work_request_id": null
+            },
+            "name": "test",
+            "options": {
+                "add_ons": {
+                    "is_kubernetes_dashboard_enabled": true,
+                    "is_tiller_enabled": true
+                },
+                "kubernetes_network_config": {
+                    "pods_cidr": "10.244.0.0/16",
+                    "services_cidr": "10.96.0.0/16"
+                },
+                "service_lb_subnet_ids": []
+            },
+            "vcn_id": "ocid1.vcn.oc1.iad.xxxxxEXAMPLExxxxx"
+        }
+work_request:
+    description: Information of work request
+    returned: When a new work request is created
+    type: complex
+    contains:
+        compartment_id:
+            description: The OCID of the compartment in which the work request exists.
+            returned: always
+            type: string
+        id:
+            description: The OCID of the work request.
+            returned: always
+            type: string
+        operation_type:
+            description: The type of work the work request is doing.
+            returned: always
+            type: string
+        resources:
+            description: The resources this work request affects.
+            returned: always
+            type: list
+        status:
+            description: The current status of the work request.
+            returned: always
+            type: string
+        time_accepted:
+            description: The time the work request was accepted.
+            returned: always
+            type: datetime
+        time_finished:
+            description: The time the work request was finished.
+            returned: always
+            type: datetime
+        time_started:
+            description: The time the work request was started.
+            returned: always
+            type: datetime
+    sample: {
+            "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+            "id": "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx",
+            "operation_type": "CLUSTER_CREATE",
+            "resources": [
+                {
+                    "action_type": "IN_PROGRESS",
+                    "entity_type": "cluster",
+                    "entity_uri": "/clusters/ocid1.cluster.oc1..xxxxxEXAMPLExxxxx",
+                    "identifier": "ocid1.cluster.oc1..xxxxxEXAMPLExxxxx"
+                }
+            ],
+            "status": "ACCEPTED",
+            "time_accepted": "2018-07-26T18:42:26+00:00",
+            "time_finished": "2018-07-26T18:44:13+00:00",
+            "time_started": "2018-07-26T18:43:26+00:00"
+
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+from ansible.module_utils.oracle import oci_ce_utils
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    from oci.container_engine.models import CreateClusterDetails
+    from oci.container_engine.models import UpdateClusterDetails
+    from oci.container_engine.models import ClusterCreateOptions
+    from oci.container_engine.models import KubernetesNetworkConfig
+    from oci.container_engine.models import AddOnOptions
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def delete_cluster(container_engine_client, module):
+    result = oci_ce_utils.delete_and_wait(resource_type="cluster",
+                                          client=container_engine_client,
+                                          get_fn=container_engine_client.get_cluster,
+                                          kwargs_get={"cluster_id": module.params["cluster_id"]},
+                                          delete_fn=container_engine_client.delete_cluster,
+                                          kwargs_delete={"cluster_id": module.params["cluster_id"]},
+                                          module=module
+                                          )
+    return result
+
+
+def update_cluster(container_engine_client, module):
+    result = oci_ce_utils.update_and_wait(resource_type="cluster",
+                                          client=container_engine_client,
+                                          get_fn=container_engine_client.get_cluster,
+                                          kwargs_get={"cluster_id": module.params["cluster_id"]},
+                                          update_fn=container_engine_client.update_cluster,
+                                          primitive_params_update=['cluster_id'],
+                                          kwargs_non_primitive_update={
+                                              UpdateClusterDetails: "update_cluster_details"},
+                                          module=module,
+                                          update_attributes=UpdateClusterDetails().attribute_map.keys()
+                                          )
+    return result
+
+
+def create_cluster(container_engine_client, module):
+    create_cluster_details = CreateClusterDetails()
+    for attribute in create_cluster_details.attribute_map.keys():
+        if attribute in module.params:
+            setattr(create_cluster_details, attribute, module.params[attribute])
+
+    options = module.params['options']
+    if options:
+        cluster_create_options = ClusterCreateOptions()
+        cluster_create_options.service_lb_subnet_ids = options['service_lb_subnet_ids']
+        if options.get('add_ons', None):
+            add_ons = AddOnOptions()
+            add_ons.is_kubernetes_dashboard_enabled = options['add_ons']['is_kubernetes_dashboard_enabled']
+            add_ons.is_tiller_enabled = options['add_ons']['is_tiller_enabled']
+            cluster_create_options.add_ons = add_ons
+        if options.get('kubernetes_network_config', None):
+            kubernetes_network_config = KubernetesNetworkConfig()
+            kubernetes_network_config.pods_cidr = options['kubernetes_network_config']['pods_cidr']
+            kubernetes_network_config.services_cidr = options['kubernetes_network_config']['services_cidr']
+            cluster_create_options.kubernetes_network_config = kubernetes_network_config
+        create_cluster_details.options = cluster_create_options
+
+    result = oci_ce_utils.create_and_wait(resource_type="cluster",
+                                          create_fn=container_engine_client.create_cluster,
+                                          kwargs_create={"create_cluster_details": create_cluster_details},
+                                          client=container_engine_client,
+                                          get_fn=container_engine_client.get_cluster,
+                                          get_param="cluster_id",
+                                          module=module
+                                          )
+    return result
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec(supports_create=True, supports_wait=True)
+    module_args.update(dict(
+        compartment_id=dict(type='str', required=False),
+        cluster_id=dict(type='str', required=False, aliases=['id']),
+        kubernetes_version=dict(type='str', required=False),
+        name=dict(type='str', required=False),
+        options=dict(type=dict, required=False),
+        vcn_id=dict(type='str', required=False),
+        state=dict(type='str', required=False, default='present', choices=['absent', 'present'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_if=[
+            ('state', 'absent', ['cluster_id'])
+        ]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    state = module.params['state']
+    cluster_id = module.params['cluster_id']
+
+    if state == 'absent':
+        result = delete_cluster(container_engine_client, module)
+
+    else:
+        if cluster_id is not None:
+            result = update_cluster(container_engine_client, module)
+        else:
+            kwargs_list = {'compartment_id': module.params['compartment_id']}
+            exclude_attributes = {'name': True}
+            result = oci_utils.check_and_create_resource(resource_type='cluster',
+                                                         create_fn=create_cluster,
+                                                         kwargs_create={
+                                                             'container_engine_client': container_engine_client,
+                                                             'module': module},
+                                                         list_fn=container_engine_client.list_clusters,
+                                                         kwargs_list=kwargs_list,
+                                                         module=module,
+                                                         model=CreateClusterDetails(),
+                                                         exclude_attributes=exclude_attributes
+                                                         )
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_cluster_facts.py
+++ b/library/oci_cluster_facts.py
@@ -1,0 +1,196 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_cluster_facts
+short_description: Retrieve facts of clusters in OCI Container Engine for Kubernetes Service
+description:
+    - This module retrieves information of a specific cluster or of all the clusters in OCI Container Engine for
+      Kubernetes Service.
+version_added: "2.5"
+options:
+    cluster_id:
+        description: The OCID of the cluster. I(cluster_id) is required to get the details of a cluster.
+        required: false
+        aliases: [ 'id' ]
+    compartment_id:
+        description: The OCID of the compartment. I(compartment_id) is required to list all the cluster objects in a
+                     compartment.
+        required: false
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: [ oracle, oracle_name_option ]
+'''
+
+EXAMPLES = '''
+- name: Get all the clusters
+  oci_cluster_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+
+- name: Get a specific cluster
+  oci_cluster_facts:
+    cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+
+- name: Get clusters in a compartment having the specified name
+  oci_cluster_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    name: test_cluster
+'''
+
+RETURN = '''
+clusters:
+    description: List of cluster details
+    returned: always
+    type: complex
+    contains:
+        available_kubernetes_upgrades:
+            description: Available Kubernetes versions to which the clusters masters may be upgraded.
+            returned: always
+            type: list
+            sample: ["v1.10.3"]
+        compartment_id:
+            description: The OCID of the compartment in which the cluster exists.
+            returned: always
+            type: string
+            sample: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        endpoints:
+            description: Endpoints served up by the cluster masters.
+            returned: always
+            type: dict
+            sample: {"kubernetes": "xxxEXAMPLExxx.us-ashburn-1.clusters.oci.oraclecloud.com:6443"}
+        id:
+            description: The OCID of the cluster.
+            returned: always
+            type: string
+            sample: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+        kubernetes_version:
+            description: The version of Kubernetes running on the cluster masters.
+            returned: always
+            type: string
+            sample: v1.9.7
+        lifecycle_details:
+            description: Details about the state of the cluster masters.
+            returned: always
+            type: string
+        lifecycle_state:
+            description: The state of the cluster masters.
+            returned: always
+            type: string
+            sample: ACTIVE
+        metadata:
+            description: Metadata about the cluster.
+            returned: always
+            type: dict
+        name:
+            description: The name of the cluster.
+            returned: always
+            type: string
+            sample: sample_cluster
+        options:
+            description: Optional attributes for the cluster.
+            returned: always
+            type: dict
+        vcn_id:
+            description: The OCID of the virtual cloud network (VCN) in which the cluster exists.
+            returned: always
+            type: string
+    sample: [{
+            "available_kubernetes_upgrades": ["v1.10.3"],
+            "compartment_id": ocid1.compartment.oc1..xxxxxEXAMPLExxxxx,
+            "endpoints": {
+                "kubernetes": "xxxxxEXAMPLExxxxx.clusters.oci.oraclecloud.com:xxxx"
+            },
+            "id": "ocid1.cluster.oc1..xxxxxEXAMPLExxxxx",
+            "kubernetes_version": "v1.9.7",
+            "lifecycle_details": "",
+            "lifecycle_state": "ACTIVE",
+            "metadata": {
+                "created_by_user_id": "ocid1.user.oc1..xxxxxEXAMPLExxxxx",
+                "created_by_work_request_id": "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx",
+                "deleted_by_user_id": null,
+                "deleted_by_work_request_id": null,
+                "time_created": "2018-07-26T18:42:25+00:00",
+                "time_deleted": null,
+                "time_updated": null,
+                "updated_by_user_id": null,
+                "updated_by_work_request_id": null
+            },
+            "name": "test",
+            "options": {
+                "add_ons": {
+                    "is_kubernetes_dashboard_enabled": true,
+                    "is_tiller_enabled": true
+                },
+                "kubernetes_network_config": {
+                    "pods_cidr": "10.244.0.0/16",
+                    "services_cidr": "10.96.0.0/16"
+                },
+                "service_lb_subnet_ids": []
+            },
+            "vcn_id": "ocid1.vcn.oc1.iad.xxxxxEXAMPLExxxxx"
+        }]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def main():
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
+    module_args.update(dict(
+        cluster_id=dict(type='str', required=False, aliases=['id']),
+        compartment_id=dict(type='str', required=False)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    cluster_id = module.params['cluster_id']
+
+    try:
+        if cluster_id is not None:
+            result = [to_dict(oci_utils.call_with_backoff(container_engine_client.get_cluster,
+                                                          cluster_id=cluster_id).data)]
+        else:
+            result = to_dict(oci_utils.list_all_resources(container_engine_client.list_clusters,
+                                                          name=module.params['name'],
+                                                          compartment_id=module.params['compartment_id']))
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(clusters=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_cluster_options_facts.py
+++ b/library/oci_cluster_options_facts.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_cluster_options_facts
+short_description: Retrieve options available for clusters in OCI Container Engine for Kubernetes Service
+description:
+    - This module retrieves options available for clusters in OCI Container Engine for Kubernetes Service.
+version_added: "2.5"
+options:
+    cluster_option_id:
+        description: The id of the option set to retrieve. Only "all" is supported.
+        choices: ["all"]
+        required: true
+        aliases: [ 'id' ]
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: oracle
+'''
+
+EXAMPLES = '''
+- name: Get all options available for clusters
+  oci_cluster_options_facts:
+    cluster_option_id: all
+'''
+
+RETURN = '''
+cluster_options:
+    description: Options available for clusters
+    returned: always
+    type: complex
+    contains:
+        kubernetes_versions:
+            description: Available Kubernetes versions.
+            returned: always
+            type: list
+    sample: {
+            "kubernetes_versions": [
+                "v1.8.11",
+                "v1.9.7",
+                "v1.10.3",
+                "v1.11.1"
+            ]
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(
+        cluster_option_id=dict(type='str', required=True, choices=['all'], aliases=['id'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    try:
+        result = to_dict(oci_utils.call_with_backoff(container_engine_client.get_cluster_options,
+                                                     cluster_option_id=module.params['cluster_option_id']).data)
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(cluster_options=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_compartment.py
+++ b/library/oci_compartment.py
@@ -20,7 +20,7 @@ module: oci_compartment
 short_description: Manage compartments in OCI
 description:
     - This module allows the user to create and update a compartment in OCI.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the tenancy in which the compartment has to be created or the OCID of the compartment
@@ -136,8 +136,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
 
     compartment_id = module.params['compartment_id']
 

--- a/library/oci_customer_secret_key.py
+++ b/library/oci_customer_secret_key.py
@@ -24,7 +24,7 @@ description:
       Oracle-provided key for using the Object Storage Service's Amazon S3 compatible API. A user can have up to two
       secret keys at a time.
       Note: The secret key is always an Oracle-generated string; you can't change it to a string of your choice."
-version_added: "2.x"
+version_added: "2.5"
 options:
     user_id:
         description: The OCID of the user.
@@ -225,8 +225,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
     state = module.params['state']
 
     result = dict(changed=False)

--- a/library/oci_data_guard_association.py
+++ b/library/oci_data_guard_association.py
@@ -27,7 +27,7 @@ description:
     - Perform a reinstate on a disabled standby Database associated in a Data Guard Association
     - Since all operations of this module takes a long time, it is recommended to set the C(wait) to False. Use
       M(oci_data_guard_association_facts) to check the status of the operation as a separate task.
-version_added: "2.x"
+version_added: "2.5"
 options:
     database_id:
         description: Identifier of the Database to which the Data Guard should be Associated.
@@ -390,7 +390,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    db_client = DatabaseClient(oci_utils.get_oci_config(module))
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     state = module.params['state']
     if state == 'present':
         result = oci_utils.check_and_create_resource(resource_type='data_guard_association',

--- a/library/oci_data_guard_association_facts.py
+++ b/library/oci_data_guard_association_facts.py
@@ -20,7 +20,7 @@ module: oci_data_guard_association_facts
 short_description: Fetches details of an OCI Data Guard Association
 description:
     - Fetches details of an OCI Data Guard Association
-version_added: "2.x"
+version_added: "2.5"
 options:
     database_id:
         description: Identifier of the database whose Data Guard Association
@@ -229,8 +229,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_data_guard_associations(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_database.py
+++ b/library/oci_database.py
@@ -24,7 +24,7 @@ description:
     - Update a Database.
     - Since all operations of this module takes a long time, it is recommended to set the C(wait) to False. Use
       M(oci_database_facts) to check the status of the operation as a separate task.
-version_added: "2.x"
+version_added: "2.5"
 options:
     database_id:
         description: Identifier of the  Database that is required to be restored or updated.
@@ -301,7 +301,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    db_client = DatabaseClient(oci_utils.get_oci_config(module))
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     state = module.params['state']
     if state == 'restore':
         result = restore_database(db_client, module)

--- a/library/oci_database_facts.py
+++ b/library/oci_database_facts.py
@@ -20,7 +20,7 @@ module: oci_database_facts
 short_description: Fetches details of one or more Databases
 description:
     - Fetches details of one or more OCI Databases.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment in which the specified Database exists
@@ -241,8 +241,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_databases(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_db_home.py
+++ b/library/oci_db_home.py
@@ -24,7 +24,7 @@ description:
     - Delete an OCI DB Home, if present.
     - Since all operations of this module takes a long time, it is recommended to set the C(wait) to False. Use
       M(oci_db_home_facts) to check the status of the operation as a separate task.
-version_added: "2.x"
+version_added: "2.5"
 options:
     db_system_id:
         description: Identifier of the  DB System under which the DB Home should exist.
@@ -401,7 +401,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    db_client = DatabaseClient(oci_utils.get_oci_config(module))
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     if os.environ.get('OCI_DB_MOCK') is not None:
         db_client.base_client.session.headers.update(
             {'opc-host-serial': 'FakeHostSerial'})

--- a/library/oci_db_home_facts.py
+++ b/library/oci_db_home_facts.py
@@ -20,7 +20,7 @@ module: oci_db_home_facts
 short_description: Fetches details of one or more OCI DB Homes
 description:
     - Fetches details of the OCI DB Home.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment in which the specified DB System exists
@@ -34,7 +34,7 @@ options:
         aliases: ['id']
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -146,7 +146,8 @@ def list_db_homes(db_client, module):
                                compartment_id, db_system_id)
             existing_db_homes = oci_utils.list_all_resources(
                 db_client.list_db_homes,
-                compartment_id=compartment_id, db_system_id=db_system_id)
+                compartment_id=compartment_id, db_system_id=db_system_id,
+                display_name=module.params['display_name'])
         elif db_home_id:
             get_logger().debug("Listing DB Home %s", db_home_id)
             response = oci_utils.call_with_backoff(
@@ -171,7 +172,7 @@ def get_logger():
 def main():
     logger = oci_utils.get_logger("oci_db_home_facts")
     set_logger(logger)
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         db_system_id=dict(type='str', required=False),
@@ -188,8 +189,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_db_homes(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_db_home_patch_facts.py
+++ b/library/oci_db_home_patch_facts.py
@@ -20,7 +20,7 @@ module: oci_db_home_patch_facts
 short_description: Fetches details of one or more  DB Home Patches
 description:
     - Fetches details of one or more  DB Home Patches.
-version_added: "2.x"
+version_added: "2.5"
 options:
     db_home_id:
         description: Identifier of the  DB Home for which the Patches are
@@ -175,8 +175,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_db_home_patches(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_db_home_patch_history_entry_facts.py
+++ b/library/oci_db_home_patch_history_entry_facts.py
@@ -20,7 +20,7 @@ module: oci_db_home_patch_history_entry_facts
 short_description: Fetches details of one or more DB Home Patch History Entries
 description:
     - Fetches details of one or more  DB Home Patch History Entries.
-version_added: "2.x"
+version_added: "2.5"
 options:
     db_home_id:
         description: Identifier of the  DB Home whose Patch History Entries needs
@@ -165,8 +165,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_db_home_patch_history_entries(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_db_node.py
+++ b/library/oci_db_node.py
@@ -24,7 +24,7 @@ description:
     - Soft-reset a DB Node
     - All operations of this module returns after triggering the lifecycle operation. Use M(oci_db_node_facts)
       to check the status of the operation.
-version_added: "2.x"
+version_added: "2.5"
 options:
     db_node_id:
         description: Identifier of the DB Node whose lifecycle state is to be controlled.
@@ -217,7 +217,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    db_client = DatabaseClient(oci_utils.get_oci_config(module))
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = perform_db_node_action(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_db_node_facts.py
+++ b/library/oci_db_node_facts.py
@@ -20,7 +20,7 @@ module: oci_db_node_facts
 short_description: Fetches details of one or more OCI DB Nodes
 description:
     - Fetches details of the OCI DB Home.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment in which the
@@ -188,8 +188,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_db_nodes(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_db_system_facts.py
+++ b/library/oci_db_system_facts.py
@@ -20,7 +20,7 @@ module: oci_db_system_facts
 short_description: Fetches details of the OCI DB System
 description:
     - Fetches details of the OCI DB System.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment in which this
@@ -32,7 +32,7 @@ options:
         aliases: ['id']
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -256,7 +256,8 @@ def list_db_systems(db_client, module):
             get_logger().debug("Listing all DB Systems under compartment %s", compartment_id)
             existing_db_systems = oci_utils.list_all_resources(
                 db_client.list_db_systems,
-                compartment_id=compartment_id)
+                compartment_id=compartment_id,
+                display_name=module.params['display_name'])
         elif db_system_id:
             get_logger().debug("Listing DB System %s", db_system_id)
             response = oci_utils.call_with_backoff(
@@ -281,7 +282,7 @@ def get_logger():
 def main():
     logger = oci_utils.get_logger("oci_db_system_facts")
     set_logger(logger)
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         db_system_id=dict(type='str', required=False, aliases=['id'])
@@ -296,8 +297,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_db_systems(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_db_system_patch_facts.py
+++ b/library/oci_db_system_patch_facts.py
@@ -20,7 +20,7 @@ module: oci_db_system_patch_facts
 short_description: Fetches details of one or more DB System Patches
 description:
     - Fetches details of one or more  DB System Patches.
-version_added: "2.x"
+version_added: "2.5"
 options:
     db_system_id:
         description: Identifier of the  DB System for which the Patches are
@@ -174,8 +174,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_db_system_patches(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_db_system_patch_history_entry_facts.py
+++ b/library/oci_db_system_patch_history_entry_facts.py
@@ -20,7 +20,7 @@ module: oci_db_system_patch_history_entry_facts
 short_description: Fetches details of one or more DB System Patch History Entries
 description:
     - Fetches details of one or more  DB System Patch History Entries.
-version_added: "2.x"
+version_added: "2.5"
 options:
     db_system_id:
         description: Identifier of the  DB System whose Patch History Entries needs
@@ -165,8 +165,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_db_system_patch_history_entries(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_db_system_shape_facts.py
+++ b/library/oci_db_system_shape_facts.py
@@ -20,7 +20,7 @@ module: oci_db_system_shape_facts
 short_description: Fetches details of all DB System Shapes
 description:
     - Fetches details of all DB System Shapes.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment where DB Systems should be
@@ -31,7 +31,7 @@ options:
         required: true
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_name_option ]
 '''
 EXAMPLES = '''
 #Fetch DB System Shapes
@@ -102,7 +102,8 @@ def list_db_system_shapes(db_client, module):
                            compartment_id, availability_domain)
         db_system_shapes = oci_utils.list_all_resources(
             db_client.list_db_system_shapes,
-            availability_domain=availability_domain, compartment_id=compartment_id)
+            availability_domain=availability_domain, compartment_id=compartment_id,
+            name=module.params['name'])
     except ServiceError as ex:
         get_logger().error("Unable to list DB System Shapes due to %s", ex.message)
         module.fail_json(msg=ex.message)
@@ -123,7 +124,7 @@ def get_logger():
 def main():
     logger = oci_utils.get_logger("oci_db_system_shape_facts")
     set_logger(logger)
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
     module_args.update(dict(
         compartment_id=dict(type='str', required=True),
         availability_domain=dict(type='str', required=True)
@@ -135,8 +136,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_db_system_shapes(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_db_version_facts.py
+++ b/library/oci_db_version_facts.py
@@ -20,7 +20,7 @@ module: oci_db_version_facts
 short_description: Fetches details of all DB Versions
 description:
     - Fetches details of all DB Versions.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment where Database should be
@@ -140,8 +140,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    db_client = DatabaseClient(oci_config)
+    db_client = oci_utils.create_service_client(module, DatabaseClient)
     result = list_db_versions(db_client, module)
 
     module.exit_json(**result)

--- a/library/oci_dhcp_options_facts.py
+++ b/library/oci_dhcp_options_facts.py
@@ -22,7 +22,7 @@ short_description: Fetches details of a specific Dhcp Options or a list of Dhcp 
                    compartment
 description:
     - Fetches details of a specific Dhcp Options or a list of Dhcp Optionss in the specified VCN and compartment.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment details about
@@ -40,7 +40,7 @@ options:
         aliases: ['id']
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -179,7 +179,8 @@ def list_dhcp_options(virtual_network_client, module):
         if compartment_id and vcn_id:
             existing_dhcp_options = oci_utils.list_all_resources(
                 virtual_network_client.list_dhcp_options,
-                compartment_id=compartment_id, vcn_id=vcn_id)
+                compartment_id=compartment_id, vcn_id=vcn_id,
+                display_name=module.params['display_name'])
         elif dhcp_id:
             response = oci_utils.call_with_backoff(
                 virtual_network_client.get_dhcp_options, dhcp_id=dhcp_id)
@@ -191,7 +192,7 @@ def list_dhcp_options(virtual_network_client, module):
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         vcn_id=dict(type='str', required=False),
@@ -208,8 +209,8 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(oci_config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
+
     result = list_dhcp_options(virtual_network_client, module)
 
     module.exit_json(**result)

--- a/library/oci_domain_records.py
+++ b/library/oci_domain_records.py
@@ -1,0 +1,315 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_domain_records
+short_description: Update or Patch a collection of records in the specified zone in OCI DNS Service
+description:
+    - This module allows the user to update or patch a collection of records in the specified DNS zone in OCI DNS
+      Service.
+version_added: "2.5"
+options:
+    zone_id:
+        description: The OCID of the target zone. Either I(name) or I(zone_id) must be specified to update or path
+                     the collection of records in the specified zone.
+        required: false
+        aliases: ['id']
+    name:
+        description: The name of the zone. Required to create a zone. Either I(name) or I(zone_id) must be specified
+                     to update or patch the collection of recordsin the specified zone.
+        required: false
+        aliases: ['zone_name']
+    compartment_id:
+        description: The OCID of the compartment the resource belongs to.
+        required: false
+    domain:
+        description: The target fully-qualified domain name (FQDN) within the target zone.
+        required: true
+    update_items:
+        description: The items to update the Zone's domain records collection to. Replaces records in the specified
+                     zone at a domain with the records specified in the request body. If a specified record does not
+                     exist, it will be created. If the record exists, then it will be updated to represent the record
+                     in the body of the request. If a record in the zone does not exist in the request body, the record
+                     will be removed from the zone. Required to update a zone's domain records.
+        required: false
+        suboptions:
+            domain:
+                description: The fully qualified domain name where the record can be located.
+                required: true
+            record_hash:
+                description: A unique identifier for the record within its zone.
+                required: false
+            is_protected:
+                description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                             managed.
+                required: false
+            rdata:
+                description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+                required: true
+            rr_set_version:
+                description: The latest version of the record's zone in which its RRSet differs from the preceding
+                             version.
+                required: false
+            rtype:
+                description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                             L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+                required: true
+            ttl:
+                description: The Time To Live for the record, in seconds.
+                required: true
+    patch_items:
+        description: The record operations to patch the Zone's domain records collection. Updates records in the
+                     specified zone at a domain. You can update one record or all records for the specified zone
+                     depending on the changes provided in the request body. You can also add or remove records
+                     using this option. Required to patch a zone's domain records.
+        required: false
+        suboptions:
+            domain:
+                description: The fully qualified domain name where the record can be located.
+                required: false
+            record_hash:
+                description: A unique identifier for the record within its zone.
+                required: false
+            is_protected:
+                description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                             managed.
+                required: false
+            rdata:
+                description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+                required: false
+            rr_set_version:
+                description: The latest version of the record's zone in which its RRSet differs from the preceding
+                             version.
+                required: false
+            rtype:
+                description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                             L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+                required: false
+            ttl:
+                description: The Time To Live for the record, in seconds.
+                required: true
+            operation:
+                description: A description of how a record relates to a PATCH operation. REQUIRE indicates a
+                             precondition that record data must already exist. PROHIBIT indicates a precondition that
+                             record data must not already exist. ADD indicates that record data must exist after
+                             successful application. REMOVE indicates that record data must not exist after successful
+                             application. Note - ADD and REMOVE operations can succeed even if they require no changes
+                             when applied, such as when the described records are already present or absent.
+                             Note - ADD and REMOVE operations can describe changes for more than one record.
+                             Example - { "domain" - "www.example.com", "rtype" - "AAAA", "ttl" - 60 } specifies a new TTL
+                             for every record in the www.example.com AAAA RRSet.'
+                required: false
+                choices: ['REQUIRE', 'PROHIBIT', 'ADD', 'REMOVE']
+    state:
+        description: State of the Zone's domain records
+        required: false
+        default: present
+        choices: ['present']
+author: "Sivakumar Thyagarajan (@sivakumart)"
+extends_documentation_fragment: [ oracle, oracle_wait_options ]
+'''
+
+EXAMPLES = '''
+- name: Update a zone's domain records by adding a new record. This operation replaces domain records in the specified
+        zone with the specified records. So ensure that you include the original domain records, if you want to retain
+        existing records.
+  oci_domain_records:
+    name: "test_zone_1.com"
+    domain: "test_zone_1.com"
+    update_items: [ <original zone records...> , { domain: "test_zone_1.com", ttl: 30, rtype='TXT', rdata='some textual
+                    data' } ]
+
+- name: Patch a zone's domain's records
+  oci_domain_records:
+    name: test_zone1.com
+    patch_items: [ { domain: "test_zone_1.com", is_protected: false, rdata: 'some textual data',
+                     rtype: "TXT", ttl: 30, operation: "REMOVE" }]
+'''
+
+RETURN = '''
+domain_records:
+    description: Information about the zone's domain resource records
+    returned: On successful update or patch of zone's domain resource records
+    type: complex
+    contains:
+        domain:
+            description: The fully qualified domain name where the record can be located.
+            returned: always
+            type: string
+            sample: "test_zone_1.com"
+        record_hash:
+            description: A unique identifier for the record within its zone.
+            returned: always
+            type: string
+            sample: 722af089872ffe65ba909fc8fea1867e
+        is_protected:
+            description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                         managed.
+            returned: always
+            type: boolean
+            sample: false
+        rdata:
+            description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+            returned: always
+            type: string
+            sample: "ns3.p68.dns.oraclecloud.net."
+        rrsetVersion:
+            description: The latest version of the record's zone in which its RRSet differs from the preceding version.
+            returned: always
+            type: string
+            sample: "5"
+        rtype:
+            description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                         L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+            returned: always
+            type: string
+            sample: "NS"
+        ttl:
+            description: The Time To Live for the record, in seconds.
+            returned: always
+            type: string
+            sample: "86400"
+    sample:
+                {
+                    "domain": "test_zone_1.com",
+                    "is_protected": true,
+                    "rdata": "ns2.p68.dns.oraclecloud.net.",
+                    "record_hash": "9be3279d81b5e8430fd94c70cfa5f0a8",
+                    "rrset_version": "1",
+                    "rtype": "NS",
+                    "ttl": 86400
+                }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    from oci.dns.dns_client import DnsClient
+    from oci.dns.models import PatchDomainRecordsDetails, RecordOperation, RecordDetails, UpdateDomainRecordsDetails
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+RESOURCE_NAME = "domain_records"
+
+
+# DNS client accepts either a zone name or an id through the zone_name_or_id parameter for update and delete scenarios.
+# This is different from other resources.
+# XXX: for now only zone_name appears to work, and not OCID. Using an OCID gives an error "Invalid Domain Name".
+def get_zone_name_or_id(module):
+    if module.params['name'] is not None:
+        return module.params['name']
+    if module.params['zone_id'] is not None:
+        return module.params['zone_id']
+    if module.params['id'] is not None:
+        return module.params['id']
+    return None
+
+
+def create_model(model_class, user_values):
+    model_instance = model_class()
+    for attr in model_instance.attribute_map.keys():
+        if attr in user_values:
+            setattr(model_instance, attr, user_values[attr])
+    return model_instance
+
+
+def modify_domain_records(dns_client, module, modify_operation, modify_kwargs):
+    result = {}
+    try:
+        # get current domain records
+        domain_records_old = oci_utils.call_with_backoff(
+            dns_client.get_domain_records,
+            zone_name_or_id=get_zone_name_or_id(module),
+            domain=module.params['domain']).data.items
+
+        # update domain records
+        updated_rec_coll = oci_utils.call_with_backoff(modify_operation, **modify_kwargs).data
+        result[RESOURCE_NAME] = oci_utils.to_dict(updated_rec_coll.items)
+
+        # get domain records after update
+        domain_records_new = oci_utils.call_with_backoff(
+            dns_client.get_domain_records,
+            zone_name_or_id=get_zone_name_or_id(module),
+            domain=module.params['domain']).data.items
+
+        # check if there is any change between the old and the new domain records, and set changed accordingly
+        result['changed'] = not oci_utils.compare_list(domain_records_old, domain_records_new)
+    except ServiceError as ex:
+        module.fail_json(msg=str(ex))
+    return result
+
+
+def patch_domain_records(dns_client, module):
+    patch_items = module.params['patch_items']
+    patch_domain_records_details = PatchDomainRecordsDetails()
+    patch_domain_records_details.items = [create_model(RecordOperation, item) for item in patch_items]
+    kwargs = {"patch_domain_records_details": patch_domain_records_details,
+              "zone_name_or_id": get_zone_name_or_id(module), "domain": module.params['domain']}
+    return modify_domain_records(dns_client, module, modify_operation=dns_client.patch_domain_records,
+                                 modify_kwargs=kwargs)
+
+
+def update_domain_records(dns_client, module):
+    update_items = module.params['update_items']
+    update_domain_records_details = UpdateDomainRecordsDetails()
+    update_domain_records_details.items = [create_model(RecordDetails, item) for item in update_items]
+    kwargs = {"update_domain_records_details": update_domain_records_details,
+              "zone_name_or_id": get_zone_name_or_id(module), "domain": module.params['domain']}
+    return modify_domain_records(dns_client, module, modify_operation=dns_client.update_domain_records,
+                                 modify_kwargs=kwargs)
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec(supports_wait=True)
+    module_args.update(dict(
+        compartment_id=dict(type='str', required=False),
+        zone_id=dict(type='str', required=False, aliases=['id']),
+        name=dict(type='str', required=False, aliases=['zone_name']),
+        domain=dict(type='str', required=True),
+        update_items=dict(type='list', required=False),
+        patch_items=dict(type='list', required=False),
+        state=dict(type='str', required=False, default='present', choices=['present'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_one_of=[['update_items', 'patch_items'], ['zone_id', 'name']]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    config = oci_utils.get_oci_config(module)
+    dns_client = DnsClient(config)
+
+    state = module.params['state']
+    if state == 'present':
+        if module.params['update_items'] is not None:
+            result = update_domain_records(dns_client, module)
+        else:
+            result = patch_domain_records(dns_client, module)
+        module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_domain_records_facts.py
+++ b/library/oci_domain_records_facts.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_domain_records_facts
+short_description: Retrieve facts of domain records in a specified zone in Oracle Cloud Infrastructure DNS Service
+description:
+    - This module retrieves information of all records at the specified zone and domain. The results are sorted by
+      rtype in alphabetical order by default.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: The OCID of the compartment the resource belongs to. Use I(zone_id) or I(zone_name)
+                     to retrieve a specific zone's information using its OCID.
+        required: false
+    zone_id:
+        description: OCID of the target zone.
+        required: false
+        aliases: ['id']
+    name:
+        description: A case-sensitive filter for zone names. Will match any zone with a name that equals the
+                     provided value.
+        required: false
+        aliases: ['zone_name']
+    zone_version:
+        description: The version of the zone for which data is requested.
+        required: false
+    domain:
+        description: Search by domain. Will match any record whose domain (case-insensitive) equals the
+                     provided value.
+        required: false
+    rtype:
+        description: Search by record type. Will match any record whose type (case-insensitive) equals the provided
+                     value.
+        required: false
+author: "Sivakumar Thyagarajan (@sivakumart)"
+extends_documentation_fragment: oracle
+'''
+
+EXAMPLES = '''
+- name: Get a list of domain zone records in the specified zone and domain
+  oci_domain_records_facts:
+    zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+    domain: "test_zone_1.com"
+- name: Get a list of NS zone records in the specified zone and domain
+  oci_domain_records_facts:
+    zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+    domain: "test_zone_1.com"
+    rtype: 'NS'
+'''
+
+RETURN = '''
+domain_records:
+    description: A collection of DNS resource record objects.
+    returned: always
+    type: complex
+    contains:
+        domain:
+            description: The fully qualified domain name where the record can be located.
+            returned: always
+            type: string
+            sample: "test_zone_1.com"
+        record_hash:
+            description: A unique identifier for the record within its zone.
+            returned: always
+            type: string
+            sample: "f439fa9a087ff74757485953fe0a8c7d"
+        is_protected:
+            description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                         managed.
+            returned: always
+            type: boolean
+            sample: true
+        rdata:
+            description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+            returned: always
+            type: string
+            sample: "ns1.p68.dns.oraclecloud.net. hostmaster.test_zone_1.com. 1 3600 600 604800 1800"
+        rrset_version:
+            description: The latest version of the record's zone in which its RRSet differs from the preceding version.
+            returned: always
+            type: string
+            sample: "1"
+        rtype:
+            description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                         L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+            returned: always
+            type: string
+            sample: "NS"
+        ttl:
+            description: The Time To Live for the record, in seconds.
+            returned: always
+            type: string
+            sample: "86400"
+    sample:
+                {
+                    "domain": "test_zone_1.com",
+                    "is_protected": true,
+                    "rdata": "ns2.p68.dns.oraclecloud.net.",
+                    "record_hash": "9be3279d81b5e8430fd94c70cfa5f0a8",
+                    "rrset_version": "1",
+                    "rtype": "NS",
+                    "ttl": 86400
+                }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+import six
+
+try:
+    from oci.dns.dns_client import DnsClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+# DNS client accepts either a zone name or an id through the zone_name_or_id parameter for update and delete scenarios.
+# This is different from other resources.
+def get_zone_name_or_id(module):
+    if module.params['name'] is not None:
+        return module.params['name']
+    if module.params['zone_id'] is not None:
+        return module.params['zone_id']
+    if module.params['id'] is not None:
+        return module.params['id']
+    return None
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(
+        zone_id=dict(type='str', required=False, aliases=['id']),
+        name=dict(type='str', required=False, aliases=['zone_name']),
+        compartment_id=dict(type='str', required=False),
+        domain=dict(type='str', required=True),
+        zone_version=dict(type='str', required=False),
+        rtype=dict(type='str', required=False)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_one_of=[
+            ['zone_id', 'name']
+        ]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    config = oci_utils.get_oci_config(module)
+    dns_client = DnsClient(config)
+
+    try:
+        zone_name_or_id = get_zone_name_or_id(module)
+        key_list = ["compartment_id", "zone_version", "rtype"]
+        kwargs = {k: v for (k, v) in six.iteritems(module.params) if k in key_list and v is not None}
+
+        result = to_dict(oci_utils.call_with_backoff(dns_client.get_domain_records,
+                                                     zone_name_or_id=zone_name_or_id,
+                                                     domain=module.params['domain'],
+                                                     **kwargs).data.items)
+
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(domain_records=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_dynamic_group.py
+++ b/library/oci_dynamic_group.py
@@ -1,0 +1,198 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_dynamic_group
+short_description: Manage dynamic groups in OCI
+description:
+    - This module allows the user to create, delete and update dynamic groups in Oracle Cloud Infrastructure.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: The OCID of the tenancy containing the group. Required to create a dynamic group.
+        required: false
+    description:
+        description: The description you assign to the group during creation. Does not have to be unique, and it's
+                     changeable. Required to create a dynamic group.
+        required: false
+    dynamic_group_id:
+        description: The OCID of the dynamic group. Required to delete or update a dynamic group.
+        required: false
+        aliases: [ 'id' ]
+    matching_rule:
+        description: The matching rule to dynamically match an instance certificate to this dynamic group. For rule
+                     syntax, see
+                     U(https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm).
+                     Required to create a dynamic group.
+        required: false
+    name:
+        description: The name you assign to the group during creation. The name must be unique across all groups in the
+                     tenancy and cannot be changed. Required to create a dynamic group.
+        required: false
+    state:
+        description: Create or update a dynamic group with I(state=present). Use I(state=absent) to delete a dynamic
+                     group.
+        required: false
+        default: present
+        choices: ['present', 'absent']
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: [ oracle, oracle_wait_options, oracle_tags ]
+'''
+
+EXAMPLES = '''
+- name: Create a dynamic group
+  oci_dynamic_group:
+    compartment_id: ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx
+    description: Group for all instances that are in a specific compartment
+    matching_rule: "instance.compartment.id = 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx'"
+    name: Sample dynamic group
+
+- name: Update matching rule and description of a dynamic group
+  oci_dynamic_group:
+    id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+    description: Group for all instances with the tag namespace and tag key operations.department
+    matching_rule: "tag.operations.department.value"
+
+- name: Delete a dynamic group
+  oci_dynamic_group:
+    id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+    state: absent
+'''
+
+RETURN = '''
+dynamic_group:
+    description: Information about the dynamic group
+    returned: On successful create, delete & update operation
+    type: dict
+    sample: {
+            "compartment_id": "ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx",
+            "description": "Group for all instances with the tag namespace and tag key operations.department",
+            "id": "ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx",
+            "inactive_status": null,
+            "lifecycle_state": "ACTIVE",
+            "matching_rule": "tag.operations.department.value",
+            "name": "Sample dynamic group",
+            "time_created": "2018-07-05T09:38:27.176000+00:00"
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    from oci.identity.identity_client import IdentityClient
+    from oci.identity.models import CreateDynamicGroupDetails
+    from oci.identity.models import UpdateDynamicGroupDetails
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def delete_dynamic_group(identity_client, module):
+    result = oci_utils.delete_and_wait(resource_type="dynamic_group",
+                                       client=identity_client,
+                                       get_fn=identity_client.get_dynamic_group,
+                                       kwargs_get={"dynamic_group_id": module.params["dynamic_group_id"]},
+                                       delete_fn=identity_client.delete_dynamic_group,
+                                       kwargs_delete={"dynamic_group_id": module.params["dynamic_group_id"]},
+                                       module=module
+                                       )
+    return result
+
+
+def update_dynamic_group(identity_client, module):
+    result = oci_utils.check_and_update_resource(resource_type="dynamic_group",
+                                                 get_fn=identity_client.get_dynamic_group,
+                                                 kwargs_get={"dynamic_group_id": module.params["dynamic_group_id"]},
+                                                 update_fn=identity_client.update_dynamic_group,
+                                                 primitive_params_update=['dynamic_group_id'],
+                                                 kwargs_non_primitive_update={
+                                                     UpdateDynamicGroupDetails: "update_dynamic_group_details"},
+                                                 module=module,
+                                                 update_attributes=UpdateDynamicGroupDetails().attribute_map.keys()
+                                                 )
+
+    return result
+
+
+def create_dynamic_group(identity_client, module):
+    create_dynamic_group_details = CreateDynamicGroupDetails()
+    for attribute in create_dynamic_group_details.attribute_map.keys():
+        if attribute in module.params:
+            setattr(create_dynamic_group_details, attribute, module.params[attribute])
+
+    result = oci_utils.create_and_wait(resource_type="dynamic_group",
+                                       create_fn=identity_client.create_dynamic_group,
+                                       kwargs_create={"create_dynamic_group_details": create_dynamic_group_details},
+                                       client=identity_client,
+                                       get_fn=identity_client.get_dynamic_group,
+                                       get_param="dynamic_group_id",
+                                       module=module
+                                       )
+    return result
+
+
+def main():
+    module_args = oci_utils.get_taggable_arg_spec(supports_wait=True)
+    module_args.update(dict(
+        compartment_id=dict(type='str', required=False),
+        description=dict(type='str', required=False),
+        matching_rule=dict(type='str', required=False),
+        name=dict(type='str', required=False),
+        state=dict(type='str', required=False, default='present', choices=['absent', 'present']),
+        dynamic_group_id=dict(type='str', required=False, aliases=['id'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_if=[('state', 'absent', ['dynamic_group_id'])]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
+
+    state = module.params['state']
+    dynamic_group_id = module.params['dynamic_group_id']
+
+    if state == 'absent':
+        result = delete_dynamic_group(identity_client, module)
+
+    else:
+        if dynamic_group_id is not None:
+            result = update_dynamic_group(identity_client, module)
+        else:
+            result = oci_utils.check_and_create_resource(resource_type='dynamic_group',
+                                                         create_fn=create_dynamic_group,
+                                                         kwargs_create={
+                                                             'identity_client': identity_client,
+                                                             'module': module},
+                                                         list_fn=identity_client.list_dynamic_groups,
+                                                         kwargs_list={"compartment_id": module.params['compartment_id']
+                                                                      },
+                                                         module=module,
+                                                         model=CreateDynamicGroupDetails(),
+                                                         )
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_dynamic_group_facts.py
+++ b/library/oci_dynamic_group_facts.py
@@ -1,0 +1,158 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_dynamic_group_facts
+short_description: Retrieve facts of dynamic groups
+description:
+    - This module retrieves information of the specified dynamic group or lists all the dynamic groups in a tenancy.
+version_added: "2.5"
+options:
+    dynamic_group_id:
+        description: The OCID of the dynamic group. I(dynamic_group_id) is required to get a specific dynamic group's
+                     information.
+        required: false
+        aliases: [ 'id' ]
+    compartment_id:
+        description: The OCID of the compartment (remember that the tenancy is simply the root compartment).
+                     Required to list all the dynamic groups in a tenancy.
+        required: false
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: [ oracle, oracle_name_option ]
+'''
+
+EXAMPLES = '''
+- name: Get all the dynamic groups in a tenancy
+  oci_dynamic_group_facts:
+    compartment_id: ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx
+
+- name: Get information of a specific dynamic group
+  oci_dynamic_group_facts:
+    dynamic_group_id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+'''
+
+RETURN = '''
+dynamic_groups:
+    description: List of dynamic group details
+    returned: always
+    type: complex
+    contains:
+        compartment_id:
+            description: The OCID of the tenancy containing the group.
+            returned: always
+            type: string
+            sample: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        description:
+            description: The description you assign to the group. Does not have to be unique, and it's changeable.
+            returned: always
+            type: string
+            sample: "Group for all instances with the tag namespace and tag key operations.department"
+        id:
+            description: The OCID of the group.
+            returned: always
+            type: string
+            sample: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+        inactive_status:
+            description: The detailed status of INACTIVE lifecycleState.
+            returned: always
+            type: int
+            sample: 1
+        lifecycle_state:
+            description: The group's current state. After creating a group, make sure its lifecycleState changes from
+                         CREATING to ACTIVE before using it.
+            returned: always
+            type: string
+            sample: ACTIVE
+        matching_rule:
+            description: A rule string that defines which instance certificates will be matched. For syntax, see
+                         U(https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm).
+            returned: always
+            type: string
+            sample: tag.operations.department.value
+        time_created:
+            description: Date and time the group was created, in the format defined by RFC3339.
+            returned: always
+            type: datetime
+            sample: 2018-03-28T18:37:56.190000+00:00
+        name:
+            description: The name you assign to the group during creation. The name must be unique across all groups in
+                         the tenancy and cannot be changed.
+            returned: always
+            type: string
+            sample: Sample dynamic group
+    sample: [{
+            "compartment_id": "ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx",
+            "description": "Group for all instances with the tag namespace and tag key operations.department",
+            "id": "ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx",
+            "inactive_status": null,
+            "lifecycle_state": "ACTIVE",
+            "matching_rule": "tag.operations.department.value",
+            "name": "Sample dynamic group",
+            "time_created": "2018-07-05T09:38:27.176000+00:00"
+        }]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.identity.identity_client import IdentityClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def main():
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
+    module_args.update(dict(
+        dynamic_group_id=dict(type='str', required=False, aliases=['id']),
+        compartment_id=dict(type='str', required=False)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
+
+    dynamic_group_id = module.params['dynamic_group_id']
+
+    try:
+        if dynamic_group_id is not None:
+            result = [to_dict(oci_utils.call_with_backoff(identity_client.get_dynamic_group,
+                                                          dynamic_group_id=dynamic_group_id).data)]
+        else:
+            result = to_dict(oci_utils.list_all_resources(identity_client.list_dynamic_groups,
+                                                          compartment_id=module.params['compartment_id'],
+                                                          name=module.params['name']))
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(dynamic_groups=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_fault_domain_facts.py
+++ b/library/oci_fault_domain_facts.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_fault_domain_facts
+short_description: Retrieve details of fault domains in your tenancy
+description:
+    - This module retrieves details of all fault domains in your tenancy. Specify the OCID of either the tenancy
+      or another of your compartments as the value for the compartment ID (remember that the tenancy is simply
+      the root compartment).
+version_added: "2.5"
+options:
+    compartment_id:
+        description: The OCID of the compartment (either the tenancy or another compartment in the tenancy).
+        required: true
+    availability_domain:
+        description: The name of the availibility domain.
+        required: true
+author: "Sivakumar Thyagarajan (@sivakumart)"
+extends_documentation_fragment: [ oracle, oracle_name_option ]
+'''
+
+EXAMPLES = '''
+- name: Get details of all the fault domains in AD1 in your tenancy
+  oci_fault_domain_facts:
+    compartment_id: 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...vm62xq'
+    availability_domain: "IwGV:US-ASHBURN-AD-2"
+'''
+
+RETURN = '''
+fault_domains:
+    description: Information about one or more fault domains in your tenancy
+    returned: on success
+    type: complex
+    contains:
+        name:
+            description: The name of the Fault Domain.
+            returned: always
+            type: string
+            sample: FAULT-DOMAIN-1
+        compartment_id:
+            description: The OCID of the compartment.
+            returned: always
+            type: string
+            sample: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq
+        availability_domain:
+            description: The name of the availabilityDomain where the Fault Domain belongs.
+            returned: always
+            type: string
+            sample: IwGV:US-ASHBURN-AD-2
+        id:
+            description: The OCID of the Fault Domain.
+            returned: always
+            type: string
+            sample: ocid1.faultdomain.oc1..xxxxxEXAMPLExxxxx..4dnw3a
+    sample: {
+       "fault_domains": [
+            {
+              "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq",
+              "id": "ocid1.faultdomain.oc1..xxxxxEXAMPLExxxxx..4dnw3a",
+              "availability_domain": "IwGV:US-ASHBURN-AD-2",
+              "name": "FAULT-DOMAIN-1"
+            },
+            {
+              "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq",
+              "id": "ocid1.faultdomain.oc1..xxxxxEXAMPLExxxxx..3dsdaa",
+              "availability_domain": "IwGV:US-ASHBURN-AD-2",
+              "name": "FAULT-DOMAIN-2"
+            },
+            {
+              "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx..6glmkwq",
+              "id": "ocid1.faultdomain.oc1..xxxxxEXAMPLExxxxx..6ttdaa",
+              "availability_domain": "IwGV:US-ASHBURN-AD-2",
+              "name": "FAULT-DOMAIN-3"
+            }
+          ]
+       }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.identity.identity_client import IdentityClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def list_fault_domains(identity_client, module):
+    try:
+        cid = module.params['compartment_id']
+        ad = module.params['availability_domain']
+        name = module.params['name']
+        fault_domains = oci_utils.list_all_resources(identity_client.list_fault_domains, compartment_id=cid,
+                                                     availability_domain=ad, name=name)
+    except AttributeError as ae:
+        # list_fault_domains is not available
+        module.fail_json(msg="Exception: {0}. OCI Python SDK 2.0.1 or above is required to use "
+                             "`oci_fault_domain_facts`. The local SDK version is {1}".format(str(ae), oci.__version__))
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    return to_dict(fault_domains)
+
+
+def main():
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
+    module_args.update(dict(
+        compartment_id=dict(type='str', required=True),
+        availability_domain=dict(type=str, required=True)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
+
+    result = list_fault_domains(identity_client, module)
+    module.exit_json(fault_domains=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_group.py
+++ b/library/oci_group.py
@@ -26,7 +26,7 @@ description:
     - Update OCI group, if present, with new user(s) associations
     - Update OCI group, if present, removing all user associations
     - Delete OCI group, if present.
-version_added: "2.x"
+version_added: "2.5"
 options:
     name:
         description: Name of the group. Must be unique within a tenancy.
@@ -141,7 +141,7 @@ group:
             sample: ocid1.group.oc1.axdf
         inactive_status:
             description: The detailed status of INACTIVE life cycle state
-            returned: always
+            returned: when group's lifecycle_state is INACTIVE
             type: string
             sample: null
         lifecycle_state:
@@ -425,7 +425,8 @@ def main():
         module.fail_json(msg='oci python sdk required for this module')
 
     oci_config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(oci_config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
+
     compartment_id = oci_config['tenancy']
     module.params.update(dict({'compartment_id': compartment_id}))
     state = module.params['state']

--- a/library/oci_image.py
+++ b/library/oci_image.py
@@ -22,7 +22,7 @@ short_description: Create, import, update and delete OCI Compute images
 description:
     - This module allows the user to create an image, import an exported image, update an image and delete OCI Compute
       Images.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment containing the instance that needs to be used as the basis for the
@@ -277,8 +277,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    compute_client = ComputeClient(config)
+    compute_client = oci_utils.create_service_client(module, ComputeClient)
     state = module.params['state']
 
     result = dict(changed=False)

--- a/library/oci_image_facts.py
+++ b/library/oci_image_facts.py
@@ -21,7 +21,7 @@ short_description: Retrieve details about one or more Compute images in OCI Comp
 description:
     - This module retrieves details about a specific image, or all images in a specified Compartment in OCI Compute
       Service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment (either the tenancy or another compartment in the tenancy). Required
@@ -33,7 +33,7 @@ options:
         aliases: ['id']
 
 author: "Sivakumar Thyagarajan (@sivakumart)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -125,7 +125,7 @@ except ImportError:
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         image_id=dict(type='str', required=False, aliases=['id'])
@@ -140,8 +140,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    compute_client = ComputeClient(config)
+    compute_client = oci_utils.create_service_client(module, ComputeClient)
 
     compartment_id = module.params['compartment_id']
     id = module.params['image_id']
@@ -149,7 +148,8 @@ def main():
     result = dict(changed=False)
     try:
         if compartment_id:
-            inst = oci_utils.list_all_resources(compute_client.list_images, compartment_id=compartment_id)
+            inst = oci_utils.list_all_resources(compute_client.list_images, compartment_id=compartment_id,
+                                                display_name=module.params['display_name'])
             result = to_dict(inst)
         else:
             inst = oci_utils.call_with_backoff(compute_client.get_image, image_id=id).data

--- a/library/oci_internet_gateway.py
+++ b/library/oci_internet_gateway.py
@@ -24,7 +24,7 @@ description:
     - Update OCI Internet Gateway, if present, with a new display name
     - Update OCI Internet Gateway, if present, with enable/disable state
     - Delete OCI Internet Gateway, if present.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment under which this Internet Gateway would be created. Mandatory for
@@ -255,8 +255,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(oci_config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
     state = module.params['state']
 
     if state == 'present':

--- a/library/oci_internet_gateway_facts.py
+++ b/library/oci_internet_gateway_facts.py
@@ -22,7 +22,7 @@ short_description: Fetches details of the OCI Internet Gateway under a Virtual
                    Cloud Network
 description:
     - Fetches details of the OCI Internet Gateway under a Virtual Cloud Network.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment in which this
@@ -40,7 +40,7 @@ options:
         aliases: ['id']
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -133,7 +133,8 @@ def list_internet_gateways(virtual_network_client, module):
         if compartment_id and vcn_id:
             existing_igs = oci_utils.list_all_resources(
                 virtual_network_client.list_internet_gateways,
-                compartment_id=compartment_id, vcn_id=vcn_id)
+                compartment_id=compartment_id, vcn_id=vcn_id,
+                display_name=module.params['display_name'])
         elif ig_id:
             response = oci_utils.call_with_backoff(
                 virtual_network_client.get_internet_gateway, ig_id=ig_id)
@@ -145,7 +146,7 @@ def list_internet_gateways(virtual_network_client, module):
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         vcn_id=dict(type='str', required=False),
@@ -162,8 +163,8 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(oci_config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
+
     result = list_internet_gateways(virtual_network_client, module)
 
     module.exit_json(**result)

--- a/library/oci_kubeconfig.py
+++ b/library/oci_kubeconfig.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_kubeconfig
+short_description: Create the Kubeconfig YAML for a cluster in OCI container engine for Kubernetes service.
+description:
+    - This module creates a cluster kubeconfig in OCI Container Engine for Kubernetes Service.
+version_added: "2.5"
+options:
+    cluster_id:
+        description: The OCID of the cluster.
+        required: true
+    create_cluster_kubeconfig_content_details :
+        description: The details of the cluster kubeconfig to create.
+        required: false
+        suboptions:
+            expiration:
+                description: The desired expiration, in seconds, to use for the kubeconfig token.
+                required: false
+            token_version:
+                description: The version of the kubeconfig token.
+                required: false
+    dest:
+        description: The complete file path of the file to which kubeconfig content should be written.
+        required: false
+    force:
+        description: Whether to force overwrite an existing kubeconfig file.
+        required: false
+        default: false
+        aliases: ['overwrite']
+        type: bool
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: oracle
+'''
+
+EXAMPLES = '''
+- name: Create a kubeconfig for a cluster
+  oci_kubeconfig:
+    cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+    create_cluster_kubeconfig_content_details:
+        expiration: 600
+    dest: "/usr/local/my_kubeconfig"
+'''
+
+RETURN = '''
+kubeconfig:
+    description: kubeconfig content
+    returned: always
+    type: dict
+    sample: {
+            kubeconfig: "apiVersion: v1\nclusters:\n- cluster:\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJ
+            Q0FURS0tLS0tCk1JSURqRENDQW5TZ....."
+    }
+'''
+
+import os
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+from ansible.module_utils.oracle import oci_ce_utils
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    from oci.container_engine.models import CreateClusterKubeconfigContentDetails
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def write_to_file(path, content):
+    with open(path, 'wb') as dest_file:
+        dest_file.write(content)
+
+
+def create_kubeconfig(container_engine_client, module):
+    result = dict(changed=False)
+    kubeconfig_details = CreateClusterKubeconfigContentDetails()
+    kubeconfig_param = module.params['create_cluster_kubeconfig_content_details']
+    if kubeconfig_param:
+        for attribute in kubeconfig_details.attribute_map.keys():
+            if kubeconfig_param.get(attribute, None):
+                kubeconfig_details.attribute = kubeconfig_param[attribute]
+
+    # Wait for cluster to be active before attempting to create kubeconfig.
+    oci_ce_utils.wait_on_resource(container_engine_client,
+                                  module,
+                                  container_engine_client.get_cluster,
+                                  {'cluster_id': module.params['cluster_id']},
+                                  states=["ACTIVE"])
+
+    result['kubeconfig'] = oci_utils.call_with_backoff(container_engine_client.create_kubeconfig,
+                                                       cluster_id=module.params['cluster_id'],
+                                                       create_cluster_kubeconfig_content_details=kubeconfig_details
+                                                       ).data.content
+    if module.params['dest']:
+        if module.params['force'] or not os.path.isfile(module.params['dest']):
+            write_to_file(module.params['dest'], result['kubeconfig'])
+            result['changed'] = True
+
+    return result
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(
+        cluster_id=dict(type='str', required=True),
+        create_cluster_kubeconfig_content_details=dict(type='dict', required=False),
+        dest=dict(type='str', required=False),
+        force=dict(type='bool', required=False, default=False, aliases=['overwrite'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_if=[
+            ('force', True, ['dest'])
+        ]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    try:
+        result = create_kubeconfig(container_engine_client, module)
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_load_balancer_backend_facts.py
+++ b/library/oci_load_balancer_backend_facts.py
@@ -21,7 +21,7 @@ module: oci_load_balancer_backend_facts
 short_description: Fetch details of all Backends in a load balancer backend set of a load balancer
 description:
     - Fetch details of all Backends in a load balancer backend set of a load balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     load_balancer_id:
         description: Identifier of the Load Balancer to which the Backends belongs.
@@ -188,7 +188,7 @@ def main():
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
-    lb_client = LoadBalancerClient(oci_utils.get_oci_config(module))
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
     result = list_load_balancer_backends(lb_client, module)
 
     module.exit_json(**result)

--- a/library/oci_load_balancer_backend_health_facts.py
+++ b/library/oci_load_balancer_backend_health_facts.py
@@ -20,7 +20,7 @@ module: oci_load_balancer_backend_health_facts
 short_description: Fetch details of Backend Health in a load balancer backend set of a load balancer
 description:
     - Fetch details of Backend Health in a load balancer backend set of a load balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     load_balancer_id:
         description: Identifier of the Load Balancer to which the Backends belongs.
@@ -155,7 +155,7 @@ def main():
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
-    lb_client = LoadBalancerClient(oci_utils.get_oci_config(module))
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
 
     result = get_load_balancer_backend_health(lb_client, module)
 

--- a/library/oci_load_balancer_backend_set_facts.py
+++ b/library/oci_load_balancer_backend_set_facts.py
@@ -21,7 +21,7 @@ module: oci_load_balancer_backend_set_facts
 short_description: Fetches details of backend set(s) that are associated with a load balancer
 description:
     - Fetches details of all backend sets, or a specific backend set, that are associated with a load balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     name:
         description: Name of the Backend Set
@@ -229,8 +229,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    lb_client = LoadBalancerClient(oci_config)
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
     result = list_load_balancer_backend_sets(lb_client, module)
 
     module.exit_json(**result)

--- a/library/oci_load_balancer_backend_set_health_facts.py
+++ b/library/oci_load_balancer_backend_set_health_facts.py
@@ -20,7 +20,7 @@ module: oci_load_balancer_backend_set_health_facts
 short_description: Fetch details of a Backend Set's health in a load balancer
 description:
     - Fetch details of Backend Set's health in a load balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     load_balancer_id:
         description: Identifier of the Load Balancer to which the Backends belongs.
@@ -157,7 +157,7 @@ def main():
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
-    lb_client = LoadBalancerClient(oci_utils.get_oci_config(module))
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
 
     result = get_load_balancer_backend_set_health(lb_client, module)
 

--- a/library/oci_load_balancer_certificate_facts.py
+++ b/library/oci_load_balancer_certificate_facts.py
@@ -21,7 +21,7 @@ module: oci_load_balancer_certificate_facts
 short_description: Fetch details of all certificates associated with a load balancer
 description:
     - Fetch details of all certificates or details of a particular certificate that is associated with a load balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     load_balancer_id:
         description: Identifier of the Load Balancer to which the certificate belongs.
@@ -154,8 +154,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    lb_client = LoadBalancerClient(oci_config)
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
     result = list_load_balancer_certificates(lb_client, module)
 
     module.exit_json(**result)

--- a/library/oci_load_balancer_facts.py
+++ b/library/oci_load_balancer_facts.py
@@ -22,7 +22,7 @@ module: oci_load_balancer_facts
 short_description: Fetches details of the OCI Load Balancer
 description:
     - Fetches details of the OCI Load Balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment in which this
@@ -34,7 +34,7 @@ options:
         aliases: ['id']
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -239,13 +239,15 @@ def list_load_balancers(lb_client, module):
     )
     compartment_id = module.params.get('compartment_id')
     load_balancer_id = module.params.get('load_balancer_id')
+    display_name = module.params.get('display_name')
     try:
         if compartment_id:
             get_logger().debug("Listing all load balancers under \
             compartment %s", compartment_id)
             existing_load_balancers = oci_utils.list_all_resources(
                 lb_client.list_load_balancers,
-                compartment_id=compartment_id)
+                compartment_id=compartment_id,
+                display_name=display_name)
         elif load_balancer_id:
             get_logger().debug("Listing load balancer %s", load_balancer_id)
             response = lb_client.get_load_balancer(load_balancer_id)
@@ -269,7 +271,7 @@ def get_logger():
 def main():
     logger = oci_utils.get_logger("oci_load_balancer_facts")
     set_logger(logger)
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         load_balancer_id=dict(type='str', required=False, aliases=['id'])
@@ -284,8 +286,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    lb_client = LoadBalancerClient(oci_config)
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
     result = list_load_balancers(lb_client, module)
 
     module.exit_json(**result)

--- a/library/oci_load_balancer_health_checker_facts.py
+++ b/library/oci_load_balancer_health_checker_facts.py
@@ -20,7 +20,7 @@ module: oci_load_balancer_health_checker_facts
 short_description: Fetch details of all health checker details of load balancer backend sets of a load balancer
 description:
     - Fetch details of all health checker details of load balancer backend sets of a load balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     load_balancer_id:
         description: Identifier of the Load Balancer to which the Backends belongs.
@@ -186,7 +186,7 @@ def main():
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
-    lb_client = LoadBalancerClient(oci_utils.get_oci_config(module))
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
     result = list_load_balancer_health_checker(lb_client, module)
 
     module.exit_json(**result)

--- a/library/oci_load_balancer_health_facts.py
+++ b/library/oci_load_balancer_health_facts.py
@@ -20,7 +20,7 @@ module: oci_load_balancer_health_facts
 short_description: Fetch details of a Load Balancer Health
 description:
     - Fetch details of a Load Balancer Health.
-version_added: "2.x"
+version_added: "2.5"
 options:
     load_balancer_id:
         description: Identifier of the Load Balancer
@@ -152,7 +152,7 @@ def main():
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
-    lb_client = LoadBalancerClient(oci_utils.get_oci_config(module))
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
 
     result = get_load_balancer_health(lb_client, module)
 

--- a/library/oci_load_balancer_health_summary_facts.py
+++ b/library/oci_load_balancer_health_summary_facts.py
@@ -20,7 +20,7 @@ module: oci_load_balancer_health_summary_facts
 short_description: Fetches the summary health statuses for all load balancers in a given compartment.
 description:
     - Fetches the summary health statuses for all load balancers in a given compartment.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the Compartment containing all Load Balancer
@@ -121,7 +121,7 @@ def main():
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
-    lb_client = LoadBalancerClient(oci_utils.get_oci_config(module))
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
 
     result = list_load_balancer_healths(lb_client, module)
 

--- a/library/oci_load_balancer_hostname_facts.py
+++ b/library/oci_load_balancer_hostname_facts.py
@@ -21,7 +21,7 @@ module: oci_load_balancer_hostname_facts
 short_description: Fetch details of all hostnames of a load balancer
 description:
     - Fetch details of all hostnames of a load balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     load_balancer_id:
         description: Identifier of the Load Balancer to which the hostnames belongs.
@@ -133,8 +133,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    lb_client = LoadBalancerClient(oci_config)
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
     result = list_load_balancer_hostnames(lb_client, module)
 
     module.exit_json(**result)

--- a/library/oci_load_balancer_listener_facts.py
+++ b/library/oci_load_balancer_listener_facts.py
@@ -21,7 +21,7 @@ module: oci_load_balancer_listener_facts
 short_description: Fetch details of all listeners of a load balancer
 description:
     - Fetch details of all listeners of a load balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     load_balancer_id:
         description: Identifier of the Load Balancer to which the listeners belongs.
@@ -188,7 +188,7 @@ def main():
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
-    lb_client = LoadBalancerClient(oci_utils.get_oci_config(module))
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
     result = list_load_balancer_listeners(lb_client, module)
 
     module.exit_json(**result)

--- a/library/oci_load_balancer_path_route_set_facts.py
+++ b/library/oci_load_balancer_path_route_set_facts.py
@@ -20,7 +20,7 @@ module: oci_load_balancer_path_route_set_facts
 short_description: Fetches details of path route set(s) that are associated with a load balancer
 description:
     - Fetches details of all path route sets, or a specific path route set, that are associated with a load balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     path_route_set_name:
         description: Name of the Path Route Set
@@ -151,8 +151,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    lb_client = LoadBalancerClient(oci_config)
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
     result = list_load_balancer_path_route_sets(lb_client, module)
 
     module.exit_json(**result)

--- a/library/oci_load_balancer_policy_facts.py
+++ b/library/oci_load_balancer_policy_facts.py
@@ -20,7 +20,7 @@ module: oci_load_balancer_policy_facts
 short_description: Fetches details of all load balancer policies supported in the OCI Load Balancer Service.
 description:
     - Fetches details of all load balancer policies supported in the OCI Load Balancer Service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the Compartment containing all Load Balancer
@@ -28,7 +28,7 @@ options:
         aliases: ['id']
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_name_option ]
 '''
 
 EXAMPLES = '''
@@ -83,7 +83,8 @@ def list_load_balancer_policies(lb_client, module):
     try:
         result['load_balancer_policies'] = to_dict(oci_utils.list_all_resources(
             lb_client.list_policies,
-            compartment_id=compartment_id))
+            compartment_id=compartment_id,
+            name=module.params['name']))
     except ServiceError as ex:
         get_logger().error("Unable to list all load balancer policies due to: %s", ex.message)
         module.fail_json(msg=ex.message)
@@ -103,7 +104,7 @@ def get_logger():
 def main():
     logger = oci_utils.get_logger("oci_load_balancer_policy_facts")
     set_logger(logger)
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
     module_args.update(dict(
         compartment_id=dict(type='str', required=True, aliases=['id'])
     ))
@@ -113,7 +114,7 @@ def main():
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
-    lb_client = LoadBalancerClient(oci_utils.get_oci_config(module))
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
 
     result = list_load_balancer_policies(lb_client, module)
 

--- a/library/oci_load_balancer_protocol_facts.py
+++ b/library/oci_load_balancer_protocol_facts.py
@@ -20,7 +20,7 @@ module: oci_load_balancer_protocol_facts
 short_description: Fetches details of all the traffic protocols supported in the OCI Load Balancer Service.
 description:
     - Fetches details of all the traffic protocols supported in the OCI Load Balancer Service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the Compartment containing all Load Balancer
@@ -28,7 +28,7 @@ options:
         aliases: ['id']
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_name_option ]
 '''
 
 EXAMPLES = '''
@@ -83,7 +83,8 @@ def list_load_balancer_protocols(lb_client, module):
     try:
         result['load_balancer_protocols'] = to_dict(oci_utils.list_all_resources(
             lb_client.list_protocols,
-            compartment_id=compartment_id))
+            compartment_id=compartment_id,
+            name=module.params['name']))
     except ServiceError as ex:
         get_logger().error("Unable to list all load balancer protocols due to: %s", ex.message)
         module.fail_json(msg=ex.message)
@@ -103,7 +104,7 @@ def get_logger():
 def main():
     logger = oci_utils.get_logger("oci_load_balancer_protocol_facts")
     set_logger(logger)
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
     module_args.update(dict(
         compartment_id=dict(type='str', required=True, aliases=['id'])
     ))
@@ -113,7 +114,7 @@ def main():
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
-    lb_client = LoadBalancerClient(oci_utils.get_oci_config(module))
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
 
     result = list_load_balancer_protocols(lb_client, module)
 

--- a/library/oci_load_balancer_shape_facts.py
+++ b/library/oci_load_balancer_shape_facts.py
@@ -20,7 +20,7 @@ module: oci_load_balancer_shape_facts
 short_description: Fetches details of all valid load balancer shapes supported in the OCI Load Balancer Service.
 description:
     - Fetches details of all valid load balancer shapes supported in the OCI Load Balancer Service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the Compartment containing all Load Balancer
@@ -28,7 +28,7 @@ options:
         aliases: ['id']
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_name_option ]
 '''
 
 EXAMPLES = '''
@@ -83,7 +83,8 @@ def list_load_balancer_shapes(lb_client, module):
     try:
         result['load_balancer_shapes'] = to_dict(oci_utils.list_all_resources(
             lb_client.list_shapes,
-            compartment_id=compartment_id))
+            compartment_id=compartment_id,
+            name=module.params.get('name')))
     except ServiceError as ex:
         get_logger().error("Unable to list all load balancer shapes due to: %s", ex.message)
         module.fail_json(msg=ex.message)
@@ -103,7 +104,7 @@ def get_logger():
 def main():
     logger = oci_utils.get_logger("oci_load_balancer_shape_facts")
     set_logger(logger)
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
     module_args.update(dict(
         compartment_id=dict(type='str', required=True, aliases=['id'])
     ))
@@ -113,7 +114,7 @@ def main():
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
-    lb_client = LoadBalancerClient(oci_utils.get_oci_config(module))
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
 
     result = list_load_balancer_shapes(lb_client, module)
 

--- a/library/oci_load_balancer_work_request_facts.py
+++ b/library/oci_load_balancer_work_request_facts.py
@@ -21,7 +21,7 @@ module: oci_load_balancer_work_request_facts
 short_description: Fetch details of all work_requests of a load balancer
 description:
     - Fetch details of all work_requests of a load balancer.
-version_added: "2.x"
+version_added: "2.5"
 options:
     load_balancer_id:
         description: Identifier of the Load Balancer to which the Work Requests belongs.
@@ -210,8 +210,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    lb_client = LoadBalancerClient(oci_config)
+    lb_client = oci_utils.create_service_client(module, LoadBalancerClient)
     result = list_load_balancer_work_requests(lb_client, module)
 
     module.exit_json(**result)

--- a/library/oci_node_pool.py
+++ b/library/oci_node_pool.py
@@ -1,0 +1,417 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_node_pool
+short_description: Manage node pools in OCI Container Engine for Kubernetes Service
+description:
+    - This module allows the user to create, delete and update node pools in OCI Container Engine for Kubernetes
+      Service.
+version_added: "2.5"
+options:
+    cluster_id:
+        description: The OCID of the cluster to which this node pool is attached. Required to create a node pool.
+        required: false
+    compartment_id:
+        description: The OCID of the compartment in which the node pool exists. Required to create a node pool.
+        required: false
+    initial_node_labels:
+        description: A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+        required: false
+        suboptions:
+            key:
+                description: The key of the pair.
+                required: true
+            value:
+                description: The value of the pair.
+                required: true
+    kubernetes_version:
+        description: The version of Kubernetes to install on the nodes in the node pool. Required to create a node pool.
+        required: false
+    name:
+        description: The name of the node pool. Avoid entering confidential information. Required to create a node pool.
+        required: false
+    node_image_name:
+        description: The name of the image running on the nodes in the node pool. Required to create a node pool.
+        required: false
+    node_pool_id:
+        description: The OCID of the node pool. Required to update or delete a node pool.
+        required: false
+        aliases: ['id']
+    node_shape:
+        description: The name of the node shape of the nodes in the node pool. Required to create a node pool.
+        required: false
+    quantity_per_subnet:
+        description: The number of nodes to create in each subnet.
+        required: false
+    ssh_public_key:
+        description: The SSH public key to add to each node in the node pool.
+        required: false
+    subnet_ids:
+        description: The OCIDs of the subnets in which to place nodes for this node pool. Required to create a node
+                     pool.
+        required: false
+    state:
+        description: Create or update a node pool with I(state=present). Use I(state=absent) to delete a node pool.
+        required: false
+        default: present
+        choices: ['present', 'absent']
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: [ oracle, oracle_creatable_resource, oracle_wait_options ]
+'''
+
+EXAMPLES = '''
+- name: Create a node pool
+  oci_node_pool:
+    cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    name: test_node_pool
+    kubernetes_version: "v1.9.7"
+    node_image_name: "Oracle-Linux-7.4"
+    node_shape: "VM.Standard1.1"
+    quantity_per_subnet: 1
+    subnet_ids: ["ocid1.subnet.oc1..xxxxxEXAMPLExxxxx"]
+    initial_node_labels:
+      - key: "vm_type"
+        value: "standard"
+      - key: "stage"
+        value: "dev"
+
+- name: Update node pool
+  oci_node_pool:
+    id: ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx
+    name: ansible_node_pool
+    kubernetes_version: "v1.10.3"
+    initial_node_labels:
+      - key: "vm_type"
+        value: "standard"
+      - key: "stage"
+        value: "prod"
+
+- name: Delete node pool
+  oci_node_pool:
+    id: ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx
+    state: absent
+'''
+
+RETURN = '''
+node_pool:
+    description: Information about the node pool
+    returned: On successful create, delete & update operations on node pool
+    type: complex
+    contains:
+        cluster_id:
+            description: The OCID of the cluster to which this node pool is attached.
+            returned: always
+            type: list
+            sample: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+        compartment_id:
+            description: The OCID of the compartment in which the node pool exists.
+            returned: always
+            type: string
+            sample: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        id:
+            description: The OCID of the node pool.
+            returned: always
+            type: string
+            sample: ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx
+        initial_node_labels:
+            description: A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+            returned: always
+            type: list
+            sample: [
+                {
+                    "key": "vm_type",
+                    "value": "standard"
+                },
+                {
+                    "key": "stage",
+                    "value": "prod"
+                }
+            ]
+        kubernetes_version:
+            description: The version of Kubernetes running on the nodes in the node pool.
+            returned: always
+            type: string
+            sample: v1.9.7
+        lifecycle_details:
+            description: Details about the state of the cluster masters.
+            returned: always
+            type: string
+        name:
+            description: The name of the node pool.
+            returned: always
+            type: string
+            sample: sample_node_pool
+        node_image_id:
+            description: The OCID of the image running on the nodes in the node pool.
+            returned: always
+            type: string
+            sample: ocid1.image.oc1..xxxxxEXAMPLExxxxx
+        node_shape:
+            description: The name of the node shape of the nodes in the node pool.
+            returned: always
+            type: string
+            sample: VM.Standard1.1
+        nodes:
+            description: The nodes in the node pool.
+            returned: always
+            type: string
+        quantity_per_subnet:
+            description: The number of nodes in each subnet.
+            returned: always
+            type: int
+            sample: 1
+        ssh_public_key:
+            description: The SSH public key on each node in the node pool.
+            returned: always
+            type: string
+        subnet_ids:
+            description: The OCIDs of the subnets in which to place nodes for this node pool.
+            returned: always
+            type: list
+    sample: {
+            "cluster_id": "ocid1.cluster.oc1..xxxxxEXAMPLExxxxx",
+            "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+            "id": "ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx",
+            "initial_node_labels": [
+                {
+                    "key": "vm_type",
+                    "value": "standard"
+                },
+                {
+                    "key": "stage",
+                    "value": "prod"
+                }
+            ],
+            "kubernetes_version": "v1.9.7",
+            "name": "test_node_pool",
+            "node_image_id": "ocid1.image.oc1..xxxxxEXAMPLExxxxx",
+            "node_image_name": "Oracle-Linux-7.4",
+            "node_shape": "VM.Standard1.1",
+            "nodes": [
+                {
+                    "availability_domain": "IwGV:US-ASHBURN-AD-1",
+                    "id": "ocid1.instance.oc1..xxxxxEXAMPLExxxxx",
+                    "lifecycle_details": "waiting for running compute instance",
+                    "lifecycle_state": "UPDATING",
+                    "name": "oke-c3dsodfgezw-n3wiztggrrt-st2au5vefpq-0",
+                    "node_error": null,
+                    "node_pool_id": "ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx",
+                    "public_ip": "129.213.129.26",
+                    "subnet_id": "ocid1.subnet.oc1..xxxxxEXAMPLExxxxx"
+                }
+            ],
+            "quantity_per_subnet": 1,
+            "ssh_public_key": "",
+            "subnet_ids": [
+                "ocid1.subnet..xxxxxEXAMPLExxxxx"
+            ]
+        }
+work_request:
+    description: Information of work request
+    returned: When a new work request is created
+    type: complex
+    contains:
+        compartment_id:
+            description: The OCID of the compartment in which the work request exists.
+            returned: always
+            type: string
+        id:
+            description: The OCID of the work request.
+            returned: always
+            type: string
+        operation_type:
+            description: The type of work the work request is doing.
+            returned: always
+            type: string
+        resources:
+            description: The resources this work request affects.
+            returned: always
+            type: list
+        status:
+            description: The current status of the work request.
+            returned: always
+            type: string
+        time_accepted:
+            description: The time the work request was accepted.
+            returned: always
+            type: datetime
+        time_finished:
+            description: The time the work request was finished.
+            returned: always
+            type: datetime
+        time_started:
+            description: The time the work request was started.
+            returned: always
+            type: datetime
+    sample: {
+            "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+            "id": "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx",
+            "operation_type": "NODEPOOL_UPDATE",
+            "resources": [
+                {
+                    "action_type": "UPDATED",
+                    "entity_type": "nodepool",
+                    "entity_uri": "/nodePools/ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx",
+                    "identifier": "ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx"
+                },
+                {
+                    "action_type": "RELATED",
+                    "entity_type": "cluster",
+                    "entity_uri": "/clusters/ocid1.cluster.oc1..xxxxxEXAMPLExxxxx",
+                    "identifier": "ocid1.cluster.oc1..xxxxxEXAMPLExxxxx"
+                }
+            ],
+            "status": "SUCCEEDED",
+            "time_accepted": "2018-08-02T10:22:22+00:00",
+            "time_finished": "2018-08-02T10:24:13+00:00",
+            "time_started": "2018-08-02T10:24:09+00:00"
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+from ansible.module_utils.oracle import oci_ce_utils
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    from oci.container_engine.models import CreateNodePoolDetails
+    from oci.container_engine.models import UpdateNodePoolDetails
+    from oci.container_engine.models import KeyValue
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def delete_node_pool(container_engine_client, module):
+    result = oci_ce_utils.delete_and_wait(resource_type="node_pool",
+                                          client=container_engine_client,
+                                          get_fn=container_engine_client.get_node_pool,
+                                          kwargs_get={"node_pool_id": module.params["node_pool_id"]},
+                                          delete_fn=container_engine_client.delete_node_pool,
+                                          kwargs_delete={"node_pool_id": module.params["node_pool_id"]},
+                                          module=module,
+                                          wait_applicable=False
+                                          )
+    return result
+
+
+def update_node_pool(container_engine_client, module):
+    result = oci_ce_utils.update_and_wait(resource_type="node_pool",
+                                          client=container_engine_client,
+                                          get_fn=container_engine_client.get_node_pool,
+                                          kwargs_get={"node_pool_id": module.params["node_pool_id"]},
+                                          update_fn=container_engine_client.update_node_pool,
+                                          primitive_params_update=['node_pool_id'],
+                                          kwargs_non_primitive_update={
+                                              UpdateNodePoolDetails: "update_node_pool_details"},
+                                          module=module,
+                                          update_attributes=UpdateNodePoolDetails().attribute_map.keys(),
+                                          wait_applicable=False
+                                          )
+    return result
+
+
+def create_node_pool(container_engine_client, module):
+    create_node_pool_details = CreateNodePoolDetails()
+    for attribute in create_node_pool_details.attribute_map.keys():
+        if attribute in module.params:
+            setattr(create_node_pool_details, attribute, module.params[attribute])
+
+    node_labels = module.params['initial_node_labels']
+    if node_labels:
+        initial_node_labels = []
+        for d in node_labels:
+            keyvalue = KeyValue()
+            if d.get("key", None) and d.get("value", None):
+                keyvalue.key = d.get("key")
+                keyvalue.value = d.get("value")
+                initial_node_labels.append(keyvalue)
+        create_node_pool_details.initial_node_labels = initial_node_labels
+
+    result = oci_ce_utils.create_and_wait(resource_type="node_pool",
+                                          create_fn=container_engine_client.create_node_pool,
+                                          kwargs_create={"create_node_pool_details": create_node_pool_details},
+                                          client=container_engine_client,
+                                          get_fn=container_engine_client.get_node_pool,
+                                          get_param="node_pool_id",
+                                          module=module
+                                          )
+    return result
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec(supports_create=True, supports_wait=True)
+    module_args.update(dict(
+        compartment_id=dict(type='str', required=False),
+        node_pool_id=dict(type='str', required=False, aliases=['id']),
+        cluster_id=dict(type='str', required=False),
+        kubernetes_version=dict(type='str', required=False),
+        name=dict(type='str', required=False),
+        initial_node_labels=dict(type=list, required=False),
+        subnet_ids=dict(type=list, required=False),
+        state=dict(type='str', required=False, default='present', choices=['absent', 'present']),
+        node_image_name=dict(type='str', required=False),
+        node_shape=dict(type='str', required=False),
+        quantity_per_subnet=dict(type='int', required=False),
+        ssh_public_key=dict(type='str', required=False)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_if=[
+            ('state', 'absent', ['node_pool_id'])
+        ]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    state = module.params['state']
+    node_pool_id = module.params['node_pool_id']
+
+    if state == 'absent':
+        result = delete_node_pool(container_engine_client, module)
+
+    else:
+        if node_pool_id is not None:
+            result = update_node_pool(container_engine_client, module)
+        else:
+            kwargs_list = {'compartment_id': module.params['compartment_id']}
+            exclude_attributes = {'name': True}
+            result = oci_utils.check_and_create_resource(resource_type='node_pool',
+                                                         create_fn=create_node_pool,
+                                                         kwargs_create={
+                                                             'container_engine_client': container_engine_client,
+                                                             'module': module},
+                                                         list_fn=container_engine_client.list_node_pools,
+                                                         kwargs_list=kwargs_list,
+                                                         module=module,
+                                                         model=CreateNodePoolDetails(),
+                                                         exclude_attributes=exclude_attributes
+                                                         )
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_node_pool_facts.py
+++ b/library/oci_node_pool_facts.py
@@ -1,0 +1,228 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_node_pool_facts
+short_description: Retrieve facts of node pools in OCI Container Engine for Kubernetes Service
+description:
+    - This module retrieves information of a specific node pool or of all the node pools in OCI Container Engine
+      for Kubernetes Service.
+version_added: "2.5"
+options:
+    node_pool_id:
+        description: The OCID of the node pool. I(node_pool_id) is required to get the details of a node pool.
+        required: false
+        aliases: [ 'id' ]
+    compartment_id:
+        description: The OCID of the compartment. I(compartment_id) is required to list all the node pools in a
+                     compartment.
+        required: false
+    cluster_id:
+        description: The OCID of the cluster.
+        required: false
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: [ oracle, oracle_name_option ]
+'''
+
+EXAMPLES = '''
+- name: Get all the node pools in a compartment
+  oci_node_pool_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+
+- name: Get all the node pools in a compartment and filter by cluster
+  oci_node_pool_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+
+- name: Get a specific node pool
+  oci_node_pool_facts:
+    id: ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx
+'''
+
+RETURN = '''
+node_pools:
+    description: List of node pool details
+    returned: always
+    type: complex
+    contains:
+        cluster_id:
+            description: The OCID of the cluster to which this node pool is attached.
+            returned: always
+            type: list
+            sample: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+        compartment_id:
+            description: The OCID of the compartment in which the node pool exists.
+            returned: always
+            type: string
+            sample: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        id:
+            description: The OCID of the node pool.
+            returned: always
+            type: string
+            sample: ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx
+        initial_node_labels:
+            description: A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+            returned: always
+            type: list
+            sample: [
+                {
+                    "key": "type",
+                    "value": "standard"
+                },
+                {
+                    "key": "stage",
+                    "value": "prod"
+                }
+            ]
+        kubernetes_version:
+            description: The version of Kubernetes running on the nodes in the node pool.
+            returned: always
+            type: string
+            sample: v1.9.7
+        lifecycle_details:
+            description: Details about the state of the cluster masters.
+            returned: always
+            type: string
+        name:
+            description: The name of the node pool.
+            returned: always
+            type: string
+            sample: sample_node_pool
+        node_image_id:
+            description: The OCID of the image running on the nodes in the node pool.
+            returned: always
+            type: string
+            sample: ocid1.image.oc1..xxxxxEXAMPLExxxxx
+        node_shape:
+            description: The name of the node shape of the nodes in the node pool.
+            returned: always
+            type: string
+            sample: VM.Standard1.1
+        nodes:
+            description: The nodes in the node pool.
+            returned: when retrieving a specific node pool
+            type: string
+        quantity_per_subnet:
+            description: The number of nodes in each subnet.
+            returned: always
+            type: int
+            sample: 1
+        ssh_public_key:
+            description: The SSH public key on each node in the node pool.
+            returned: always
+            type: string
+        subnet_ids:
+            description: The OCIDs of the subnets in which to place nodes for this node pool.
+            returned: always
+            type: list
+    sample: [{
+            "cluster_id": "ocid1.cluster.oc1..xxxxxEXAMPLExxxxx",
+            "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+            "id": "ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx",
+            "initial_node_labels": [
+                {
+                    "key": "type",
+                    "value": "standard"
+                },
+                {
+                    "key": "stage",
+                    "value": "prod"
+                }
+            ],
+            "kubernetes_version": "v1.9.7",
+            "name": "test_node_pool",
+            "node_image_id": "ocid1.image.oc1..xxxxxEXAMPLExxxxx",
+            "node_image_name": "Oracle-Linux-7.4",
+            "node_shape": "VM.Standard1.1",
+            "nodes": [
+                {
+                    "availability_domain": "IwGV:US-ASHBURN-AD-1",
+                    "id": "ocid1.instance.oc1..xxxxxEXAMPLExxxxx",
+                    "lifecycle_details": "waiting for running compute instance",
+                    "lifecycle_state": "UPDATING",
+                    "name": "oke-c3dsodfgezw-n3wiztggrrt-st2au5vefpq-0",
+                    "node_error": null,
+                    "node_pool_id": "ocid1.nodepool.oc1..xxxxxEXAMPLExxxxx",
+                    "public_ip": "129.213.129.26",
+                    "subnet_id": "ocid1.subnet.oc1..xxxxxEXAMPLExxxxx"
+                }
+            ],
+            "quantity_per_subnet": 1,
+            "ssh_public_key": "",
+            "subnet_ids": [
+                "ocid1.subnet..xxxxxEXAMPLExxxxx"
+            ]
+        }]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def main():
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
+    module_args.update(dict(
+        node_pool_id=dict(type='str', required=False, aliases=['id']),
+        cluster_id=dict(type='str', required=False),
+        compartment_id=dict(type='str', required=False)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    node_pool_id = module.params['node_pool_id']
+
+    try:
+        if node_pool_id is not None:
+            result = [to_dict(oci_utils.call_with_backoff(container_engine_client.get_node_pool,
+                                                          node_pool_id=node_pool_id).data)]
+        else:
+            if module.params['cluster_id']:
+                result = to_dict(oci_utils.list_all_resources(container_engine_client.list_node_pools,
+                                                              compartment_id=module.params['compartment_id'],
+                                                              cluster_id=module.params['cluster_id'],
+                                                              name=module.params['name']))
+            else:
+                result = to_dict(oci_utils.list_all_resources(container_engine_client.list_node_pools,
+                                                              compartment_id=module.params['compartment_id'],
+                                                              name=module.params['name']))
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(node_pools=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_node_pool_options_facts.py
+++ b/library/oci_node_pool_options_facts.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_node_pool_options_facts
+short_description: Retrieve options available for node pools in OCI Container Engine for Kubernetes Service
+description:
+    - This module retrieves options available for node pools in OCI Container Engine for Kubernetes Service.
+version_added: "2.5"
+options:
+    node_pool_option_id:
+        description: The id of the option set to retrieve. Use "all" to get all options, or use a cluster ID to get
+                     options specific to the provided cluster.
+        required: true
+        aliases: ['id']
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: oracle
+'''
+
+EXAMPLES = '''
+- name: Get all the node pool options available for node pools
+  oci_node_pool_options_facts:
+    node_pool_option_id: all
+
+- name: Get all the node pool options available for a specific cluster
+  oci_node_pool_options_facts:
+    node_pool_option_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+'''
+
+RETURN = '''
+node_pool_options:
+    description: Options available for node pools
+    returned: always
+    type: complex
+    contains:
+        images:
+            description: Available images for nodes
+            returned: always
+            type: list
+        kubernetes_versions:
+            description: Available Kubernetes versions.
+            returned: always
+            type: list
+        shapes:
+            description: Available shapes for nodes.
+            returned: always
+            type: list
+    sample: {
+            "images": [
+                "Oracle-Linux-7.4",
+                "Oracle-Linux-7.5"
+            ],
+            "kubernetes_versions": [
+                "v1.8.11",
+                "v1.9.7",
+                "v1.10.3",
+                "v1.11.1"
+            ],
+            "shapes": [
+                "VM.Standard2.1",
+                "VM.Standard2.2",
+                "VM.Standard1.1",
+                "VM.Standard1.2",
+                "VM.DenseIO1.4"
+            ]
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(
+        node_pool_option_id=dict(type='str', required=True, aliases=['id'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    try:
+        result = to_dict(oci_utils.call_with_backoff(container_engine_client.get_node_pool_options,
+                                                     node_pool_option_id=module.params['node_pool_option_id']).data)
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(node_pool_options=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_object.py
+++ b/library/oci_object.py
@@ -21,7 +21,7 @@ short_description: Manage objects in OCI Object Storage Service
 description:
     - Create, read, update or delete an object in OCI. This module allows the user to store a file as an object in OCI
       or download an object from OCI to a local file.
-version_added: "2.x"
+version_added: "2.5"
 options:
     bucket_name:
         description: Name of the bucket in which the object exists.
@@ -320,8 +320,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    config = oci_utils.get_oci_config(module)
-    object_storage_client = ObjectStorageClient(config)
+    object_storage_client = oci_utils.create_service_client(module, ObjectStorageClient)
 
     state = module.params['state']
     src = module.params['src']

--- a/library/oci_object_facts.py
+++ b/library/oci_object_facts.py
@@ -22,7 +22,7 @@ short_description: Retrieve details of an object or all the objects in a specifi
 description:
     - This module retrieves details of an object or all the objects present in a specified namespace and bucket in OCI \
       Object Storage Service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     namespace_name:
         description: Name of the namespace from which facts of objects need to be fetched.
@@ -123,8 +123,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    config = oci_utils.get_oci_config(module)
-    object_storage_client = ObjectStorageClient(config)
+    object_storage_client = oci_utils.create_service_client(module, ObjectStorageClient)
 
     namespace = module.params['namespace_name']
     bucket = module.params['bucket_name']

--- a/library/oci_oke_work_request.py
+++ b/library/oci_oke_work_request.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_oke_work_request
+short_description: Manage work requests in OCI Container Engine for Kubernetes Service
+description:
+    - This module allows the user to cancel a work request that has not started in OCI Container Engine for Kubernetes
+      Service.
+version_added: "2.5"
+options:
+    work_request_id:
+        description: The OCID of the work request. Required to delete a work request.
+        required: true
+        aliases: [ 'id' ]
+    state:
+        description: Use I(state=absent) to delete a work request.
+        required: false
+        default: absent
+        choices: ["absent"]
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: [ oracle, oracle_wait_options ]
+'''
+
+EXAMPLES = '''
+- name: Cancel a work request
+  oci_oke_work_request:
+    id: "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx"
+'''
+
+RETURN = '''
+work_request:
+    description: Information of work request
+    returned: On successful delete
+    type: complex
+    contains:
+        compartment_id:
+            description: The OCID of the compartment in which the work request exists.
+            returned: always
+            type: string
+        id:
+            description: The OCID of the work request.
+            returned: always
+            type: string
+        operation_type:
+            description: The type of work the work request is doing.
+            returned: always
+            type: string
+        resources:
+            description: The resources this work request affects.
+            returned: always
+            type: list
+        status:
+            description: The current status of the work request.
+            returned: always
+            type: string
+        time_accepted:
+            description: The time the work request was accepted.
+            returned: always
+            type: datetime
+        time_finished:
+            description: The time the work request was finished.
+            returned: always
+            type: datetime
+        time_started:
+            description: The time the work request was started.
+            returned: always
+            type: datetime
+    sample: {
+            "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+            "id": "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx",
+            "operation_type": "CLUSTER_CREATE",
+            "resources": [],
+            "status": "CANCELED",
+            "time_accepted": "2018-07-26T18:42:26+00:00",
+            "time_finished": "2018-07-26T18:44:13+00:00",
+            "time_started": "2018-07-26T18:43:26+00:00"
+
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+from ansible.module_utils.oracle import oci_ce_utils
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def delete_work_request(container_engine_client, module):
+    result = oci_ce_utils.delete_and_wait(resource_type="work_request",
+                                          client=container_engine_client,
+                                          get_fn=container_engine_client.get_work_request,
+                                          kwargs_get={"work_request_id": module.params["work_request_id"]},
+                                          delete_fn=container_engine_client.delete_work_request,
+                                          kwargs_delete={"work_request_id": module.params["work_request_id"]},
+                                          module=module
+                                          )
+    return result
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec(supports_wait=True)
+    module_args.update(dict(
+        work_request_id=dict(type='str', required=True, aliases=['id']),
+        state=dict(type='str', required=False, default='absent', choices=['absent'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    result = delete_work_request(container_engine_client, module)
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_oke_work_request_error_facts.py
+++ b/library/oci_oke_work_request_error_facts.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_oke_work_request_error_facts
+short_description: Retrieve errors of a work request in OCI Container Engine for Kubernetes Service
+description:
+    - This module retrieves errors of a work request in OCI Container Engine for Kubernetes Service.
+version_added: "2.5"
+options:
+    work_request_id:
+        description: The OCID of the work request.
+        required: true
+    compartment_id:
+        description: The OCID of the compartment.
+        required: true
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: oracle
+'''
+
+EXAMPLES = '''
+- name: Get the errors of a work request
+  oci_oke_work_request_error_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    work_request_id: "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx"
+'''
+
+RETURN = '''
+work_request_errors:
+    description: List of work request errors
+    returned: always
+    type: complex
+    contains:
+        code:
+            description:  A short error code that defines the error, meant for programmatic parsing.
+            returned: always
+            type: string
+        message:
+            description: A human-readable error string.
+            returned: always
+            type: string
+        timestamp:
+            description: The date and time the error occurred.
+            returned: always
+            type: string
+    sample: [{
+            "code": "GetWorkRequestGeneric",
+            "message": "failed to get DNS record from OCI API",
+            "timestamp": "2018-08-16T12:20:48Z"
+    }]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(
+        work_request_id=dict(type='str', required=True),
+        compartment_id=dict(type='str', required=True)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    try:
+        result = to_dict(oci_utils.list_all_resources(container_engine_client.list_work_request_errors,
+                                                      compartment_id=module.params['compartment_id'],
+                                                      work_request_id=module.params['work_request_id']))
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(work_request_errors=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_oke_work_request_facts.py
+++ b/library/oci_oke_work_request_facts.py
@@ -1,0 +1,188 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_oke_work_request_facts
+short_description: Retrieve facts of work requests in OCI Container Engine for Kubernetes Service
+description:
+    - This module retrieves information of a specified work request or lists work requests in a compartment.
+version_added: "2.5"
+options:
+    work_request_id:
+        description: The OCID of the work request. I(work_request_id) is required to get a specific work request's
+                     information.
+        required: false
+        aliases: [ 'id' ]
+    compartment_id:
+        description: The OCID of the compartment. Required to list all the work requests in a compartment.
+        required: false
+    cluster_id:
+        description: The OCID of the cluster. Use I(cluster_id) with I(compartment_id) to filter work requests related
+                     to a cluster in the specified compartment.
+        required: false
+    resource_id:
+        description: The OCID of the resource associated with a work request. Use I(resource_id) with I(compartment_id)
+                     to filter work requests related to a resource in the specified compartment.
+        required: false
+    resource_type:
+        description: Type of the resource associated with a work request. Use I(resource_type) with I(compartment_id)
+                     to filter work requests related to the resource type in the specified compartment.
+        required: false
+        choices: ["CLUSTER", "NODEPOOL"]
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: oracle
+'''
+
+EXAMPLES = '''
+- name: Get all the work requests in a specific compartment
+  oci_oke_work_request_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+
+- name: Get a specific work request
+  oci_oke_work_request_facts:
+    id: ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx
+
+- name: Get all the work requests in compartment associated with a particular cluster
+  oci_oke_work_request_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+
+- name: Get all work requests in a compartment for a specified cluster in which resource of type NODEPOOL is associated
+  oci_oke_work_request_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    cluster_id: ocid1.cluster.oc1..xxxxxEXAMPLExxxxx
+    resource_type: NODEPOOL
+'''
+
+RETURN = '''
+work_requests:
+    description: List of work request details
+    returned: always
+    type: complex
+    contains:
+        compartment_id:
+            description: The OCID of the compartment in which the work request exists.
+            returned: always
+            type: string
+        id:
+            description: The OCID of the work request.
+            returned: always
+            type: string
+        operation_type:
+            description: The type of work the work request is doing.
+            returned: always
+            type: string
+        resources:
+            description: The resources this work request affects.
+            returned: always
+            type: list
+        status:
+            description: The current status of the work request.
+            returned: always
+            type: string
+        time_accepted:
+            description: The time the work request was accepted.
+            returned: always
+            type: datetime
+        time_finished:
+            description: The time the work request was finished.
+            returned: always
+            type: datetime
+        time_started:
+            description: The time the work request was started.
+            returned: always
+            type: datetime
+    sample: [{
+            "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+            "id": "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx",
+            "operation_type": "CLUSTER_CREATE",
+            "resources": [
+                {
+                    "action_type": "IN_PROGRESS",
+                    "entity_type": "cluster",
+                    "entity_uri": "/clusters/ocid1.cluster.oc1..xxxxxEXAMPLExxxxx",
+                    "identifier": "ocid1.cluster.oc1..xxxxxEXAMPLExxxxx"
+                }
+            ],
+            "status": "ACCEPTED",
+            "time_accepted": "2018-07-26T18:42:26+00:00",
+            "time_finished": "2018-07-26T18:44:13+00:00",
+            "time_started": "2018-07-26T18:43:26+00:00"
+
+    }]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(
+        work_request_id=dict(type='str', required=False, aliases=['id']),
+        compartment_id=dict(type='str', required=False),
+        cluster_id=dict(type='str', required=False),
+        resource_id=dict(type='str', required=False),
+        resource_type=dict(type='str', required=False, choices=['CLUSTER', 'NODEPOOL'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_one_of=[
+            ['compartment_id', 'work_request_id']
+        ]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    work_request_id = module.params['work_request_id']
+
+    try:
+        if work_request_id is not None:
+            result = [to_dict(oci_utils.call_with_backoff(container_engine_client.get_work_request,
+                                                          work_request_id=work_request_id).data)]
+        else:
+            kwargs_list = {"compartment_id": module.params['compartment_id']}
+            list_args = ["cluster_id", "resource_id", "resource_type"]
+            for arg in list_args:
+                if module.params[arg]:
+                    kwargs_list[arg] = module.params[arg]
+            result = to_dict(oci_utils.list_all_resources(container_engine_client.list_work_requests,
+                                                          **kwargs_list))
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(work_requests=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_oke_work_request_log_entry_facts.py
+++ b/library/oci_oke_work_request_log_entry_facts.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_oke_work_request_log_entry_facts
+short_description: Retrieve logs of a work request in OCI Container Engine for Kubernetes Service
+description:
+    - This module retrieves logs of a work request in OCI Container Engine for Kubernetes Service.
+version_added: "2.5"
+options:
+    work_request_id:
+        description: The OCID of the work request.
+        required: true
+    compartment_id:
+        description: The OCID of the compartment.
+        required: true
+author: "Rohit Chaware (@rohitChaware)"
+extends_documentation_fragment: oracle
+'''
+
+EXAMPLES = '''
+- name: Get the logs of a work request
+  oci_oke_work_request_log_entry_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    work_request_id: "ocid1.clustersworkrequest.oc1..xxxxxEXAMPLExxxxx"
+'''
+
+RETURN = '''
+work_request_log_entries:
+    description: List of work request log entries
+    returned: always
+    type: complex
+    contains:
+        message:
+            description: The description of an action that occurred.
+            returned: always
+            type: string
+        timestamp:
+            description: The date and time the log entry occurred.
+            returned: always
+            type: string
+    sample: [{
+            "message": "extending job lease time",
+            "timestamp": "2018-08-16T12:20:48Z"
+    }]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.container_engine.container_engine_client import ContainerEngineClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(
+        work_request_id=dict(type='str', required=True),
+        compartment_id=dict(type='str', required=True)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    container_engine_client = oci_utils.create_service_client(module, ContainerEngineClient)
+
+    try:
+        result = to_dict(oci_utils.list_all_resources(container_engine_client.list_work_request_logs,
+                                                      compartment_id=module.params['compartment_id'],
+                                                      work_request_id=module.params['work_request_id']))
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(work_request_log_entries=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_policy.py
+++ b/library/oci_policy.py
@@ -20,7 +20,7 @@ module: oci_policy
 short_description: Manage policies in OCI Identity and Access Management
 description:
     - This module allows the user to create, delete and update policies in OCI Identity and Access Management service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment containing the policy (either the tenancy or another compartment).
@@ -225,8 +225,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
     state = module.params['state']
     policy_id = module.params['policy_id']
     exclude_attributes = {'version_date': True}

--- a/library/oci_policy_facts.py
+++ b/library/oci_policy_facts.py
@@ -22,7 +22,7 @@ short_description: Retrieve details about a policy or policies attached to a com
 description:
     - This module retrieves a specific policy or all the policies attached to a specified compartment in OCI Identity
       and Access Management service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment (remember that the tenancy is simply the root compartment). Required to
@@ -33,7 +33,7 @@ options:
         required: false
         aliases: [ 'id' ]
 author: "Rohit Chaware (@rohitChaware)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_name_option ]
 '''
 
 EXAMPLES = '''
@@ -130,7 +130,7 @@ except ImportError:
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         policy_id=dict(type='str', required=False, aliases=['id'])
@@ -147,15 +147,15 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
 
     policy_id = module.params['policy_id']
 
     try:
         if policy_id is None:
             result = to_dict(oci_utils.list_all_resources(identity_client.list_policies,
-                                                          compartment_id=module.params['compartment_id']))
+                                                          compartment_id=module.params['compartment_id'],
+                                                          name=module.params['name']))
         else:
             result = [to_dict(identity_client.get_policy(policy_id).data)]
     except ServiceError as ex:

--- a/library/oci_private_ip.py
+++ b/library/oci_private_ip.py
@@ -21,7 +21,7 @@ module: oci_private_ip
 short_description: Manage private IPs in OCI
 description:
     - This module allows the user to create, delete and update private IPs in OCI.
-version_added: "2.x"
+version_added: "2.5"
 options:
     display_name:
         description: A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential
@@ -175,8 +175,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
 
     state = module.params['state']
     private_ip_id = module.params['private_ip_id']

--- a/library/oci_private_ip_facts.py
+++ b/library/oci_private_ip_facts.py
@@ -21,7 +21,7 @@ module: oci_private_ip_facts
 short_description: Retrieve facts of private IPs
 description:
     - This module retrieves information of a specified private IP or lists all the private IPs in a subnet.
-version_added: "2.x"
+version_added: "2.5"
 options:
     private_ip_id:
         description: The OCID of the private IP. I(private_ip_id) is required to get a specific private IP's
@@ -32,7 +32,7 @@ options:
         description: The OCID of the subnet. Required to list all the private IPs in a subnet.
         required: false
 author: "Rohit Chaware (@rohitChaware)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -150,7 +150,7 @@ except ImportError:
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         private_ip_id=dict(type='str', required=False, aliases=['id']),
         subnet_id=dict(type='str', required=False)
@@ -164,8 +164,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
 
     private_ip_id = module.params['private_ip_id']
 
@@ -175,7 +174,8 @@ def main():
                                                           private_ip_id=private_ip_id).data)]
         else:
             result = to_dict(oci_utils.list_all_resources(virtual_network_client.list_private_ips,
-                                                          subnet_id=module.params['subnet_id']))
+                                                          subnet_id=module.params['subnet_id'],
+                                                          display_name=module.params['display_name']))
     except ServiceError as ex:
         module.fail_json(msg=ex.message)
 

--- a/library/oci_public_ip.py
+++ b/library/oci_public_ip.py
@@ -21,7 +21,7 @@ module: oci_public_ip
 short_description: Manage public IPs in OCI
 description:
     - This module allows the user to create, delete and update public IPs in OCI.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment to contain the public IP. For ephemeral public IPs, you must set this
@@ -199,8 +199,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
 
     state = module.params['state']
     public_ip_id = module.params['public_ip_id']

--- a/library/oci_public_ip_facts.py
+++ b/library/oci_public_ip_facts.py
@@ -21,7 +21,7 @@ module: oci_public_ip_facts
 short_description: Retrieve facts of public IPs
 description:
     - This module retrieves information of the specified public IP or all public IPs in the specified compartment.
-version_added: "2.x"
+version_added: "2.5"
 options:
     public_ip_id:
         description: OCID of the public IP. Use I(public_ip_id) to retrieve a specific public IP's information using its
@@ -50,7 +50,7 @@ options:
                      public IPs in the specified I(compartment_id) and I(availability_domain).
         required: false
 author: "Rohit Chaware (@rohitChaware)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -182,7 +182,7 @@ except ImportError:
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         public_ip_id=dict(type='str', required=False, aliases=['id']),
         private_ip_id=dict(type='str', required=False),
@@ -200,8 +200,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
 
     public_ip_id = module.params['public_ip_id']
 
@@ -221,7 +220,8 @@ def main():
                                                           ).data)]
         elif module.params['scope'] is not None:
             list_args = {'scope': module.params['scope'],
-                         'compartment_id': module.params['compartment_id']
+                         'compartment_id': module.params['compartment_id'],
+                         'display_name': module.params['display_name']
                          }
             if module.params['availability_domain'] is not None:
                 list_args['availability_domain'] = module.params['availability_domain']

--- a/library/oci_region_facts.py
+++ b/library/oci_region_facts.py
@@ -20,9 +20,9 @@ module: oci_region_facts
 short_description: Retrieve details about all Regions offered by Oracle Cloud Infrastructure
 description:
     - This module retrieves details about all Regions offered by Oracle Cloud Infrastructure.
-version_added: "2.x"
+version_added: "2.5"
 author: "Sivakumar Thyagarajan (@sivakumart)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_name_option ]
 '''
 
 EXAMPLES = '''
@@ -78,7 +78,8 @@ except ImportError:
 
 def list_regions(identity_client, module):
     try:
-        regions = oci_utils.call_with_backoff(identity_client.list_regions).data
+        regions = oci_utils.list_all_resources(identity_client.list_regions,
+                                               name=module.params['name'])
     except ServiceError as ex:
         module.fail_json(msg=ex.message)
 
@@ -86,7 +87,7 @@ def list_regions(identity_client, module):
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
 
     module = AnsibleModule(
         argument_spec=module_args,
@@ -96,8 +97,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
 
     result = list_regions(identity_client, module)
     module.exit_json(regions=result)

--- a/library/oci_region_subscription_facts.py
+++ b/library/oci_region_subscription_facts.py
@@ -26,7 +26,7 @@ options:
         description: The OCID of the tenancy for which region subscriptions needs to be retrieved
         required: true
         aliases: [ 'id' ]
-version_added: "2.x"
+version_added: "2.5"
 author: "Sivakumar Thyagarajan (@sivakumart)"
 extends_documentation_fragment: oracle
 '''
@@ -115,8 +115,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
 
     result = list_region_subscriptions(identity_client, module)
     module.exit_json(region_subscriptions=result)

--- a/library/oci_route_table_facts.py
+++ b/library/oci_route_table_facts.py
@@ -23,7 +23,7 @@ short_description: Fetches details of a specific Route Table or a
                    compartment
 description:
     - Fetches details of a specific Route Table or a list of Route tables in the specified VCN and compartment.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment details about
@@ -41,7 +41,7 @@ options:
         aliases: ['id']
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -164,7 +164,8 @@ def list_route_tables(virtual_network_client, module):
         if compartment_id and vcn_id:
             existing_route_tables = oci_utils.list_all_resources(
                 virtual_network_client.list_route_tables,
-                compartment_id=compartment_id, vcn_id=vcn_id)
+                compartment_id=compartment_id, vcn_id=vcn_id,
+                display_name=module.params['display_name'])
         elif rt_id:
             response = oci_utils.call_with_backoff(
                 virtual_network_client.get_route_table, rt_id=rt_id)
@@ -176,7 +177,7 @@ def list_route_tables(virtual_network_client, module):
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         vcn_id=dict(type='str', required=False),
@@ -193,8 +194,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(oci_config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
     result = list_route_tables(virtual_network_client, module)
 
     module.exit_json(**result)

--- a/library/oci_rrset.py
+++ b/library/oci_rrset.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_rrset
+short_description: Update, Patch or Delete a collection of DNS records of the same domain and type in the specified
+                   zone in OCI DNS Service
+description:
+    - This module allows the user to update, patch or delete a collection of DNS records of the same domain and type in
+      the specified DNS zone in OCI DNS Service.
+version_added: "2.5"
+options:
+    zone_id:
+        description: The OCID of the target zone. Either I(name) or I(zone_id) must be specified to update or patch
+                     the collection of records in the specified zone.
+        required: false
+        aliases: ['id']
+    name:
+        description: The name of the zone. Required to create a zone. Either I(name) or I(zone_id) must be specified
+                     to update or patch the collection of records in the specified zone.
+        required: false
+        aliases: ['zone_name']
+    compartment_id:
+        description: The OCID of the compartment the resource belongs to.
+        required: false
+    domain:
+        description: The target fully-qualified domain name (FQDN) within the target zone.
+        required: true
+    rtype:
+        description: The type of the target RRSet within the target zone.
+        required: true
+    update_items:
+        description: The items to update the RRSet collection to. Replaces records in the specified
+                     zone at a domain with the records specified in the request body. If a specified record does not
+                     exist, it will be created. If the record exists, then it will be updated to represent the record
+                     in the body of the request. If a record in the zone does not exist in the request body, the record
+                     will be removed from the zone. Required to update a RRSet.
+        required: false
+        suboptions:
+            domain:
+                description: The fully qualified domain name where the record can be located.
+                required: true
+            record_hash:
+                description: A unique identifier for the record within its zone.
+                required: false
+            is_protected:
+                description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                             managed.
+                required: false
+            rdata:
+                description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+                required: true
+            rr_set_version:
+                description: The latest version of the record's zone in which its RRSet differs from the preceding
+                             version.
+                required: false
+            rtype:
+                description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                             L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+                required: true
+            ttl:
+                description: The Time To Live for the record, in seconds.
+                required: true
+    patch_items:
+        description: The record operations to patch the RRSet collection. Updates records in the
+                     specified zone at a domain. You can update one record or all records for the specified zone
+                     depending on the changes provided in the request body. You can also add or remove records
+                     using this option. Required to patch a RRSet.
+        required: false
+        suboptions:
+            domain:
+                description: The fully qualified domain name where the record can be located.
+                required: false
+            record_hash:
+                description: A unique identifier for the record within its zone.
+                required: false
+            is_protected:
+                description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                             managed.
+                required: false
+            rdata:
+                description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+                required: false
+            rr_set_version:
+                description: The latest version of the record's zone in which its RRSet differs from the preceding
+                             version.
+                required: false
+            rtype:
+                description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                             L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+                required: false
+            ttl:
+                description: The Time To Live for the record, in seconds.
+                required: true
+            operation:
+                description: A description of how a record relates to a PATCH operation. REQUIRE indicates a
+                             precondition that record data must already exist. PROHIBIT indicates a precondition that
+                             record data must not already exist. ADD indicates that record data must exist after
+                             successful application. REMOVE indicates that record data must not exist after successful
+                             application. Note - ADD and REMOVE operations can succeed even if they require no changes
+                             when applied, such as when the described records are already present or absent.
+                             Note - ADD and REMOVE operations can describe changes for more than one record.
+                             Example - { "domain" - "www.example.com", "rtype" - "AAAA", "ttl" - 60 } specifies a new TTL
+                             for every record in the www.example.com AAAA RRSet.'
+                required: false
+                choices: ['REQUIRE', 'PROHIBIT', 'ADD', 'REMOVE']
+    state:
+        description: State of the RRSet. Use I(state='absent') to delete all records in the specified RRSet.
+        required: false
+        default: present
+        choices: ['present', 'absent']
+author: "Sivakumar Thyagarajan (@sivakumart)"
+extends_documentation_fragment: [ oracle, oracle_wait_options ]
+'''
+
+EXAMPLES = '''
+- name: Update a RRSet by adding a new record. This operation replaces DNS records in the specified RRSet with the
+        specified records. So ensure that you include the original RRSet records, if you want to retain existing
+        records.
+  oci_rrset:
+    name: "test_zone_1.com"
+    domain: "test_zone_1.com"
+    rtype: 'TXT'
+    update_items: [ <original zone's TXT records...> , { domain: "test_zone_1.com", ttl: 30, rtype='TXT',
+                    rdata='some textual data' } ]
+
+- name: Patch a RRSet
+  oci_rrset:
+    name: test_zone1.com
+    domain: "test_zone_1.com"
+    rtype: "TXT"
+    patch_items: [{
+                    domain: "test_zone_1.com",
+                    is_protected: false,
+                    rdata: "some textual data",
+                    rtype: "TXT",
+                    ttl: 30,
+                    operation: "REMOVE"
+                    }]
+'''
+
+RETURN = '''
+rrset:
+    description: Information about all the DNS records in the RRSet
+    returned: On successful update or patch of the RRSet
+    type: complex
+    contains:
+        domain:
+            description: The fully qualified domain name where the record can be located.
+            returned: always
+            type: string
+            sample: "test_zone_1.com"
+        record_hash:
+            description: A unique identifier for the record within its zone.
+            returned: always
+            type: string
+            sample: 722af089872ffe65ba909fc8fea1867e
+        is_protected:
+            description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                         managed.
+            returned: always
+            type: boolean
+            sample: false
+        rdata:
+            description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+            returned: always
+            type: string
+            sample: "ns3.p68.dns.oraclecloud.net."
+        rrsetVersion:
+            description: The latest version of the record's zone in which its RRSet differs from the preceding version.
+            returned: always
+            type: string
+            sample: "5"
+        rtype:
+            description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                         L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+            returned: always
+            type: string
+            sample: "NS"
+        ttl:
+            description: The Time To Live for the record, in seconds.
+            returned: always
+            type: string
+            sample: "86400"
+    sample:
+                {
+                    "domain": "test_zone_1.com",
+                    "is_protected": true,
+                    "rdata": "ns2.p68.dns.oraclecloud.net.",
+                    "record_hash": "9be3279d81b5e8430fd94c70cfa5f0a8",
+                    "rrset_version": "1",
+                    "rtype": "NS",
+                    "ttl": 86400
+                }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    from oci.dns.dns_client import DnsClient
+    from oci.dns.models import PatchRRSetDetails, RecordOperation, RecordDetails, UpdateRRSetDetails
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+RESOURCE_NAME = "rrset"
+
+
+# DNS client accepts either a zone name or an id through the zone_name_or_id parameter for update and delete scenarios.
+# This is different from other resources.
+# XXX: for now only zone_name appears to work, and not OCID. Using an OCID gives an error "Invalid Domain Name".
+def get_zone_name_or_id(module):
+    if module.params['name'] is not None:
+        return module.params['name']
+    if module.params['zone_id'] is not None:
+        return module.params['zone_id']
+    if module.params['id'] is not None:
+        return module.params['id']
+    return None
+
+
+def create_model(model_class, user_values):
+    model_instance = model_class()
+    for attr in model_instance.attribute_map.keys():
+        if attr in user_values:
+            setattr(model_instance, attr, user_values[attr])
+    return model_instance
+
+
+def modify_rrset(dns_client, module, modify_operation, modify_kwargs):
+    result = {}
+    try:
+        # get current rrset
+        rrset_old = oci_utils.call_with_backoff(
+            dns_client.get_rr_set,
+            zone_name_or_id=get_zone_name_or_id(module),
+            domain=module.params['domain'],
+            rtype=module.params['rtype']).data.items
+
+        # update rrset
+        updated_rec_coll = oci_utils.call_with_backoff(modify_operation, **modify_kwargs).data
+        result[RESOURCE_NAME] = oci_utils.to_dict(updated_rec_coll.items)
+
+        # get rrset after update
+        rrset_new = oci_utils.call_with_backoff(
+            dns_client.get_rr_set,
+            zone_name_or_id=get_zone_name_or_id(module),
+            domain=module.params['domain'],
+            rtype=module.params['rtype']).data.items
+
+        # check if there is any change between the old and the new rrsets, and set changed accordingly
+        result['changed'] = not oci_utils.compare_list(rrset_old, rrset_new)
+    except ServiceError as ex:
+        module.fail_json(msg=str(ex))
+    return result
+
+
+def patch_rrset(dns_client, module):
+    patch_items = module.params['patch_items']
+    patch_rr_set_details = PatchRRSetDetails()
+    patch_rr_set_details.items = [create_model(RecordOperation, item) for item in patch_items]
+    kwargs = {"patch_rr_set_details": patch_rr_set_details,
+              "zone_name_or_id": get_zone_name_or_id(module), "domain": module.params['domain'],
+              "rtype": module.params['rtype']}
+    return modify_rrset(dns_client, module, modify_operation=dns_client.patch_rr_set,
+                        modify_kwargs=kwargs)
+
+
+def update_rrset(dns_client, module):
+    update_items = module.params['update_items']
+    update_rr_set_details = UpdateRRSetDetails()
+    update_rr_set_details.items = [create_model(RecordDetails, item) for item in update_items]
+    kwargs = {"update_rr_set_details": update_rr_set_details,
+              "zone_name_or_id": get_zone_name_or_id(module), "domain": module.params['domain'],
+              "rtype": module.params['rtype']}
+    return modify_rrset(dns_client, module, modify_operation=dns_client.update_rr_set,
+                        modify_kwargs=kwargs)
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec(supports_wait=True)
+    module_args.update(dict(
+        compartment_id=dict(type='str', required=False),
+        zone_id=dict(type='str', required=False, aliases=['id']),
+        name=dict(type='str', required=False, aliases=['zone_name']),
+        domain=dict(type='str', required=True),
+        rtype=dict(type='str', required=True),
+        update_items=dict(type='list', required=False),
+        patch_items=dict(type='list', required=False),
+        state=dict(type='str', required=False, default='present', choices=['present', 'absent'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_one_of=[['zone_id', 'name']]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    config = oci_utils.get_oci_config(module)
+    dns_client = DnsClient(config)
+
+    state = module.params['state']
+    result = {}
+    if state == 'absent':
+        kwargs = {"zone_name_or_id": get_zone_name_or_id(module), "domain": module.params['domain'],
+                  "rtype": module.params['rtype']}
+        curr_rr_set = dns_client.get_rr_set(**kwargs).data.items
+        if curr_rr_set:
+            oci_utils.call_with_backoff(dns_client.delete_rr_set, **kwargs)
+            result['changed'] = True
+        # XXX: delete_and wait requires the resource to have a lifecycle_state and
+        # rr_set doesn't have one.
+        # result = oci_utils.delete_and_wait(resource_type=RESOURCE_NAME,
+        #                                    client=dns_client,
+        #                                    get_fn=dns_client.get_rr_set,
+        #                                    kwargs_get=kwargs,
+        #                                    delete_fn=dns_client.delete_rr_set,
+        #                                    kwargs_delete=kwargs,
+        #                                    module=module)
+    else:
+        if module.params['update_items'] is not None:
+            result = update_rrset(dns_client, module)
+        else:
+            result = patch_rrset(dns_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_rrset_facts.py
+++ b/library/oci_rrset_facts.py
@@ -1,0 +1,187 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_rrset_facts
+short_description: Retrieve facts of a RRSet in a specified zone in Oracle Cloud Infrastructure DNS Service
+description:
+    - This module gets a list of all records in the specified RRSet. The results are sorted by recordHash by default.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: The OCID of the compartment the resource belongs to. Use I(zone_id) or I(zone_name)
+                     to retrieve a specific zone's information using its OCID.
+        required: false
+    zone_id:
+        description: OCID of the target zone.
+        required: false
+        aliases: ['id']
+    name:
+        description: A case-sensitive filter for zone names. Will match any zone with a name that equals the
+                     provided value.
+        required: false
+        aliases: ['zone_name']
+    rtype:
+        description: The type of the target RRSet within the target zone.
+        required: true
+    domain:
+        description: Search by domain. Will match any record whose domain (case-insensitive) equals the
+                     provided value.
+        required: true
+    zone_version:
+        description: The version of the zone for which data is requested.
+        required: false
+author: "Sivakumar Thyagarajan (@sivakumart)"
+extends_documentation_fragment: oracle
+'''
+
+EXAMPLES = '''
+- name: Get a list of all records in the specified RRSet
+  oci_rrset_facts:
+    zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+    domain: "test_zone_1.com"
+    rtype: "TXT"
+'''
+
+RETURN = '''
+rrset:
+    description: A collection of DNS resource record objects.
+    returned: always
+    type: complex
+    contains:
+        domain:
+            description: The fully qualified domain name where the record can be located.
+            returned: always
+            type: string
+            sample: "test_zone_1.com"
+        record_hash:
+            description: A unique identifier for the record within its zone.
+            returned: always
+            type: string
+            sample: "f439fa9a087ff74757485953fe0a8c7d"
+        is_protected:
+            description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                         managed.
+            returned: always
+            type: boolean
+            sample: true
+        rdata:
+            description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+            returned: always
+            type: string
+            sample: "ns1.p68.dns.oraclecloud.net. hostmaster.test_zone_1.com. 1 3600 600 604800 1800"
+        rrset_version:
+            description: The latest version of the record's zone in which its RRSet differs from the preceding version.
+            returned: always
+            type: string
+            sample: "1"
+        rtype:
+            description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                         L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+            returned: always
+            type: string
+            sample: "NS"
+        ttl:
+            description: The Time To Live for the record, in seconds.
+            returned: always
+            type: string
+            sample: "86400"
+    sample:
+                {
+                    "domain": "test_zone_1.com",
+                    "is_protected": true,
+                    "rdata": "ns2.p68.dns.oraclecloud.net.",
+                    "record_hash": "9be3279d81b5e8430fd94c70cfa5f0a8",
+                    "rrset_version": "1",
+                    "rtype": "NS",
+                    "ttl": 86400
+                }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+import six
+
+try:
+    from oci.dns.dns_client import DnsClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+# DNS client accepts either a zone name or an id through the zone_name_or_id parameter for update and delete scenarios.
+# This is different from other resources.
+def get_zone_name_or_id(module):
+    if module.params['name'] is not None:
+        return module.params['name']
+    if module.params['zone_id'] is not None:
+        return module.params['zone_id']
+    if module.params['id'] is not None:
+        return module.params['id']
+    return None
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(
+        zone_id=dict(type='str', required=False, aliases=['id']),
+        name=dict(type='str', required=False, aliases=['zone_name']),
+        compartment_id=dict(type='str', required=False),
+        domain=dict(type='str', required=True),
+        zone_version=dict(type='str', required=False),
+        rtype=dict(type='str', required=True)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_one_of=[
+            ['zone_id', 'name']
+        ]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    config = oci_utils.get_oci_config(module)
+    dns_client = DnsClient(config)
+
+    try:
+        zone_name_or_id = get_zone_name_or_id(module)
+        key_list = ["compartment_id", "zone_version"]
+        kwargs = {k: v for (k, v) in six.iteritems(module.params) if k in key_list and v is not None}
+
+        result = to_dict(oci_utils.call_with_backoff(dns_client.get_rr_set,
+                                                     zone_name_or_id=zone_name_or_id,
+                                                     domain=module.params['domain'],
+                                                     rtype=module.params['rtype'],
+                                                     **kwargs).data.items)
+
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(rrset=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_security_list_facts.py
+++ b/library/oci_security_list_facts.py
@@ -23,7 +23,7 @@ short_description: Fetches details of a specific Security List or a
                    compartment
 description:
     - Fetches details of a specific Security List or a list of Security Lists in the specified VCN and compartment.oc
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: Identifier of the compartment details about
@@ -41,7 +41,7 @@ options:
         aliases: ['id']
 author:
     - "Debayan Gupta(@debayan_gupta)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -241,7 +241,8 @@ def list_security_lists(virtual_network_client, module):
         if compartment_id and vcn_id:
             existing_security_lists = oci_utils.list_all_resources(
                 virtual_network_client.list_security_lists,
-                compartment_id=compartment_id, vcn_id=vcn_id)
+                compartment_id=compartment_id, vcn_id=vcn_id,
+                display_name=module.params['display_name'])
         elif security_list_id:
             response = oci_utils.call_with_backoff(
                 virtual_network_client.get_security_list, security_list_id=security_list_id)
@@ -253,7 +254,7 @@ def list_security_lists(virtual_network_client, module):
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         vcn_id=dict(type='str', required=False),
@@ -270,8 +271,8 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module')
 
-    oci_config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(oci_config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
+
     result = list_security_lists(virtual_network_client, module)
 
     module.exit_json(**result)

--- a/library/oci_shape_facts.py
+++ b/library/oci_shape_facts.py
@@ -21,7 +21,7 @@ short_description: Retrieve details about shapes that can be used to launch inst
 description:
     - This module retrieves details about shapes that can be used to launch instances within a specified Compartment in
       OCI Compute Service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment (either the tenancy or another compartment in the tenancy).
@@ -90,8 +90,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    compute_client = ComputeClient(config)
+    compute_client = oci_utils.create_service_client(module, ComputeClient)
 
     compartment_id = module.params['compartment_id']
     availability_domain = module.params['availability_domain']

--- a/library/oci_subnet.py
+++ b/library/oci_subnet.py
@@ -21,7 +21,7 @@ module: oci_subnet
 short_description: Manage subnets in a VCN in OCI
 description:
     - This module allows the user to create, delete and update subnets in a VCN in OCI.
-version_added: "2.x"
+version_added: "2.5"
 options:
     availability_domain:
         description: The Availability Domain to contain the subnet. Required when creating a subnet with
@@ -214,8 +214,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
     exclude_attributes = {'display_name': True, 'dns_label': True, 'dhcp_options_id': True}
     state = module.params['state']
     subnet_id = module.params['subnet_id']

--- a/library/oci_subnet_facts.py
+++ b/library/oci_subnet_facts.py
@@ -22,7 +22,7 @@ short_description: Retrieve facts of subnets
 description:
     - This module allows the user to retrieve information of the specified subnet or all the subnets in the specified
       VCN and the specified compartment.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment. I(compartment_id) is required to retrieve all the subnets in the
@@ -38,7 +38,7 @@ options:
                      the specified compartment.
         required: false
 author: "Rohit Chaware (@rohitChaware)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -183,7 +183,7 @@ except ImportError:
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         subnet_id=dict(type='str', required=False),
@@ -198,8 +198,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
 
     subnet_id = module.params['subnet_id']
     vcn_id = module.params['vcn_id']
@@ -216,7 +215,8 @@ def main():
         try:
             result = to_dict(oci_utils.list_all_resources(
                 virtual_network_client.list_subnets,
-                compartment_id=compartment_id, vcn_id=vcn_id))
+                compartment_id=compartment_id, vcn_id=vcn_id,
+                display_name=module.params['display_name']))
         except ServiceError as ex:
             module.fail_json(msg=ex.message)
     else:

--- a/library/oci_swift_password.py
+++ b/library/oci_swift_password.py
@@ -25,7 +25,7 @@ description:
       Infrastructure Object Storage Service. This password is associated with the user's Console login. Swift passwords
       never expire. A user can have up to two Swift passwords at a time. Note: The password is always an
       Oracle-generated string; you can't change it to a string of your choice."
-version_added: "2.x"
+version_added: "2.5"
 options:
     user_id:
         description: The OCID of the user.
@@ -226,8 +226,8 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
+
     state = module.params['state']
 
     result = dict(changed=False)

--- a/library/oci_swift_password_facts.py
+++ b/library/oci_swift_password_facts.py
@@ -22,7 +22,7 @@ description:
     - This module retrieves details of swift passwords of a specified user. The returned object contains the swift
       password's OCID, but not the password itself. The actual password is returned only upon creation of a swift
       password using the M(oci_swift_password) module.
-version_added: "2.x"
+version_added: "2.5"
 options:
     user_id:
         description: The OCID of the user
@@ -142,8 +142,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
 
     user_id = module.params.get("user_id")
     id = module.params.get("swift_password_id", None)

--- a/library/oci_tag.py
+++ b/library/oci_tag.py
@@ -24,7 +24,7 @@ description:
       the schema of a tag and includes a namespace, tag key, and tag value type. Currently the only tag value type
       supported is "string", and hence is not specified during creation. Defined tag keys are case insensitive. However
       note that defined tag values are case sensitive.
-version_added: "2.x"
+version_added: "2.5"
 options:
     tag_namespace_id:
         description: The OCID of the tag namespace that will contain this tag key definition.
@@ -213,8 +213,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
     state = module.params['state']
 
     result = dict(changed=False)

--- a/library/oci_tag_facts.py
+++ b/library/oci_tag_facts.py
@@ -21,7 +21,7 @@ short_description: Retrieve details of tag key definitions for a specified tag n
 description:
     - This module retrieves details of all tag key definitions of a specified tag namespace, or a specific tag key
       definition in OCI.
-version_added: "2.x"
+version_added: "2.5"
 options:
     tag_namespace_id:
         description: The OCID of the tag namespace whose tag definitions must be retrieved
@@ -113,7 +113,7 @@ except ImportError:
 
 def list_tags(identity_client, tag_namespace_id, tag_name, module):
     try:
-        if tag_name is not None and not tag_name:
+        if tag_name is not None:
             tag = oci_utils.call_with_backoff(identity_client.get_tag, tag_namespace_id=tag_namespace_id,
                                               tag_name=tag_name).data
             return to_dict([tag])
@@ -138,8 +138,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
 
     tag_namespace_id = module.params.get("tag_namespace_id")
     tag_name = module.params.get("tag_name", None)

--- a/library/oci_tag_namespace.py
+++ b/library/oci_tag_namespace.py
@@ -23,7 +23,7 @@ description:
     - This module allows the user to create, retire and reactivate tag namespaces in OCI. A tag namespace is a
       container for tag keys. It consists of a name, and zero or more tag key definitions. Tag namespaces are not case
       sensitive, and must be unique across the tenancy.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment containing the tag namespace (the compartment may also be the root
@@ -205,8 +205,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
     state = module.params['state']
 
     result = dict(changed=False)

--- a/library/oci_tag_namespace_facts.py
+++ b/library/oci_tag_namespace_facts.py
@@ -20,7 +20,7 @@ module: oci_tag_namespace_facts
 short_description: Retrieve details of tag namespaces for a specified compartment or tenancy in OCI
 description:
     - This module retrieves details of tag namespaces of a specified tenancy or compartment in OCI.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment whose tag namespaces must be retrieved. To get the tag namespaces of
@@ -33,7 +33,7 @@ options:
         aliases: ['id']
 
 author: "Sivakumar Thyagarajan (@sivakumart)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_name_option ]
 '''
 
 EXAMPLES = '''
@@ -118,13 +118,15 @@ def list_tag_namespaces(identity_client, compartment_id, tag_namespace_id, modul
                                                  tag_namespace_id=tag_namespace_id).data
             return to_dict([tag_ns])
 
-        return to_dict(oci_utils.list_all_resources(identity_client.list_tag_namespaces, compartment_id=compartment_id))
+        return to_dict(oci_utils.list_all_resources(identity_client.list_tag_namespaces,
+                                                    compartment_id=compartment_id,
+                                                    name=module.params['name']))
     except ServiceError as ex:
         module.fail_json(msg=ex.message)
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         tag_namespace_id=dict(type='str', required=False, aliases=['id'])
@@ -138,8 +140,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
 
     compartment_id = module.params.get("compartment_id")
     tagns_id = module.params.get("tag_namespace_id", None)

--- a/library/oci_tenancy_facts.py
+++ b/library/oci_tenancy_facts.py
@@ -20,7 +20,7 @@ module: oci_tenancy_facts
 short_description: Retrieve details about a tenancy in Oracle Cloud Infrastructure
 description:
     - This module retrieves details about a tenancy in Oracle Cloud Infrastructure.
-version_added: "2.x"
+version_added: "2.5"
 options:
     tenancy_id:
         description: The OCID of the tenancy for which details needs to be retrieved
@@ -105,8 +105,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
 
     result = get_tenancy_details(identity_client, module)
     module.exit_json(tenancy=result)

--- a/library/oci_user.py
+++ b/library/oci_user.py
@@ -29,7 +29,7 @@ description:
     - Update OCI user, if present, and reset the ui password of the user
     - Unblock a blocked user
     - Delete OCI user, if present.
-version_added: "2.x"
+version_added: "2.5"
 options:
     name:
         description: Name of the user. Must be unique for a tenancy.
@@ -183,7 +183,7 @@ user:
             sample: ocid1.user.oc1.axdf
         inactive_status:
             description: The detailed status of INACTIVE life cycle state
-            returned: always
+            returned: when user's lifecycle_state is INACTIVE
             type: string
             sample: None
         lifecycle_state:
@@ -535,7 +535,8 @@ def main():
         module.fail_json(msg='oci python sdk required for this module')
 
     oci_config = oci_utils.get_oci_config(module)
-    identity_client = IdentityClient(oci_config)
+    identity_client = oci_utils.create_service_client(module, IdentityClient)
+
     compartment_id = oci_config['tenancy']
     module.params.update(dict({'compartment_id': compartment_id}))
     state = module.params['state']

--- a/library/oci_vcn.py
+++ b/library/oci_vcn.py
@@ -21,7 +21,7 @@ module: oci_vcn
 short_description: Manage Virtual Cloud Networks(VCN) in OCI
 description:
     - This module allows the user to create, delete and update virtual cloud networks(VCNs) in OCI.
-version_added: "2.x"
+version_added: "2.5"
 options:
     cidr_block:
         description: The CIDR IP address block of the VCN. Required when creating a VCN with I(state=present).
@@ -81,7 +81,7 @@ vcn:
     type: dict
     sample: {
             "cidr_block": "10.0.0.0/16",
-            "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+            compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
             "default_dhcp_options_id": "ocid1.dhcpoptions.oc1.phx.xxxxxEXAMPLExxxxx",
             "default_route_table_id": "ocid1.routetable.oc1.phx.xxxxxEXAMPLExxxxx",
             "default_security_list_id": "ocid1.securitylist.oc1.phx.xxxxxEXAMPLExxxxx",
@@ -171,8 +171,8 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    virtual_network_client = VirtualNetworkClient(config)
+    virtual_network_client = oci_utils.create_service_client(module, VirtualNetworkClient)
+
     exclude_attributes = {'display_name': True, 'dns_label': True}
     state = module.params['state']
     vcn_id = module.params['vcn_id']

--- a/library/oci_vnic.py
+++ b/library/oci_vnic.py
@@ -22,7 +22,7 @@ short_description: Update a VNIC
 description:
     - This module allows the user to update a specified VNIC. To create a primary VNIC, use oci_instance. To create a
       secondary VNIC and attach it to an instance, use oci_vnic_attachment.
-version_added: "2.x"
+version_added: "2.5"
 options:
   hostname_label:
         description: The hostname for the VNIC's primary private IP. Used for DNS. The value is the hostname portion of
@@ -139,9 +139,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    virtnetwork_client = VirtualNetworkClient(config)
-
+    virtnetwork_client = oci_utils.create_service_client(module, VirtualNetworkClient)
     result = dict(changed=False)
 
     id = module.params['id']

--- a/library/oci_vnic_attachment.py
+++ b/library/oci_vnic_attachment.py
@@ -23,7 +23,7 @@ short_description: Create a secondary VNIC and attach it to a compute instance, 
 description:
     - This module allows the user to create a secondary VNIC and attach it to a compute instance, detach a secondary
       VNIC attachment from a compute instance, and delete the secondary VNIC.
-version_added: "2.x"
+version_added: "2.5"
 options:
     instance_id:
         description: The OCID of the instance to which the secondary VNIC must be attached. Required when a secondary
@@ -283,8 +283,8 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    compute_client = ComputeClient(config)
+    compute_client = oci_utils.create_service_client(module, ComputeClient)
+
     state = module.params['state']
 
     result = dict(changed=False)

--- a/library/oci_vnic_attachment_facts.py
+++ b/library/oci_vnic_attachment_facts.py
@@ -21,7 +21,7 @@ short_description: Retrieve details about one or more VNIC attachments in the sp
 description:
     - This module retrieves details about a VNIC attachment, or all VNIC attachments in a specified Compartment in OCI
       Compute Service. A VNIC attachment resides in the same compartment as the attached instance.
-version_added: "2.x"
+version_added: "2.5"
 options:
     availability_domain:
         description: The name of the Availability Domain.
@@ -42,7 +42,7 @@ options:
         aliases: ['id']
 
 author: "Sivakumar Thyagarajan (@sivakumart)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -153,7 +153,7 @@ except ImportError:
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         availability_domain=dict(type='str', required=False),
@@ -170,8 +170,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    compute_client = ComputeClient(config)
+    compute_client = oci_utils.create_service_client(module, ComputeClient)
 
     compartment_id = module.params.get('compartment_id', None)
     id = module.params['vnic_attachment_id']
@@ -180,7 +179,7 @@ def main():
     try:
         if compartment_id:
             # filter and get only key:values that have been provided by the user
-            key_list = ['availability_domain', "instance_id", "compartment_id"]
+            key_list = ['availability_domain', "instance_id", "compartment_id", "display_name"]
             param_map = {k: v for (k, v) in six.iteritems(module.params) if k in key_list and v is not None}
 
             inst = oci_utils.list_all_resources(compute_client.list_vnic_attachments, **param_map)

--- a/library/oci_vnic_facts.py
+++ b/library/oci_vnic_facts.py
@@ -20,7 +20,7 @@ module: oci_vnic_facts
 short_description: Retrieve details about a specific VNIC
 description:
     - This module retrieves details about a specific VNIC.
-version_added: "2.x"
+version_added: "2.5"
 options:
     vnic_id:
         description: The OCID of the VNIC. Required for retrieving information about a specific VNIC attachment.
@@ -156,8 +156,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    virtnw_client = VirtualNetworkClient(config)
+    virtnw_client = oci_utils.create_service_client(module, VirtualNetworkClient)
 
     id = module.params['vnic_id']
 

--- a/library/oci_volume_attachment.py
+++ b/library/oci_volume_attachment.py
@@ -21,7 +21,7 @@ module: oci_volume_attachment
 short_description: Attach or detach a volume in OCI Block Volume service
 description:
     - This module allows the user to attach a volume to an instance or detach a volume from an instance in OCI.
-version_added: "2.x"
+version_added: "2.5"
 options:
     instance_id:
         description: The OCID of the instance. Required to attach a volume to an instance with I(state=present).
@@ -152,8 +152,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    compute_client = ComputeClient(config)
+    compute_client = oci_utils.create_service_client(module, ComputeClient)
 
     state = module.params['state']
     exclude_attributes = {'display_name': True}

--- a/library/oci_volume_attachment_facts.py
+++ b/library/oci_volume_attachment_facts.py
@@ -22,7 +22,7 @@ short_description: Retrieve facts of volume attachments in OCI
 description:
     - This module retrieves information of a specified volume attachment or all the volume attachments in a specified
       compartment.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment. Required to get information of all the volume attachments in a
@@ -41,7 +41,7 @@ options:
                      information related to I(volume_id).
         required: false
 author: "Rohit Chaware (@rohitChaware)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -176,7 +176,7 @@ except ImportError:
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         instance_id=dict(type='str', required=False),
@@ -195,8 +195,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    compute_client = ComputeClient(config)
+    compute_client = oci_utils.create_service_client(module, ComputeClient)
 
     volume_attachment_id = module.params['volume_attachment_id']
 
@@ -206,7 +205,7 @@ def main():
                                                           volume_attachment_id=volume_attachment_id).data)]
 
         else:
-            key_list = ["compartment_id", "instance_id", "volume_id"]
+            key_list = ["compartment_id", "instance_id", "volume_id", "display_name"]
             param_map = {k: v for (k, v) in six.iteritems(module.params) if k in key_list and v is not None}
 
             result = to_dict(oci_utils.list_all_resources(compute_client.list_volume_attachments, **param_map))

--- a/library/oci_volume_backup.py
+++ b/library/oci_volume_backup.py
@@ -22,7 +22,7 @@ short_description: Manage volume backups in OCI Block Volume service
 description:
     - This module allows the user to perform create, delete & update operations on volume backups in OCI Block Volume
       service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     display_name:
         description: A user-friendly name for the volume backup. Does not have to be unique and it's changeable. Avoid
@@ -266,8 +266,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    block_storage_client = BlockstorageClient(config)
+    block_storage_client = oci_utils.create_service_client(module, BlockstorageClient)
 
     state = module.params['state']
     volume_backup_id = module.params['volume_backup_id']

--- a/library/oci_volume_backup_facts.py
+++ b/library/oci_volume_backup_facts.py
@@ -22,7 +22,7 @@ short_description: Retrieve facts of volume backups in OCI Block Volume service
 description:
     - This module retrieves information of a specified volume backup or all the volume backups in a compartment in OCI
       Block Volume service.
-version_added: "2.x"
+version_added: "2.5"
 options:
     compartment_id:
         description: The OCID of the compartment.
@@ -32,7 +32,7 @@ options:
         required: false
         aliases: [ 'id' ]
 author: "Rohit Chaware (@rohitChaware)"
-extends_documentation_fragment: oracle
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 '''
 
 EXAMPLES = '''
@@ -139,7 +139,7 @@ except ImportError:
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(dict(
         compartment_id=dict(type='str', required=False),
         volume_backup_id=dict(type='str', required=False, aliases=['id'])
@@ -159,8 +159,7 @@ def main():
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg='oci python sdk required for this module.')
 
-    config = oci_utils.get_oci_config(module)
-    block_storage_client = BlockstorageClient(config)
+    block_storage_client = oci_utils.create_service_client(module, BlockstorageClient)
 
     volume_backup_id = module.params['volume_backup_id']
 
@@ -172,7 +171,8 @@ def main():
         else:
             compartment_id = module.params['compartment_id']
             result = to_dict(oci_utils.list_all_resources(block_storage_client.list_volume_backups,
-                                                          compartment_id=compartment_id))
+                                                          compartment_id=compartment_id,
+                                                          display_name=module.params['display_name']))
     except ServiceError as ex:
         module.fail_json(msg=ex.message)
 

--- a/library/oci_zone.py
+++ b/library/oci_zone.py
@@ -1,0 +1,307 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_zone
+short_description: Manage a Zone in OCI DNS Service
+description:
+    - This module allows the user to create, update and delete a Zone in OCI DNS Service.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: The OCID of the compartment containing the zone. Required to create a zone.
+        required: false
+    name:
+        description: The name of the zone. Required to create a zone. Either I(name) or I(zone_id) must be specified
+                     to update or delete a zone.
+        required: false
+        aliases: ['zone_name']
+    zone_id:
+        description: The OCID of the target zone. Either I(name) or I(zone_id) must be specified to update or
+                     delete a zone.
+        required: false
+        aliases: ['id']
+    zone_type:
+        description: The type of the zone. Must be either PRIMARY or SECONDARY. Required to create a zone.
+        required: false
+        choices: ['PRIMARY', 'SECONDARY']
+    external_masters:
+        description: External master servers for the Zone
+        required: false
+        suboptions:
+            address:
+                description: The server's IP address (IPv4 or IPv6).
+                required: true
+            port:
+                description: The server's port. Port value must be a value of 53, otherwise omit the port value.
+                required: false
+            tsig:
+                description: A L(TSIG, https://tools.ietf.org/html/rfc2845) key.
+                required: false
+                suboptions:
+                    name:
+                        description: A domain name identifying the key for a given pair of hosts.
+                        required: true
+                    secret:
+                        description: A base64 string encoding the binary shared secret.
+                        required: true
+                    algorithm:
+                        description: "TSIG Algorithms are encoded as domain names, but most consist of only one
+                                     non-empty label, which is not required to be explicitly absolute. Applicable
+                                     algorithms include: hmac-sha1, hmac-sha224, hmac-sha256, hmac-sha512. For more
+                                     information on these algorithms, please see
+                                     L(RFC 4635, https://tools.ietf.org/html/rfc4635#section-2)."
+                        required: true
+    state:
+        description: Create or update a zone with I(state=present). Use I(state=absent) to delete a zone.
+        required: false
+        default: present
+        choices: ['present', 'absent']
+author: "Sivakumar Thyagarajan (@sivakumart)"
+extends_documentation_fragment: [ oracle, oracle_creatable_resource, oracle_wait_options ]
+'''
+
+EXAMPLES = '''
+- name: Create a zone
+  oci_zone:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    name: test_zone_1.com
+    zone_type: PRIMARY
+
+- name: Update a zone using id
+  oci_zone:
+    id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+    external_masters: [ { address: "12.123.123.123", tsig: { name: "test_zone_1.com", secret: "XXXX",
+                            algorithm: "hmac-sha1" } } ]
+
+- name: Update a zone using name
+  oci_zone:
+    name: test_zone1.com
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    external_masters: [ { address: "12.123.123.123", tsig: { name: "test_zone_1.com", secret: "XXXX",
+                            algorithm: "hmac-sha1" } } ]
+- name: Delete a zone
+  oci_zone:
+    id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+    state: absent
+'''
+
+RETURN = '''
+zone:
+    description: Information about the zone
+    returned: On successful create, delete & update operations on zone
+    type: complex
+    contains:
+        name:
+            description: The name of the zone.
+            returned: always
+            type: string
+            sample: "test_zone_1.com"
+        compartment_id:
+            description: The OCID of the compartment containing the Zone.
+            returned: always
+            type: string
+            sample: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        zone_type:
+            description: The type of the zone. Must be either PRIMARY or SECONDARY.
+            returned: always
+            type: string
+            sample: "PRIMARY"
+        external_masters:
+            description: External master servers for the zone.
+            returned: always
+            type: list
+            sample: { address: "12.123.123.123", tsig: { name: "test_zone_1.com", secret: "XXXX",
+                            algorithm: "hmac-sha1" } }
+        self_uri:
+            description: The canonical absolute URL of the resource.
+            returned: always
+            type: string
+            sample: "https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/test_zone_1.com"
+        id:
+            description: The OCID of the zone
+            returned: always
+            type: string
+            sample: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+        time_created:
+            description: The date and time the resource was created in "YYYY-MM-ddThh:mmZ" format with a Z offset, as
+                         defined by RFC 3339.
+            returned: always
+            type: string
+            sample: "2018-08-23T11:36:26+00:00"
+        version:
+            description: Version is the never-repeating, totally-orderable, version of the zone, from which the serial
+                         field of the zone's SOA record is derived.
+            returned: always
+            type: string
+            sample: "1"
+        serial:
+            description: The current serial of the zone. As seen in the zone's SOA record.
+            returned: always
+            type: int
+            sample: 1
+        lifecycle_state:
+            description: The current state of the zone resource.
+            returned: always
+            type: string
+            sample: "ACTIVE"
+        nameservers:
+            description: The authoritative nameservers for the zone.
+            returned: optional
+            type: list
+            sample: [{ hostname: "XXX" }]
+    sample: {
+                "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+                "external_masters": [],
+                "id": "ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx",
+                "lifecycle_state": "ACTIVE",
+                "name": "test_zone_1.com",
+                "self_uri": "https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/test_zone_1.com",
+                "serial": 1,
+                "time_created": "2018-08-23T11:36:26+00:00",
+                "version": "1",
+                "zone_type": "PRIMARY"
+        }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    from oci.dns.dns_client import DnsClient
+    from oci.dns.models import CreateZoneDetails, UpdateZoneDetails
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+# DNS client accepts either a zone name or an id through the zone_name_or_id parameter for update and delete scenarios.
+# This is different from other resources.
+# XXX: for now only zone_name appears to work, and not OCID. Using an OCID gives an error "Invalid Domain Name".
+def get_zone_name_or_id(module):
+    if module.params['name'] is not None:
+        return module.params['name']
+    if module.params['zone_id'] is not None:
+        return module.params['zone_id']
+    if module.params['id'] is not None:
+        return module.params['id']
+    return None
+
+
+def delete_zone(dns_client, module):
+    result = oci_utils.delete_and_wait(resource_type="zone",
+                                       client=dns_client,
+                                       get_fn=dns_client.get_zone,
+                                       kwargs_get={"zone_name_or_id": get_zone_name_or_id(module)},
+                                       delete_fn=dns_client.delete_zone,
+                                       kwargs_delete={"zone_name_or_id": get_zone_name_or_id(module)},
+                                       module=module
+                                       )
+    return result
+
+
+def update_zone(dns_client, module):
+    result = oci_utils.check_and_update_resource(resource_type="zone",
+                                                 get_fn=dns_client.get_zone,
+                                                 kwargs_get={"zone_name_or_id": get_zone_name_or_id(module)},
+                                                 update_fn=dns_client.update_zone,
+                                                 primitive_params_update=['zone_name_or_id'],
+                                                 kwargs_non_primitive_update={
+                                                     UpdateZoneDetails: "update_zone_details"
+                                                 },
+                                                 module=module,
+                                                 update_attributes=UpdateZoneDetails().attribute_map.keys())
+    return result
+
+
+# XXX: Importing of a Zone via a zone file in RFC 1035 master file format as exported by BIND (through the Content-Type
+# header as `text/dns` as documented in the API?), doesn't appear to be supported in the SDK. It is supported in the
+# the console though. Check if this is possible via the SDK
+def create_zone(dns_client, module):
+    create_zone_details = CreateZoneDetails()
+    for attribute in create_zone_details.attribute_map:
+        if attribute in module.params:
+            setattr(create_zone_details, attribute, module.params[attribute])
+
+    result = oci_utils.create_and_wait(resource_type="zone",
+                                       create_fn=dns_client.create_zone,
+                                       kwargs_create={"create_zone_details": create_zone_details},
+                                       client=dns_client,
+                                       get_fn=dns_client.get_zone,
+                                       get_param="zone_name_or_id",
+                                       module=module
+                                       )
+    return result
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec(supports_create=True, supports_wait=True)
+    module_args.update(dict(
+        compartment_id=dict(type='str', required=False),
+        name=dict(type='str', required=False, aliases=['zone_name']),
+        zone_id=dict(type='str', required=False, aliases=['id']),
+        zone_type=dict(type='str', required=False, choices=['PRIMARY', 'SECONDARY']),
+        external_masters=dict(type='list', required=False),
+        state=dict(type='str', required=False, default='present', choices=['absent', 'present'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        mutually_exclusive=['zone_id', 'name'],
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    config = oci_utils.get_oci_config(module)
+    dns_client = DnsClient(config)
+
+    state = module.params['state']
+    zone_id = module.params['zone_id']
+
+    if state == 'absent':
+        result = delete_zone(dns_client, module)
+
+    else:
+        if zone_id is not None:
+            module.params['zone_name_or_id'] = get_zone_name_or_id(module)
+            result = update_zone(dns_client, module)
+            # XXX: also handle case where zone name is specified
+        else:
+            if module.params['zone_type'] is None:
+                module.fail_json(msg='Zone_type must be specified while creating a Zone')
+            kwargs_list = {'compartment_id': module.params['compartment_id']}
+
+            result = oci_utils.check_and_create_resource(resource_type='zone',
+                                                         create_fn=create_zone,
+                                                         kwargs_create={
+                                                             'dns_client': dns_client,
+                                                             'module': module},
+                                                         list_fn=dns_client.list_zones,
+                                                         kwargs_list=kwargs_list,
+                                                         module=module,
+                                                         model=CreateZoneDetails(),
+                                                         exclude_attributes=None
+                                                         )
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_zone_facts.py
+++ b/library/oci_zone_facts.py
@@ -1,0 +1,215 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_zone_facts
+short_description: Retrieve facts of zones in Oracle Cloud Infrastructure DNS Service
+description:
+    - This module retrieves information of the specified zone or all zones in the specified compartment.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: The OCID of the compartment the resource belongs to. Use I(zone_id) to retrieve a specific
+                     zone's information using its OCID.
+        required: false
+    zone_id:
+        description: OCID of the target zone.
+        required: false
+        aliases: ['id']
+    name:
+        description: A case-sensitive filter for zone names. Will match any zone with a name that equals the
+                     provided value.
+        required: false
+        aliases: ['zone_name']
+    zone_type:
+        description: Search by zone type, PRIMARY or SECONDARY. Will match any zone whose type equals the provided
+                     value.
+        required: false
+        choices: ['PRIMARY', 'SECONDARY']
+author: "Sivakumar Thyagarajan (@sivakumart)"
+extends_documentation_fragment: oracle
+'''
+
+EXAMPLES = '''
+- name: Get a list of zones in the specified compartment
+  oci_zone_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+
+- name: Get a zone with the specified name
+  oci_zone_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    name: test_zone_1.com
+
+- name: Get a list of primary zones in the specified compartment
+  oci_zone_facts:
+    compartment_id: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+    zone_type: "PRIMARY"
+
+- name: Gets details of a specific zone using the OCID of the zone
+  oci_zone_facts:
+    zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+'''
+
+RETURN = '''
+zones:
+    description: List of Zone details
+    returned: always
+    type: complex
+    contains:
+        name:
+            description: The name of the zone.
+            returned: always
+            type: string
+            sample: "test_zone_1.com"
+        compartment_id:
+            description: The OCID of the compartment containing the Zone.
+            returned: always
+            type: string
+            sample: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
+        zone_type:
+            description: The type of the zone. Must be either PRIMARY or SECONDARY.
+            returned: always
+            type: string
+            sample: "PRIMARY"
+        external_masters:
+            description: External master servers for the zone.
+            returned: always
+            type: list
+            sample: [...]
+        self_uri:
+            description: The canonical absolute URL of the resource.
+            returned: always
+            type: string
+            sample: "https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/test_zone_1.com"
+        id:
+            description: The OCID of the zone
+            returned: always
+            type: string
+            sample: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+        time_created:
+            description: The date and time the resource was created in "YYYY-MM-ddThh:mmZ" format with a Z offset, as
+                         defined by RFC 3339.
+            returned: always
+            type: string
+            sample: "2018-08-23T11:36:26+00:00"
+        version:
+            description: Version is the never-repeating, totally-orderable, version of the zone, from which the serial
+                         field of the zone's SOA record is derived.
+            returned: always
+            type: string
+            sample: "1"
+        serial:
+            description: The current serial of the zone. As seen in the zone's SOA record.
+            returned: always
+            type: int
+            sample: 1
+        lifecycle_state:
+            description: The current state of the zone resource.
+            returned: always
+            type: string
+            sample: "ACTIVE"
+        nameservers:
+            description: The authoritative nameservers for the zone.
+            returned: optional
+            type: list
+            sample: [{ hostname: "XXX" }]
+    sample: [{
+                "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+                "external_masters": [],
+                "id": "ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx",
+                "lifecycle_state": "ACTIVE",
+                "name": "test_zone_1.com",
+                "self_uri": "https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/test_zone_1.com",
+                "serial": 1,
+                "time_created": "2018-08-23T11:36:26+00:00",
+                "version": "1",
+                "zone_type": "PRIMARY"
+        }]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+import six
+
+try:
+    from oci.dns.dns_client import DnsClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+# DNS client accepts either a zone name or an id through the zone_name_or_id parameter for update and delete scenarios.
+# This is different from other resources.
+def get_zone_name_or_id(module):
+    if module.params['name']:
+        return module.params['name']
+    if module.params['zone_id']:
+        return module.params['zone_id']
+    return None
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(
+        zone_id=dict(type='str', required=False, aliases=['id']),
+        name=dict(type='str', required=False, aliases=['zone_name']),
+        compartment_id=dict(type='str', required=False),
+        zone_type=dict(type='str', required=False, choices=['PRIMARY', 'SECONDARY'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_one_of=[
+            ['zone_id', 'compartment_id']
+        ]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    config = oci_utils.get_oci_config(module)
+    dns_client = DnsClient(config)
+
+    zone_id = module.params['zone_id']
+    compartment_id = module.params['compartment_id']
+
+    try:
+        if zone_id is not None:
+            result = [to_dict(oci_utils.call_with_backoff(dns_client.get_zone,
+                                                          zone_name_or_id=get_zone_name_or_id(module)).data)]
+        elif compartment_id is not None:
+            key_list = ['compartment_id', 'name', 'zone_type']
+            param_map = {k: v for (k, v) in six.iteritems(module.params) if k in key_list and v is not None}
+            zone_summaries = to_dict(oci_utils.list_all_resources(dns_client.list_zones, **param_map))
+            # Get Zone model from zone-summaries returned by `list_zones`
+            result = to_dict([oci_utils.call_with_backoff(dns_client.get_zone, zone_name_or_id=z['id']).data
+                              for z in zone_summaries])
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(zones=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_zone_records.py
+++ b/library/oci_zone_records.py
@@ -1,0 +1,303 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_zone_records
+short_description: Update or Patch a collection of records in the specified zone in OCI DNS Service
+description:
+    - This module allows the user to update or patch a collection of records in the specified DNS zone in OCI DNS
+      Service.
+version_added: "2.5"
+options:
+    zone_id:
+        description: The OCID of the target zone. Either I(name) or I(zone_id) must be specified to update or path
+                     the collection of records in the specified zone.
+        required: false
+        aliases: ['id']
+    name:
+        description: The name of the zone. Required to create a zone. Either I(name) or I(zone_id) must be specified
+                     to update or patch the collection of recordsin the specified zone.
+        required: false
+        aliases: ['zone_name']
+    compartment_id:
+        description: The OCID of the compartment the resource belongs to.
+        required: false
+    update_items:
+        description: The items to update the Zone's records collection to. Required to update a zone.
+        required: false
+        suboptions:
+            domain:
+                description: The fully qualified domain name where the record can be located.
+                required: true
+            record_hash:
+                description: A unique identifier for the record within its zone.
+                required: false
+            is_protected:
+                description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                             managed.
+                required: false
+            rdata:
+                description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+                required: true
+            rr_set_version:
+                description: The latest version of the record's zone in which its RRSet differs from the preceding
+                             version.
+                required: false
+            rtype:
+                description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                             L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+                required: true
+            ttl:
+                description: The Time To Live for the record, in seconds.
+                required: true
+    patch_items:
+        description: The record operations to patch the Zone's records collection. Required to patch a zone.
+        required: false
+        suboptions:
+            domain:
+                description: The fully qualified domain name where the record can be located.
+                required: false
+            record_hash:
+                description: A unique identifier for the record within its zone.
+                required: false
+            is_protected:
+                description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                             managed.
+                required: false
+            rdata:
+                description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+                required: false
+            rr_set_version:
+                description: The latest version of the record's zone in which its RRSet differs from the preceding
+                             version.
+                required: false
+            rtype:
+                description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                             L(Resource Record (RR) TYPEs,https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+                required: false
+            ttl:
+                description: The Time To Live for the record, in seconds.
+                required: true
+            operation:
+                description: A description of how a record relates to a PATCH operation. REQUIRE indicates a
+                             precondition that record data must already exist. PROHIBIT indicates a precondition that
+                             record data must not already exist. ADD indicates that record data must exist after
+                             successful application. REMOVE indicates that record data must not exist after successful
+                             application. Note - ADD and REMOVE operations can succeed even if they require no changes
+                             when applied, such as when the described records are already present or absent.
+                             Note - ADD and REMOVE operations can describe changes for more than one record.
+                             Example - { "domain" - "www.example.com", "rtype" - "AAAA", "ttl" - 60 } specifies a new TTL
+                             for every record in the www.example.com AAAA RRSet.'
+                required: false
+                choices: ['REQUIRE', 'PROHIBIT', 'ADD', 'REMOVE']
+    state:
+        description: State of the Zone records
+        required: false
+        default: present
+        choices: ['present']
+author: "Sivakumar Thyagarajan (@sivakumart)"
+extends_documentation_fragment: [ oracle, oracle_wait_options ]
+'''
+
+EXAMPLES = '''
+- name: Update a zone's records by adding a new record. This operation replaces records in the specified zone with the
+        specified records. So ensure that you include the original zone records, if you want to retain existing records.
+  oci_zone_records:
+    name: "test_zone_1.com"
+    update_items: [ <original zone records...> , { domain: "test_zone_1.com", ttl: 30, rtype='TXT', rdata='some textual
+                    data' } ]
+
+- name: Patch a zone's records
+  oci_zone_records:
+    name: test_zone1.com
+    patch_items: [{
+                    domain: "test_zone_1.com",
+                    is_protected: false,
+                    rdata: "some textual data",
+                    rtype: "TXT",
+                    ttl: 30,
+                    operation: "REMOVE"
+                    }]
+'''
+
+RETURN = '''
+zone_records:
+    description: Information about the zone's resource records
+    returned: On successful update or patch of zone's resource records
+    type: complex
+    contains:
+        domain:
+            description: The fully qualified domain name where the record can be located.
+            returned: always
+            type: string
+            sample: "test_zone_1.com"
+        record_hash:
+            description: A unique identifier for the record within its zone.
+            returned: always
+            type: string
+            sample: 722af089872ffe65ba909fc8fea1867e
+        is_protected:
+            description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                         managed.
+            returned: always
+            type: boolean
+            sample: false
+        rdata:
+            description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+            returned: always
+            type: string
+            sample: "ns3.p68.dns.oraclecloud.net."
+        rrsetVersion:
+            description: The latest version of the record's zone in which its RRSet differs from the preceding version.
+            returned: always
+            type: string
+            sample: "5"
+        rtype:
+            description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                         L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+            returned: always
+            type: string
+            sample: "NS"
+        ttl:
+            description: The Time To Live for the record, in seconds.
+            returned: always
+            type: string
+            sample: "86400"
+    sample:
+                {
+                    "domain": "test_zone_1.com",
+                    "is_protected": true,
+                    "rdata": "ns2.p68.dns.oraclecloud.net.",
+                    "record_hash": "9be3279d81b5e8430fd94c70cfa5f0a8",
+                    "rrset_version": "1",
+                    "rtype": "NS",
+                    "ttl": 86400
+                }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    from oci.dns.dns_client import DnsClient
+    from oci.dns.models import PatchZoneRecordsDetails, RecordOperation, RecordDetails, UpdateZoneRecordsDetails
+    from oci.exceptions import ServiceError
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+RESOURCE_NAME = "zone_records"
+
+
+# DNS client accepts either a zone name or an id through the zone_name_or_id parameter for update and delete scenarios.
+# This is different from other resources.
+# XXX: for now only zone_name appears to work, and not OCID. Using an OCID gives an error "Invalid Domain Name".
+def get_zone_name_or_id(module):
+    if module.params['name'] is not None:
+        return module.params['name']
+    if module.params['zone_id'] is not None:
+        return module.params['zone_id']
+    if module.params['id'] is not None:
+        return module.params['id']
+    return None
+
+
+def create_model(model_class, user_values):
+    model_instance = model_class()
+    for attr in model_instance.attribute_map.keys():
+        if attr in user_values:
+            setattr(model_instance, attr, user_values[attr])
+    return model_instance
+
+
+def modify_zone_records(dns_client, module, modify_operation, modify_kwargs):
+    result = {}
+    try:
+        # get current zone records
+        zone_records_old = oci_utils.call_with_backoff(
+            dns_client.get_zone_records, zone_name_or_id=get_zone_name_or_id(module)).data.items
+
+        # update zone records
+        updated_rec_coll = oci_utils.call_with_backoff(modify_operation, **modify_kwargs).data
+        result[RESOURCE_NAME] = oci_utils.to_dict(updated_rec_coll.items)
+
+        # get zone records after update
+        zone_records_new = oci_utils.call_with_backoff(
+            dns_client.get_zone_records, zone_name_or_id=get_zone_name_or_id(module)).data.items
+
+        # check if there is any change between the old and the new zone records, and set changed accordingly
+        result['changed'] = not oci_utils.compare_list(zone_records_old, zone_records_new)
+    except ServiceError as ex:
+        module.fail_json(msg=str(ex))
+    return result
+
+
+def patch_zone_records(dns_client, module):
+    patch_items = module.params['patch_items']
+    patch_zone_records_details = PatchZoneRecordsDetails()
+    patch_zone_records_details.items = [create_model(RecordOperation, item) for item in patch_items]
+    kwargs = {"patch_zone_records_details": patch_zone_records_details,
+              "zone_name_or_id": get_zone_name_or_id(module)}
+    return modify_zone_records(dns_client, module, modify_operation=dns_client.patch_zone_records, modify_kwargs=kwargs)
+
+
+def update_zone_records(dns_client, module):
+    update_items = module.params['update_items']
+    update_zone_records_details = UpdateZoneRecordsDetails()
+    update_zone_records_details.items = [create_model(RecordDetails, item) for item in update_items]
+    kwargs = {"update_zone_records_details": update_zone_records_details,
+              "zone_name_or_id": get_zone_name_or_id(module)}
+    return modify_zone_records(dns_client, module, modify_operation=dns_client.update_zone_records,
+                               modify_kwargs=kwargs)
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec(supports_wait=True)
+    module_args.update(dict(
+        compartment_id=dict(type='str', required=False),
+        zone_id=dict(type='str', required=False, aliases=['id']),
+        name=dict(type='str', required=False, aliases=['zone_name']),
+        update_items=dict(type='list', required=False),
+        patch_items=dict(type='list', required=False),
+        state=dict(type='str', required=False, default='present', choices=['present'])
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_one_of=[['update_items', 'patch_items'], ['zone_id', 'name']]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    config = oci_utils.get_oci_config(module)
+    dns_client = DnsClient(config)
+
+    state = module.params['state']
+    if state == 'present':
+        if module.params['update_items'] is not None:
+            result = update_zone_records(dns_client, module)
+        else:
+            result = patch_zone_records(dns_client, module)
+        module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oci_zone_records_facts.py
+++ b/library/oci_zone_records_facts.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: oci_zone_records_facts
+short_description: Retrieve facts of records in a specified zone in Oracle Cloud Infrastructure DNS Service
+description:
+    - This module retrieves information of records in a specified zone. The results are sorted by domain in
+      alphabetical order by default. For more information about records, please see
+      L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+version_added: "2.5"
+options:
+    compartment_id:
+        description: The OCID of the compartment the resource belongs to. Use I(zone_id) or I(zone_name)
+                     to retrieve a specific zone's information using its OCID.
+        required: false
+    zone_id:
+        description: OCID of the target zone.
+        required: false
+        aliases: ['id']
+    name:
+        description: A case-sensitive filter for zone names. Will match any zone with a name that equals the
+                     provided value.
+        required: false
+        aliases: ['zone_name']
+    zone_version:
+        description: The version of the zone for which data is requested.
+        required: false
+    domain:
+        description: Search by domain. Will match any record whose domain (case-insensitive) equals the
+                     provided value.
+        required: false
+    domain_contains:
+        description: Search by domain. Will match any record whose domain (case-insensitive) contains the provided
+                     value.
+        required: false
+    rtype:
+        description: Search by record type. Will match any record whose type (case-insensitive) equals the provided
+                     value.
+        required: false
+author: "Sivakumar Thyagarajan (@sivakumart)"
+extends_documentation_fragment: oracle
+'''
+
+EXAMPLES = '''
+- name: Get a list of zone records in the specified zone
+  oci_zone_records_facts:
+    zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+
+- name: Get a list of zone records in a zone for a specific domain
+  oci_zone_records_facts:
+    zone_id: ocid1.dns-zone.oc1..xxxxxEXAMPLExxxxx
+    domain: test_zone_1.com
+
+- name: Gets a list of NS records in a specific zone
+  oci_zone_records_facts:
+    name: test_zone_1.com
+    rtype: NS
+'''
+
+RETURN = '''
+zone_records:
+    description: A collection of DNS resource record objects.
+    returned: always
+    type: complex
+    contains:
+        domain:
+            description: The fully qualified domain name where the record can be located.
+            returned: always
+            type: string
+            sample: "test_zone_1.com"
+        record_hash:
+            description: A unique identifier for the record within its zone.
+            returned: always
+            type: string
+            sample: "f439fa9a087ff74757485953fe0a8c7d"
+        is_protected:
+            description: A Boolean flag indicating whether or not parts of the record are unable to be explicitly
+                         managed.
+            returned: always
+            type: boolean
+            sample: true
+        rdata:
+            description: The record's data, as whitespace-delimited tokens in type-specific presentation format.
+            returned: always
+            type: string
+            sample: "ns1.p68.dns.oraclecloud.net. hostmaster.test_zone_1.com. 1 3600 600 604800 1800"
+        rrset_version:
+            description: The latest version of the record's zone in which its RRSet differs from the preceding version.
+            returned: always
+            type: string
+            sample: "1"
+        rtype:
+            description: The canonical name for the record's type, such as A or CNAME. For more information, see
+                         L(Resource Record (RR) TYPEs, https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4).
+            returned: always
+            type: string
+            sample: "NS"
+        ttl:
+            description: The Time To Live for the record, in seconds.
+            returned: always
+            type: string
+            sample: "86400"
+    sample:
+                {
+                    "domain": "test_zone_1.com",
+                    "is_protected": true,
+                    "rdata": "ns2.p68.dns.oraclecloud.net.",
+                    "record_hash": "9be3279d81b5e8430fd94c70cfa5f0a8",
+                    "rrset_version": "1",
+                    "rtype": "NS",
+                    "ttl": 86400
+                }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+import six
+
+try:
+    from oci.dns.dns_client import DnsClient
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError
+
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+# DNS client accepts either a zone name or an id through the zone_name_or_id parameter for update and delete scenarios.
+# This is different from other resources.
+def get_zone_name_or_id(module):
+    if module.params['name'] is not None:
+        return module.params['name']
+    if module.params['zone_id'] is not None:
+        return module.params['zone_id']
+    if module.params['id'] is not None:
+        return module.params['id']
+    return None
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(
+        zone_id=dict(type='str', required=False, aliases=['id']),
+        name=dict(type='str', required=False, aliases=['zone_name']),
+        compartment_id=dict(type='str', required=False),
+        zone_version=dict(type='str', required=False),
+        domain=dict(type='str', required=False),
+        domain_contains=dict(type='str', required=False),
+        rtype=dict(type='str', required=False)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_one_of=[
+            ['zone_id', 'name']
+        ]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg='oci python sdk required for this module.')
+
+    config = oci_utils.get_oci_config(module)
+    dns_client = DnsClient(config)
+
+    try:
+        zone_name_or_id = get_zone_name_or_id(module)
+        key_list = ["compartment_id", "zone_version", "domain", "domain_contains", "rtype"]
+        kwargs = {k: v for (k, v) in six.iteritems(module.params) if k in key_list and v is not None}
+
+        result = to_dict(oci_utils.call_with_backoff(dns_client.get_zone_records,
+                                                     zone_name_or_id=zone_name_or_id,
+                                                     **kwargs).data.items)
+
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+    module.exit_json(zone_records=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/module_docs_fragments/oracle.py
+++ b/module_docs_fragments/oracle.py
@@ -54,6 +54,16 @@ class ModuleDocFragment(object):
                   the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the
                   key passphrase is not specified through a configuration file (See C(config_file_location)).
             required: false
+        auth_type:
+            description:
+                - The type of authentication to use for making API requests. By default C(auth_type="api_key") based
+                  authentication is performed and the API key (see I(api_user_key_file)) in your config file will be
+                  used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, 
+                  if any, is used. Use C(auth_type="instance_principal") to use instance principal based authentication
+                  when running ansible playbooks within an OCI compute instance.
+            choices: ['api_key', 'instance_principal']
+            default: 'api_key'
+            required: false
         tenancy:
             description:
                 - OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is

--- a/module_docs_fragments/oracle_display_name_option.py
+++ b/module_docs_fragments/oracle_display_name_option.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = '''
+    options:
+        display_name:
+            description: Use I(display_name) along with the other options to return only resources that match the given
+                         display name exactly.
+            required: false
+    '''

--- a/module_docs_fragments/oracle_name_option.py
+++ b/module_docs_fragments/oracle_name_option.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+
+class ModuleDocFragment(object):
+    DOCUMENTATION = '''
+    options:
+        name:
+            description: Use I(name) along with the other options to return only resources that match the given name
+                         exactly.
+            required: false
+    '''

--- a/module_utils/oracle/oci_ce_utils.py
+++ b/module_utils/oracle/oci_ce_utils.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from ansible.module_utils.oracle import oci_utils
+try:
+    import oci
+    from oci.container_engine.models import KeyValue
+    from oci.util import to_dict
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+MAX_WAIT_TIMEOUT_IN_SECONDS = 1200
+
+DEFAULT_READY_STATES = ["AVAILABLE", "ACTIVE", "RUNNING", "PROVISIONED", "ATTACHED", "ASSIGNED"]
+
+DEFAULT_TERMINATED_STATES = ["TERMINATED", "DETACHED", "DELETED"]
+
+logger = oci_utils.get_logger("oci_ce_utils")
+
+
+def _debug(s):
+    get_logger().debug(s)
+
+
+def get_logger():
+    return logger
+
+
+def wait_on_work_request(client, response, module):
+    try:
+        if module.params.get('wait', None):
+            wait_response = oci.wait_until(client,
+                                           response,
+                                           evaluate_response=lambda r: r.data.status == "SUCCEEDED",
+                                           max_wait_seconds=module.params.get(
+                                               'wait_timeout',
+                                               MAX_WAIT_TIMEOUT_IN_SECONDS)
+                                           )
+        else:
+            wait_response = oci.wait_until(client,
+                                           response,
+                                           evaluate_response=lambda r: r.data.status == "ACCEPTED",
+                                           max_wait_seconds=module.params.get(
+                                               'wait_timeout',
+                                               MAX_WAIT_TIMEOUT_IN_SECONDS)
+                                           )
+    except MaximumWaitTimeExceeded as ex:
+        module.fail_json(msg=str(ex))
+    except ServiceError as ex:
+        module.fail_json(msg=str(ex))
+    return wait_response.data
+
+
+def wait_on_resource(client, module, get_fn, kwargs_get, states, evaluate_response=None):
+    try:
+        if evaluate_response:
+            wait_response = oci.wait_until(client,
+                                           get_fn(**kwargs_get),
+                                           evaluate_response=evaluate_response,
+                                           max_wait_seconds=module.params.get(
+                                               'wait_timeout',
+                                               MAX_WAIT_TIMEOUT_IN_SECONDS)
+                                           )
+        else:
+            wait_response = oci.wait_until(client,
+                                           get_fn(**kwargs_get),
+                                           evaluate_response=lambda r: r.data.lifecycle_state in states,
+                                           max_wait_seconds=module.params.get(
+                                               'wait_timeout',
+                                               MAX_WAIT_TIMEOUT_IN_SECONDS)
+                                           )
+        return wait_response.data
+    except MaximumWaitTimeExceeded as ex:
+        module.fail_json(msg=str(ex))
+    except ServiceError as ex:
+        module.fail_json(msg=str(ex))
+
+
+def delete_and_wait(resource_type, client, get_fn, kwargs_get, delete_fn, kwargs_delete, module, states=None,
+                    wait_applicable=True):
+    result = dict(changed=False)
+    try:
+        resource = ''
+        resource = to_dict(oci_utils.call_with_backoff(get_fn, **kwargs_get).data)
+        if resource:
+            if resource_type == "work_request":
+                if resource['status'] not in ["CANCELING", "CANCELED"]:
+                    resource = call_and_wait(client, result, wait_applicable, module, states, DEFAULT_TERMINATED_STATES,
+                                             delete_fn, kwargs_delete, get_fn, kwargs_get,
+                                             evaluate_response=lambda r: r.data.status in ["CANCELING", "CANCELED"])
+            elif "lifecycle_state" not in resource or resource['lifecycle_state'] not in {'DELETING', 'DELETED'}:
+                resource = call_and_wait(client, result, wait_applicable, module, states, DEFAULT_TERMINATED_STATES,
+                                         delete_fn, kwargs_delete, get_fn, kwargs_get)
+            result[resource_type] = resource
+        else:
+            _debug("Resource {0} with {1} already deleted. So returning changed=False".format(resource_type,
+                                                                                              kwargs_get))
+    except ServiceError as ex:
+        if ex.status != 404:
+            module.fail_json(msg=ex.message)
+        result[resource_type] = resource
+    return result
+
+
+def call_and_wait(client, result, wait_applicable, module, states, default_states, fn, kwargs_fn, get_fn, kwargs_get,
+                  evaluate_response=None):
+    # Get the resource as after a delete operation on a resource(eg node pool) the resource may not exist.
+    resource = to_dict(oci_utils.call_with_backoff(get_fn, **kwargs_get).data)
+    wr_id = oci_utils.call_with_backoff(fn, **kwargs_fn).headers.get('opc-work-request-id')
+    if wr_id:
+        get_wr_response = oci_utils.call_with_backoff(client.get_work_request, work_request_id=wr_id)
+        result['work_request'] = to_dict(wait_on_work_request(client, get_wr_response, module))
+    result['changed'] = True
+    if wait_applicable and module.params.get('wait', None):
+        if states is None:
+            states = module.params.get('wait_until') or default_states
+        resource = to_dict(wait_on_resource(client, module, get_fn, kwargs_get, states, evaluate_response))
+    else:
+        try:
+            resource = to_dict(oci_utils.call_with_backoff(get_fn, **kwargs_get).data)
+        except ServiceError as ex:
+            if ex.status != 404:
+                module.fail_json(msg=ex.message)
+    return resource
+
+
+def update_and_wait(resource_type, client, get_fn, kwargs_get, update_fn, primitive_params_update,
+                    kwargs_non_primitive_update, module, update_attributes, states=None, wait_applicable=True):
+    try:
+        result = dict(changed=False)
+        attributes_to_update, resource = oci_utils.get_attr_to_update(get_fn, kwargs_get, module, update_attributes)
+        if attributes_to_update:
+            kwargs_update = oci_utils.get_kwargs_update(attributes_to_update, kwargs_non_primitive_update,
+                                                        module, primitive_params_update)
+            if resource_type == "node_pool":
+                # UpdateNodePoolDetails has a non-primitive type 'initial_node_labels'.
+                set_node_pool_kwargs_update(kwargs_update, module)
+            resource = call_and_wait(client, result, wait_applicable, module, states, DEFAULT_READY_STATES,
+                                     update_fn, kwargs_update, get_fn, kwargs_get)
+        result[resource_type] = to_dict(resource)
+        return result
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+
+
+def set_node_pool_kwargs_update(kwargs_update, module):
+    node_labels = module.params["initial_node_labels"]
+    if node_labels:
+        initial_node_labels = []
+        for d in node_labels:
+            if d.get("key", None) and d.get("value", None):
+                keyvalue = KeyValue()
+                keyvalue.key = d.get("key")
+                keyvalue.value = d.get("value")
+                initial_node_labels.append(keyvalue)
+        kwargs_update["update_node_pool_details"].initial_node_labels = initial_node_labels
+    return kwargs_update
+
+
+def create_and_wait(resource_type, create_fn, kwargs_create, client, get_fn, get_param, module, wait_applicable=True,
+                    states=None):
+    result = dict(changed=False)
+    try:
+        response = oci_utils.call_with_backoff(create_fn, **kwargs_create)
+        wr_id = response.headers.get('opc-work-request-id')
+        get_wr_response = oci_utils.call_with_backoff(client.get_work_request, work_request_id=wr_id)
+        result['work_request'] = to_dict(wait_on_work_request(client, get_wr_response, module))
+        _debug("Work request:{0}".format(result['work_request']))
+        result['changed'] = True
+        if wait_applicable and module.params.get('wait', None):
+            if states is None:
+                states = module.params.get('wait_until') or DEFAULT_READY_STATES
+            if resource_type == "cluster":
+                resource_affected = result['work_request']['resources'][0]
+                _debug("Affected resources:{0}".format(resource_affected))
+                resource = to_dict(wait_on_resource(client,
+                                                    module,
+                                                    get_fn,
+                                                    {get_param: resource_affected['identifier']},
+                                                    states
+                                                    ))
+                result[resource_type] = to_dict(resource)
+            elif resource_type == "node_pool":
+                for resource in result['work_request']['resources']:
+                    if resource['entity_type'] == "nodepool":
+                        node_pool_id = resource['identifier']
+                        break
+                node_pool = oci_utils.call_with_backoff(get_fn, **{get_param: node_pool_id}).data
+
+                total_worker_nodes = node_pool.quantity_per_subnet * len(node_pool.subnet_ids)
+
+                # Wait till all nodes start to get provisioned so that node_id of all the nodes becomes available.
+                wait_response = oci.wait_until(client,
+                                               get_fn(**{get_param: node_pool_id}),
+                                               evaluate_response=lambda r: r.data.nodes is not None and
+                                               len(r.data.nodes) == total_worker_nodes,
+                                               max_wait_seconds=module.params.get(
+                                                   'wait_timeout', MAX_WAIT_TIMEOUT_IN_SECONDS)
+                                               )
+
+                result[resource_type] = to_dict(wait_response.data)
+        return result
+
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)

--- a/samples/container_engine/deploy_app_on_k8s_cluster/README.md
+++ b/samples/container_engine/deploy_app_on_k8s_cluster/README.md
@@ -1,0 +1,31 @@
+# Overview
+
+This sample creates a cluster with Oracle Cloud Infrastructure Container Engine for
+Kubernetes(OKE) and deploys a sample app on the cluster. This sample is also
+documented in this [tutorial](http://www.oracle.com/webfolder/technetwork/tutorials/obe/oci/oke-full/index.html).
+
+This sample:
+- creates a configured VCN and related resources required for setting up an OKE cluster
+- creates a cluster
+- creates a node pool
+- downloads the kubeconfig file for the cluster
+- deploys a sample app on the cluster
+- verifies successful deployment
+
+# Pre-requisites
+This sample uses `k8s_raw` module which requires `openshift`. Please install `openshift` through:
+> pip install openshift
+
+This sample also requires [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to be
+installed and setup locally.
+
+# Instructions
+
+To run the sample, after ensuring that you have the pre-requisites for OCI 
+ansible cloud modules, please provide values (that are specific to your tenancy)
+for the following variables in the `vars` section of `sample.yaml`:
+- ad1: Name of the first availability domain.
+- ad2: Name of the second availability domain.
+- ad3: Name of the third availability domain.
+- cluster_compartment: OCID of the compartment in which you want to create OKE cluster.
+- kubeconfig_path: Path to download the kubeconfig for the created cluster.

--- a/samples/container_engine/deploy_app_on_k8s_cluster/hello.yaml
+++ b/samples/container_engine/deploy_app_on_k8s_cluster/hello.yaml
@@ -1,0 +1,40 @@
+---
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: hello-k8s-deployment
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: helloworld
+  replicas: 1 # deployment runs 1 pods matching the template
+  template: # create pods using pod definition in this template
+    metadata:
+      labels:
+        app: helloworld
+    spec:
+      containers:
+      - name: helloworld
+        image: karthequian/helloworld:latest
+        ports:
+        - containerPort: 80 #Endpoint is at port 80 in the container
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-k8s-service
+  namespace: default
+spec:
+  type: NodePort #Exposes the service as a node port
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: helloworld

--- a/samples/container_engine/deploy_app_on_k8s_cluster/sample.yaml
+++ b/samples/container_engine/deploy_app_on_k8s_cluster/sample.yaml
@@ -1,0 +1,163 @@
+---
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+# author: "Rohit Chaware (@rohitChaware)"
+
+- name: Create an OKE cluster and deploy a sample app
+  hosts: localhost
+  vars:
+    # common networking definitions
+    quad_zero_route: "0.0.0.0/0"
+    TCP_protocol: "6"
+    SSH_port: "22"
+
+    vcn_name: "mytestvcn"
+    vcn_cidr_block: "10.0.0.0/16"
+    vcn_dns_label: "mytestvcn"
+
+    ig_name: "myinternetgatewayformytestvcn"
+
+    # route all internet access to our Internet Gateway
+    route_table_rules:
+        - cidr_block: "{{ quad_zero_route }}"
+          network_entity_id: "{{ ig_id }}"
+
+    subnet1_cidr: "10.0.0.0/24"
+    subnet2_cidr: "10.0.1.0/24"
+    subnet3_cidr: "10.0.2.0/24"
+
+    subnet1_name: "mytestsubnet1"
+    subnet2_name: "mytestsubnet2"
+    subnet3_name: "mytestsubnet3"
+
+    lb_subnet1_cidr: "10.0.20.0/24"
+    lb_subnet2_cidr: "10.0.21.0/24"
+
+    lb_subnet1_name: "LB Subnet1"
+    lb_subnet2_name: "LB Subnet2"
+
+    cluster_name: "my_test_cluster"
+    node_pool_name: "my_node_pool"
+
+    deployment_yaml_path: "hello.yaml"
+    deployment_name: "hello-k8s-deployment"
+
+    OKE_ip_address1: "130.35.0.0/16"
+    OKE_ip_address2: "138.1.0.0/17"
+
+    #########################################
+    # Tenancy specific configuration
+    # *Note* - Override the following variables based on your tenancy
+    # or set a valid value for the corresponding environment variable     
+    #########################################
+    ad1: "{{ lookup('env', 'SAMPLE_AD1_NAME') }}"
+    ad2: "{{ lookup('env', 'SAMPLE_AD2_NAME') }}"
+    ad3: "{{ lookup('env', 'SAMPLE_AD3_NAME') }}"
+    cluster_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
+    kubeconfig_path: "{{ lookup('env', 'KUBECONFIG_PATH') }}"
+
+  tasks:
+    - import_tasks: setup.yaml
+
+    - name: Get Kubernetes version available for creating cluster
+      oci_cluster_options_facts:
+        cluster_option_id: all
+      register: result
+    - debug:
+        msg: "{{ result }}"
+    - set_fact:
+        k8s_version: "{{ result.cluster_options.kubernetes_versions[1] }}"
+
+    - name: Create an OKE cluster
+      oci_cluster:
+        compartment_id: "{{ cluster_compartment }}"
+        name: "{{ cluster_name }}"
+        vcn_id: "{{ vcn_id }}"
+        kubernetes_version: "{{ k8s_version }}"
+        options:
+          service_lb_subnet_ids:
+            - "{{ lb_subnet1_id }}"
+            - "{{ lb_subnet2_id }}"
+      register: result
+    - debug:
+        msg: "{{ result }}"
+    - set_fact:
+        cluster_id: "{{result.cluster.id }}"
+
+    - name: Get node shapes and images available for creating nodes in the cluster
+      oci_node_pool_options_facts:
+        id: "{{ cluster_id }}"
+      register: result
+    - debug:
+        msg: "{{ result }}"
+    - set_fact:
+        node_image_name: "{{ result.node_pool_options.images[0] }}"
+        node_shape: "{{ result.node_pool_options.shapes[2] }}"
+
+    - name: Create a node pool
+      oci_node_pool:
+        cluster_id: "{{ cluster_id }}"
+        compartment_id: "{{ cluster_compartment }}"
+        name: "{{ node_pool_name }}"
+        kubernetes_version: "{{ k8s_version }}"
+        node_image_name: "{{ node_image_name }}"
+        node_shape: "{{ node_shape }}"
+        quantity_per_subnet: 1
+        subnet_ids:
+          - "{{ ad1_subnet_id }}"
+          - "{{ ad2_subnet_id }}"
+          - "{{ ad3_subnet_id }}"
+      register: result
+    - debug:
+        msg: "{{ result }}"
+    - set_fact:
+        node_pool_id: "{{ result.node_pool.id }}"
+
+    - name: Download kubeconfig
+      oci_kubeconfig:
+        cluster_id: "{{ cluster_id }}"
+        dest: "{{ kubeconfig_path }}"
+        force: true
+
+    - command: kubectl cluster-info
+      environment:
+        KUBECONFIG: "{{ kubeconfig_path }}"
+      register: result
+    - debug:
+        msg: "{{ result }}"
+
+    - command: kubectl get nodes
+      environment:
+        KUBECONFIG: "{{ kubeconfig_path }}"
+      register: result
+    - debug:
+        msg: "{{ result }}"
+
+    - name: Create a deployment and a service on the created OKE cluster
+      k8s_raw:
+        kubeconfig: "{{ kubeconfig_path }}"
+        state: present
+        src: "{{ deployment_yaml_path }}"
+      register: result
+    - debug:
+        msg: "{{ result }}"
+
+    - name: Get the deployment to assert successful deployment
+      k8s_raw:
+        kubeconfig: "{{ kubeconfig_path }}"
+        namespace: default
+        kind: Deployment
+        name: "{{ deployment_name }}"
+      register: deployment
+    - debug:
+        msg: "{{ deployment }}"
+
+    - name: Assert that deployment is retrieved
+      assert:
+        that:
+          - deployment.result.metadata.name == deployment_name
+
+    - import_tasks: teardown.yaml

--- a/samples/container_engine/deploy_app_on_k8s_cluster/setup.yaml
+++ b/samples/container_engine/deploy_app_on_k8s_cluster/setup.yaml
@@ -1,0 +1,139 @@
+---
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+# author: "Rohit Chaware (@rohitChaware)"
+
+- name: Check pre-requisites
+  fail:
+    msg: "Environment variable {{item}} not set. Please declare an environment variable with an appropriate value for the sample to work."
+  when: item not in ansible_env
+  with_items:
+    - "SAMPLE_COMPARTMENT_OCID"
+    - "KUBECONFIG_PATH"
+    - "SAMPLE_AD1_NAME"
+    - "SAMPLE_AD2_NAME"
+    - "SAMPLE_AD3_NAME"
+
+- name: Create a VCN
+  oci_vcn:
+    compartment_id: "{{ cluster_compartment }}"
+    display_name: "{{ vcn_name }}"
+    cidr_block: "{{ vcn_cidr_block }}"
+    dns_label: "{{ vcn_dns_label }}"
+  register: vcnresult
+- debug:
+    msg: "{{ vcnresult }}"
+- set_fact:
+    vcn_id: "{{ vcnresult.vcn.id }}"
+
+- name : Create an internet gateway
+  oci_internet_gateway:
+    compartment_id: "{{ cluster_compartment }}"
+    vcn_id: "{{ vcn_id }}"
+    name: "{{ ig_name }}"
+    enabled: 'yes'
+    state: 'present'
+  register: result
+- debug:
+    msg: "{{ result }}"
+- set_fact:
+    ig_id: "{{ result.internet_gateway.id }}"
+
+- name: Update default route table of VCN to connect internet gateway to the VCN
+  oci_route_table:
+    id: "{{ vcnresult.vcn.default_route_table_id }}"
+    route_rules: "{{ route_table_rules }}"
+    purge_route_rules: 'no'
+  register: result
+- debug:
+    msg: "{{ result }}"
+- set_fact:
+    rt_id: "{{ result.route_table.id }}"
+
+- name: Create subnets for worker nodes in AD1, AD2 & AD3
+  oci_subnet:
+    availability_domain: "{{ item.ad }}"
+    cidr_block: "{{ item.cidr }}"
+    compartment_id: "{{ cluster_compartment }}"
+    display_name: "{{ item.subnet_name }}"
+    vcn_id: '{{ vcn_id }}'
+  loop:
+    - { ad: '{{ ad1 }}', cidr: '{{ subnet1_cidr }}', subnet_name: '{{ subnet1_name }}' }
+    - { ad: '{{ ad2 }}', cidr: '{{ subnet2_cidr }}', subnet_name: '{{ subnet2_name }}' }
+    - { ad: '{{ ad3 }}', cidr: '{{ subnet3_cidr }}', subnet_name: '{{ subnet3_name }}' }
+  register: result
+- debug:
+    msg: "{{ result }}"
+- set_fact:
+    ad1_subnet_id: "{{ result.results[0].subnet.id }}"
+    ad2_subnet_id: "{{ result.results[1].subnet.id }}"
+    ad3_subnet_id: "{{ result.results[2].subnet.id }}"
+
+# Use a jinja2 template of the ingress and egress security rules to generate a templated version of the final rules.
+- name: create ingress rules yaml body
+  template: src=./templates/ingress_security_rules.yaml.j2 dest=/tmp/ingress_security_rules.yaml
+
+- name: create egress yaml body
+  template: src=./templates/egress_security_rules.yaml.j2 dest=/tmp/egress_security_rules.yaml
+
+# Load the variables defined in the generated files
+- name: load the variables defined in the ingress rules yaml body
+  include_vars:
+    file: /tmp/ingress_security_rules.yaml
+    name: loaded_ingress
+- name: print loaded_ingress
+  debug:
+    msg: "loaded ingress is {{loaded_ingress}}"
+
+- name: load the variables defined in the egress rules yaml body
+  include_vars:
+    file: /tmp/egress_security_rules.yaml
+    name: loaded_egress
+- name: print loaded_egress
+  debug:
+    msg: "loaded egress is {{loaded_egress}}"
+
+- name: Update default security list to add additional rules
+  oci_security_list:
+    id: "{{ vcnresult.vcn.default_security_list_id }}"
+    ingress_security_rules: "{{ loaded_ingress.ingress_security_rules_for_default_sec_list }}"
+    egress_security_rules:  "{{ loaded_egress.egress_security_rules_for_default_sec_list }}"
+    purge_security_rules: 'no'
+  register: result
+- debug:
+    msg: "{{ result }}"
+
+- name: Create a security list for load balancers
+  oci_security_list:
+    name: "Load Balancers"
+    compartment_id: "{{ cluster_compartment }}"
+    vcn_id: "{{ vcn_id }}"
+    ingress_security_rules: "{{ loaded_ingress.ingress_security_rules_for_lb }}"
+    egress_security_rules: "{{ loaded_egress.egress_security_rules_for_lb }}"
+  register: result
+- debug:
+    msg: "{{ result }}"
+- set_fact:
+    lb_sec_list_id: "{{ result.security_list.id }}"
+
+- name: Create load balancer subnets in AD1 & AD2
+  oci_subnet:
+    name: "{{ item.name }}"
+    availability_domain: "{{ item.ad }}"
+    compartment_id: "{{ cluster_compartment }}"
+    cidr_block: "{{ item.cidr }}"
+    vcn_id: "{{ vcn_id }}"
+    security_list_ids:
+      - "{{ lb_sec_list_id }}"
+  loop:
+    - { name: '{{ lb_subnet1_name }}', ad: '{{ ad1 }}', cidr: '{{ lb_subnet1_cidr }}' }
+    - { name: '{{ lb_subnet2_name }}', ad: '{{ ad2 }}', cidr: '{{ lb_subnet2_cidr }}' }
+  register: result
+- debug:
+    msg: "{{ result }}"
+- set_fact:
+    lb_subnet1_id: "{{ result.results[0].subnet.id }}"
+    lb_subnet2_id: "{{ result.results[1].subnet.id }}"

--- a/samples/container_engine/deploy_app_on_k8s_cluster/teardown.yaml
+++ b/samples/container_engine/deploy_app_on_k8s_cluster/teardown.yaml
@@ -1,0 +1,48 @@
+---
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+# author: "Rohit Chaware (@rohitChaware)"
+
+- name: Delete node pool
+  oci_node_pool:
+    id: "{{ node_pool_id }}"
+    state: absent
+
+- name: Delete cluster
+  oci_cluster:
+    id: "{{ cluster_id }}"
+    state : absent
+
+- name: Delete subnets
+  oci_subnet:
+    id: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ ad1_subnet_id }}"
+    - "{{ ad2_subnet_id }}"
+    - "{{ ad3_subnet_id }}"
+    - "{{ lb_subnet1_id }}"
+    - "{{ lb_subnet2_id }}"
+
+- name: Delete the security list
+  oci_security_list:
+    id: "{{ lb_sec_list_id }}"
+    state: absent
+
+- name: Update default route table to drop reference to internet gateway
+  oci_route_table:
+    id: "{{ rt_id }}"
+    route_rules: []
+
+- name : Delete the Internet Gateway
+  oci_internet_gateway:
+    id: "{{ ig_id }}"
+    state: absent
+
+- name: Delete the VCN
+  oci_vcn:
+    vcn_id: "{{ vcn_id }}"
+    state: absent

--- a/samples/container_engine/deploy_app_on_k8s_cluster/templates/egress_security_rules.yaml.j2
+++ b/samples/container_engine/deploy_app_on_k8s_cluster/templates/egress_security_rules.yaml.j2
@@ -1,0 +1,18 @@
+egress_security_rules_for_default_sec_list:
+  # stateless egress rule for the first worker node subnet
+  - is_stateless: yes
+    destination: "{{ subnet1_cidr }}"
+    protocol: all
+  # stateless egress rule for the second worker node subnet
+  - is_stateless: yes
+    destination: "{{ subnet2_cidr }}"
+    protocol: all
+  # stateless egress rule for the third worker node subnet
+  - is_stateless: yes
+    destination: "{{ subnet3_cidr }}"
+    protocol: all
+egress_security_rules_for_lb:
+  - destination: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    is_stateless: yes
+

--- a/samples/container_engine/deploy_app_on_k8s_cluster/templates/ingress_security_rules.yaml.j2
+++ b/samples/container_engine/deploy_app_on_k8s_cluster/templates/ingress_security_rules.yaml.j2
@@ -1,0 +1,40 @@
+ingress_security_rules_for_default_sec_list:
+  # stateless ingress rule for the first worker node subnet
+  - source: "{{ subnet1_cidr }}"
+    protocol: all
+    is_stateless: yes
+  # stateless ingress rule for the second worker node subnet
+  - source: "{{ subnet2_cidr }}"
+    protocol: all
+    is_stateless: yes
+  # stateless ingress rule for the third worker node subnet
+  - source: "{{ subnet3_cidr }}"
+    protocol: all
+    is_stateless: yes
+  # stateful ingress rules to enable Container Engine for Kubernetes to access worker nodes via SSH
+  - source: "{{ OKE_ip_address1 }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ SSH_port }}
+        max: {{ SSH_port }}
+  - source: "{{ OKE_ip_address2 }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ SSH_port }}
+        max: {{ SSH_port }}
+  # stateful ingress rule to enable access to worker nodes on the default NodePort range
+  - source: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: 30000
+        max: 32767
+ingress_security_rules_for_lb:
+  - source: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    is_stateless: yes
+
+
+

--- a/samples/iam/iam-use-instance-principal-auth/README.md
+++ b/samples/iam/iam-use-instance-principal-auth/README.md
@@ -1,0 +1,22 @@
+# Overview
+
+This sample shows how you can authorize compute instances to call services in Oracle Cloud Infrastructure using "Instance Principals". This sample demonstrates how you can create the resources necessary for the Instance principals feature, and how you can get OCI Ansible Modules to use instance-principal based authentication when ansible playbooks are run inside an OCI compute instance.
+
+See [the feature announcement blog](https://blogs.oracle.com/cloud-infrastructure/announcing-instance-principals-for-identity-and-access-management) and [official OCI IAM documentation](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm) for a background on what instance principals are, and how they work.
+
+This sample automates the steps described in https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm?Highlight=instance%20principal#process to setup and use OCI compute instances as principals. 
+
+A dynamic group is created that matches all compute instances within the specified `sample_compartment_ocid`. An IAM policy is then created to ensure that all instances within this dynamic group is allowed to inspect all resources and get information about all compute instances within the specified `sample_compartment_ocid`. A new compute instance is then launched within `sample_compartment_ocid`. A script is provided, that when run within the new compute instance will use instance-principal based authentication to list all compute instances within `sample_compartment_ocid`. 
+
+Note: the playbook `list-compute-instances.yaml` doesn't have any explicit references to instance-principal based authentication (this ensures that the playbook need not be modified if you want to change the authentication type -- say if you want to run the playbook outside the compute instance). To ensure instance-principal based authentication is employed, in this case, ensure that the following environment variable is set before executing the playbook:
+> OCI_ANSIBLE_AUTH_TYPE="instance_principal" 
+
+If you want to author a playbook that is tied to, and only needs to use, instance-principal based authentication, you can use the `auth_type` module option and set it to `instance_principal` directly within the playbook.
+
+# Instructions
+
+To run the sample, after ensuring that you have the pre-requisites for OCI ansible cloud modules, please provide values (that are specific to your tenancy) for the following variables in the `vars` section of `sample.yaml`:
+- `sample_tenancy_ocid`
+- `sample_compartment_ocid`
+- `sample_image_ocid` (Provide an Oracle Linux image ocid)
+- `sample_ad_name`

--- a/samples/iam/iam-use-instance-principal-auth/instance-principal-test.sh
+++ b/samples/iam/iam-use-instance-principal-auth/instance-principal-test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+
+# This script runs an ansible-playbook using OCI ansible modules to list
+# all compute instances in the current compartment. It employs the instance
+# principal for authentication
+
+# This script assumes an Centos/RHEL/Oracle Linux instance
+
+# install pre-reqs (python, git, oci SDK, oci ansible modules)
+sudo yum install -y python-pip
+sudo yum install -y git
+sudo yum install -y jq
+
+sudo pip install virtualenv
+
+# setup a virtualenv
+virtualenv -p `which python` /tmp/mypyenv
+source /tmp/mypyenv/bin/activate
+python --version
+pip --version
+which python
+which pip
+
+# install oci SDK library
+pip install oci
+
+# install ansible
+pip install ansible
+
+ansible --version
+
+# get and install latest OCI ansible modules
+git clone https://github.com/oracle/oci-ansible-modules.git
+cd oci-ansible-modules
+python install.py
+
+# -- pre-requisites installation complete.
+
+# attempt to get a list of compute instances in the specfied compartment through an ansible playbook
+cd samples/iam/iam-use-instance-principal-auth
+
+# get the compartment id of the current instance using the instance metadata
+# endpoint https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/gettingmetadata.htm
+export SAMPLE_COMPARTMENT_OCID=$(curl -Ls http://169.254.169.254/opc/v1/instance | jq -r '.compartmentId')
+
+# Set the ansible auth_type to "instance_principal" to have the OCI ansible modules
+# use the instance principal associated with this instance, to interact with the
+# OCI APIs
+OCI_ANSIBLE_AUTH_TYPE="instance_principal" ansible-playbook list-compute-instances.yaml

--- a/samples/iam/iam-use-instance-principal-auth/list-compute-instances.yaml
+++ b/samples/iam/iam-use-instance-principal-auth/list-compute-instances.yaml
@@ -1,0 +1,19 @@
+---
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+- name : List all compute instances in Ansible compartment
+  connection: local
+  hosts: localhost
+  tasks:
+    - name: Create bucket
+      oci_instance_facts:
+        # pick the compartment_id from the environment variable SAMPLE_COMPARTMENT_OCID
+        compartment_id: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"         
+      register: currinstances
+    - debug:
+        msg: "{{currinstances}}"
+

--- a/samples/iam/iam-use-instance-principal-auth/sample.yaml
+++ b/samples/iam/iam-use-instance-principal-auth/sample.yaml
@@ -1,0 +1,63 @@
+---
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+- name: Show how instance_principal based authentication can be used while running ansible playbooks within an OCI compute instance
+  hosts: localhost
+  vars:
+    dynamic_group_name: "sample_dynamic_group"
+    policy_name: "sample_policy_using_dynamic_group"
+
+    # common networking definitions
+    quad_zero_route: "0.0.0.0/0"
+    TCP_protocol: "6"
+    HTTP_port: "80"
+    HTTPS_port: "443"
+    SSH_port: "22"
+
+    vcn_name: "mytestvcn"
+    vcn_cidr_block: "10.0.0.0/16"
+    vcn_dns_label: "mytestvcn"
+
+    ig_name: "myinternetgatewayformytestvcn"
+
+    route_table_name: "myroutetable"
+    # route all internet access to our Internet Gateway
+    route_table_rules:
+        - cidr_block: "{{ quad_zero_route }}"
+          network_entity_id: "{{ ig_id }}"
+
+
+    subnet_cidr: "10.0.0.48/28"
+    subnet_name: "mytestsubnet"
+    subnet_dns_label: "mytestsubnet"
+
+    securitylist_name: "mysecuritylist"
+
+    instance_shape: "VM.Standard1.1"
+    instance_hostname: "mytestinstanceprincipalauth"
+
+    #########################################
+    # Tenancy specific configuration
+    # *Note* - Override the following variables based on your tenancy
+    # or set a valid value for the corresponding environment variable
+    #########################################
+    sample_tenancy_ocid: "{{ lookup('env', 'SAMPLE_TENANCY_OCID') }}"
+    sample_compartment_ocid: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
+    sample_image_ocid: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
+    sample_ad_name: "{{ lookup('env', 'SAMPLE_AD_NAME') }}"
+
+  tasks:
+    - import_tasks: setup.yaml
+
+    - name: ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i {{ temp_certificates_path }}/private_key.pem opc@{{ instance_public_ip }}
+      debug: msg="The setup is complete, and an instance is running and can be connected to, with the command in this task's title above. To check if instance-principal based authentication is working, copy over the script, instance-principal-test.sh, to the provisioned instance, and execute the script in that instance"
+
+    # XXX automate the steps of running the script in the newly launched instance
+    # (after publishing a public release that contains this sample)
+
+    - import_tasks: teardown.yaml
+

--- a/samples/iam/iam-use-instance-principal-auth/setup.yaml
+++ b/samples/iam/iam-use-instance-principal-auth/setup.yaml
@@ -1,0 +1,206 @@
+---
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+- name: Check pre-requisites
+  fail:
+    msg: "Environment variable {{item}} not set. Please declare an environment variable with an appropriate value for the sample to work."
+  when: item not in ansible_env
+  with_items:
+    - "SAMPLE_TENANCY_OCID"
+    - "SAMPLE_COMPARTMENT_OCID"
+    - "SAMPLE_IMAGE_OCID"
+    - "SAMPLE_AD_NAME"
+
+# Create a Dynamic group. In this dynamic group we provide the matching rules to ensure that all instances under
+# compartment SAMPLE_COMPARTMENT_OCID are allowed to make API calls against OCI Services
+- name : Create a dynamic group for instances under SAMPLE_COMPARTMENT_OCID
+  oci_dynamic_group:
+    name: "{{ dynamic_group_name }}"
+    description: "A group that ensures that all instances in compartment {{ sample_compartment_ocid }} can make API calls against OCI Services"
+    matching_rule: "instance.compartment.id = '{{ sample_compartment_ocid }}'"
+    compartment_id: "{{ sample_tenancy_ocid }}"
+  register: result
+- debug:
+    msg: "{{ result }}"
+- set_fact:
+    dynamic_group_ocid: "{{ result.dynamic_group.id }}"
+
+- name: Create a policy granting to the created dynamic group to inspect all resources and read information about instances in SAMPLE_COMPARTMENT_OCID
+  oci_policy:
+    name: "{{ policy_name }}"
+    compartment_id: "{{ sample_compartment_ocid }}"
+    description: "Allow all specified by the dynamic group {{dynamic_group_name}} to access compute API in {{sample_compartment_ocid}}"
+    statements: ["Allow dynamic-group {{dynamic_group_name}} to inspect all-resources in compartment id {{sample_compartment_ocid}}",
+                 "Allow dynamic-group {{dynamic_group_name}} to read instances in compartment id {{sample_compartment_ocid}}"]
+  register: result
+- debug:
+    msg: "{{ result }}"
+- set_fact:
+    policy_ocid: "{{ result.policy.id }}"
+
+- name: Create a temporary directory to house a temporary SSH keypair we will later use to connect to instance
+  tempfile:
+    state: directory
+    suffix: cert
+  register: result
+- set_fact:
+    temp_certificates_path: "{{ result.path }}"
+- name: Generate a Private Key
+  openssl_privatekey:
+    path: "{{ temp_certificates_path }}/private_key.pem"
+    type: RSA
+    size: 2048
+- set_fact:
+    my_test_public_key: "{{ temp_certificates_path }}/public_key.pem"
+- name: Generate a Public Key
+  openssl_publickey:
+    path: "{{ my_test_public_key }}"
+    privatekey_path: "{{ temp_certificates_path }}/private_key.pem"
+    format: OpenSSH
+
+- name: Create a VCN
+  oci_vcn:
+    compartment_id: "{{ sample_compartment_ocid }}"
+    display_name: "{{ vcn_name }}"
+    cidr_block: "{{ vcn_cidr_block }}"
+    dns_label: "{{ vcn_dns_label }}"
+  register: result
+- set_fact:
+    vcn_id: "{{ result.vcn.id }}"
+
+- name : Create a new Internet Gateway
+  oci_internet_gateway:
+    compartment_id: "{{ sample_compartment_ocid }}"
+    vcn_id: "{{ vcn_id }}"
+    name: "{{ ig_name }}"
+    enabled: 'yes'
+    state: 'present'
+  register: result
+- set_fact:
+    ig_id: "{{ result.internet_gateway.id }}"
+
+- name: Create route table to connect internet gateway to the VCN
+  oci_route_table:
+    compartment_id: "{{ sample_compartment_ocid }}"
+    vcn_id: "{{ vcn_id }}"
+    name: "{{ route_table_name }}"
+    route_rules: "{{ route_table_rules }}"
+    state: 'present'
+  register: result
+- set_fact:
+    rt_id: "{{ result.route_table.id }}"
+
+# Create a security list for allowing access to public instance
+# Use a jinja2 template of the ingress and egress security rules to generate
+# a templated version of the final rules.
+- name: create ingress rules yaml body
+  template: src=./templates/ingress_security_rules.yaml.j2 dest=/tmp/instance_ingress_security_rules.yaml
+- name: create egress yaml body
+  template: src=./templates/egress_security_rules.yaml.j2 dest=/tmp/instance_egress_security_rules.yaml
+
+# Load the variables defined in the generated files
+- name: load the variables defined in the ingress rules yaml body
+  include_vars:
+    file: /tmp/instance_ingress_security_rules.yaml
+    name: loaded_ingress
+- name: print loaded_ingress
+  debug:
+    msg: "loaded ingress is {{loaded_ingress}}"
+- name: load the variables defined in the egress rules yaml body
+  include_vars:
+    file: /tmp/instance_egress_security_rules.yaml
+    name: loaded_egress
+- name: print loaded_egress
+  debug:
+    msg: "loaded egress is {{loaded_egress}}"
+
+- name: Create a security list for allowing access to public instance
+  oci_security_list:
+    name: "{{ securitylist_name }}"
+    compartment_id: "{{ sample_compartment_ocid }}"
+    vcn_id: '{{ vcn_id }}'
+    ingress_security_rules: "{{ loaded_ingress.instance_ingress_security_rules }}"
+    egress_security_rules:  "{{ loaded_egress.instance_egress_security_rules }}"
+  register: result
+- set_fact:
+    instance_security_list_ocid: "{{ result.security_list.id }}"
+
+- name: Create a subnet to host the public instance. Link security_list and route_table.
+  oci_subnet:
+    availability_domain: "{{ sample_ad_name }}"
+    cidr_block: "{{ subnet_cidr }}"
+    compartment_id: "{{ sample_compartment_ocid }}"
+    display_name: "{{ subnet_name }}"
+    prohibit_public_ip_on_vnic: false
+    route_table_id: "{{ rt_id }}"
+    security_list_ids: [ "{{ instance_security_list_ocid }}" ]
+    vcn_id: '{{ vcn_id }}'
+    dns_label: "{{ subnet_dns_label }}"
+  register: result
+- set_fact:
+    instance_subnet_id: "{{ result.subnet.id }}"
+
+- name: Launch a compute instance in {{sample_compartment_ocid}} to test instance_principal based authentication
+  oci_instance:
+    availability_domain: "{{ sample_ad_name }}"
+    compartment_id: "{{ sample_compartment_ocid }}"
+    name: "{{instance_hostname}}"
+    image_id: "{{ sample_image_ocid }}"
+    shape: "{{ instance_shape }}"
+    vnic:
+        assign_public_ip: True
+        hostname_label: "{{ instance_hostname }}"
+        subnet_id: "{{ instance_subnet_id }}"
+    metadata:
+        ssh_authorized_keys: "{{ lookup('file',  my_test_public_key ) }}"
+  register: result
+
+- name: Print instance details
+  debug:
+    msg: "Launched a new instance {{ result }}"
+- set_fact:
+    instance_id: "{{result.instance.id }}"
+
+- name: Get the VNIC attachment details of instance
+  oci_vnic_attachment_facts:
+    compartment_id: "{{ sample_compartment_ocid }}"
+    instance_id: "{{ instance_id }}"
+  register: result
+
+- name: Get details of the VNIC
+  oci_vnic_facts:
+    id: "{{ result.vnic_attachments[0].vnic_id }}"
+  register: result
+- set_fact:
+    instance_public_ip: "{{result.vnic.public_ip}}"
+
+- name: Print the public ip of the newly launched instance
+  debug:
+    msg: 'Public IP of launched instance {{ instance_public_ip }}. Connect to it using ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i {{ temp_certificates_path }}/private_key.pem opc@{{ instance_public_ip }}'
+
+- name: Wait (upto 5 minutes) for port 22 to become open
+  wait_for:
+    port: 22
+    host: '{{ instance_public_ip }}'
+    state: started
+    delay: 10
+  vars:
+    ansible_connection: local
+
+- name: Test a ssh connection to the newly launced instance
+  # Use "opc" user as this is an OEL image
+  # Disable SSH's strict host key checking just for this one command invocation
+  command: ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i {{ temp_certificates_path }}/private_key.pem opc@{{ instance_public_ip }} uname -a
+  retries: 3
+  delay: 5
+  register: result
+  until: result.rc == 0
+
+- name: Print SSH response from launched instance now that the instance is ready
+  debug:
+    msg: "SSH response from instance -> {{ result.stdout_lines }}"
+

--- a/samples/iam/iam-use-instance-principal-auth/teardown.yaml
+++ b/samples/iam/iam-use-instance-principal-auth/teardown.yaml
@@ -1,0 +1,46 @@
+---
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+- name: Terminate the instance
+  oci_instance:
+    id: "{{ instance_id }}"
+    state: absent
+
+- name: Delete the subnet
+  oci_subnet:
+    id: "{{ instance_subnet_id }}"
+    state: absent
+
+- name: Delete the security list
+  oci_security_list:
+    id: "{{ instance_security_list_ocid }}"
+    state: absent
+
+- name: Delete the route table 
+  oci_route_table:
+    id: "{{ rt_id }}"
+    state: absent
+
+- name : Delete the Internet Gateway
+  oci_internet_gateway:
+    id: "{{ ig_id }}"
+    state: absent
+
+- name: Delete the VCN
+  oci_vcn:
+    vcn_id: "{{ vcn_id }}"
+    state: absent
+
+- name: Delete the policy
+  oci_policy:
+    policy_id: "{{ policy_ocid }}"
+    state: absent
+
+- name: Delete the dynamic group
+  oci_dynamic_group:
+    dynamic_group_id: "{{ dynamic_group_ocid }}"
+    state: absent
+

--- a/samples/iam/iam-use-instance-principal-auth/templates/egress_security_rules.yaml.j2
+++ b/samples/iam/iam-use-instance-principal-auth/templates/egress_security_rules.yaml.j2
@@ -1,0 +1,15 @@
+instance_egress_security_rules:
+  # Allow access to HTTP(S) for cloud-init (yum, pip to work)
+  - destination: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTP_port }}
+        max: {{ HTTP_port }}
+  - destination: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTPS_port }}
+        max: {{ HTTPS_port }}
+

--- a/samples/iam/iam-use-instance-principal-auth/templates/ingress_security_rules.yaml.j2
+++ b/samples/iam/iam-use-instance-principal-auth/templates/ingress_security_rules.yaml.j2
@@ -1,0 +1,9 @@
+instance_ingress_security_rules:
+  # Allow incoming SSH connections
+  - source: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ SSH_port }}
+        max: {{ SSH_port }}
+

--- a/samples/solutions/secure-mongodb-deployment/check_secure_mongodb_deployment.yaml
+++ b/samples/solutions/secure-mongodb-deployment/check_secure_mongodb_deployment.yaml
@@ -33,3 +33,28 @@
       until: result['status']|default(0) == 200
     - assert:
         that: "1.0 == {{ result.json.MongoDB_ping_status.ok }}"
+
+    - name: Check whether the appserver is reachable and and mongodb is reachable through Load Balancer with HTTP
+      uri:
+         url: http://{{public_load_balancer_ip_address}}/test
+         body_format: json
+         timeout: 300
+      register: result
+      retries: 5
+      delay: 10
+      until: result['status']|default(0) == 200
+    - assert:
+        that: "1.0 == {{ result.json.MongoDB_ping_status.ok }}"
+
+    - name: Check whether the appserver is reachable and and mongodb is reachable through Load Balancer with HTTPS
+      uri:
+         url: https://{{public_load_balancer_ip_address}}/test
+         body_format: json
+         timeout: 300
+         validate_certs: false
+      register: result
+      retries: 5
+      delay: 10
+      until: result['status']|default(0) == 200
+    - assert:
+        that: "1.0 == {{ result.json.MongoDB_ping_status.ok }}"

--- a/samples/solutions/secure-mongodb-deployment/demo_teardown_using_inventory.yaml
+++ b/samples/solutions/secure-mongodb-deployment/demo_teardown_using_inventory.yaml
@@ -30,9 +30,22 @@
     with_items: "{{ instances }}"
     until: result.instances[0].lifecycle_state == "TERMINATED"
     when: instances is defined
-    retries: 5
+    retries: 10
     # 10 seconds delays between retries
     delay: 10
+  
+  - oci_load_balancer_facts:
+      compartment_id: "{{ demo_compartment_ocid }}"
+    register: result
+  - set_fact:
+      demo_load_balancer_id: "{{ item['id'] }}"
+    with_items: "{{ result.load_balancers }}"
+    when: item.display_name.find(demo_var_prefix) != -1
+
+  - oci_load_balancer:
+      load_balancer_id: "{{ demo_load_balancer_id }}"       
+      state: 'absent'
+    ignore_errors: yes
 
   - oci_vcn_facts:
       compartment_id: "{{ demo_compartment_ocid }}"

--- a/samples/solutions/secure-mongodb-deployment/host_vars/localhost
+++ b/samples/solutions/secure-mongodb-deployment/host_vars/localhost
@@ -9,7 +9,7 @@ infra_name: "mongodb-demo-setup-{{ random_suffix }}"
 
 # A prefix we add to all the display_names of demo artifacts that we
 # create in this demo
-demo_var_prefix: "demo-20171214-{{ random_suffix }}"
+demo_var_prefix: "secure-mongodb-{{ random_suffix }}"
 
 # networking common vars
 quad_zero_route: "0.0.0.0/0"
@@ -24,7 +24,8 @@ demo_vcn_cidr_block: "10.0.0.0/26"
 demo_public_subnet_ad1_cidr: "10.0.0.0/28"
 demo_private_subnet_mongo_ad1_cidr: "10.0.0.16/28"
 demo_private_subnet_mongo_ad2_cidr: "10.0.0.32/28"
-demo_bastion_ad1_cidr: "10.0.0.48/28"
-
+demo_lb_subnet_ad1_cidr: "10.0.0.56/30"
+demo_lb_subnet_ad2_cidr: "10.0.0.60/30"
+bastion_subnet_cidr_block: "10.0.0.48/29"
 # Compartment to use for the demo
 demo_compartment_ocid: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"

--- a/samples/solutions/secure-mongodb-deployment/roles/appserver/tasks/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/appserver/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Slurp cloud-init content from the template-applied result for AS1
   slurp: 
     src: "{{ role_path }}/files/appserver_bootstrap"
-  register: demo_appserver_1_cloud_init
+  register: demo_appserver_cloud_init
 
 - name: Launch AS1 in Public Subnet
   oci_instance:
@@ -25,10 +25,10 @@
         image_id: "{{ demo_appserver_image_ocid }}"
         shape: "{{ demo_appserver_shape }}"
         compartment_id: "{{ demo_compartment_ocid }}"
-        availability_domain: "{{ demo_appserver_availability_domain }}"
+        availability_domain: "{{ demo_appserver_availability_domain_ad1 }}"
         metadata:
             ssh_authorized_keys: "{{ lookup('file', demo_ssh_public_key)}}"
-            user_data: "{{ demo_appserver_1_cloud_init['content'] }}"
+            user_data: "{{ demo_appserver_cloud_init['content'] }}"
         vnic:
             hostname_label: "{{ demo_appserver_1_host_name }}"
             assign_pubic_ip: True
@@ -55,7 +55,46 @@
   register: result
 
 - set_fact:
-    appserver_public_ip: "{{ result.vnic.public_ip }}"
+    appserver_1_private_ip: "{{ result.vnic.private_ip }}"
+
+- name: Launch AS2 in Public Subnet
+  oci_instance:
+        name: "{{ demo_appserver_2_name }}"
+        image_id: "{{ demo_appserver_image_ocid }}"
+        shape: "{{ demo_appserver_shape }}"
+        compartment_id: "{{ demo_compartment_ocid }}"
+        availability_domain: "{{ demo_appserver_availability_domain_ad1 }}"
+        metadata:
+            ssh_authorized_keys: "{{ lookup('file', demo_ssh_public_key)}}"
+            user_data: "{{ demo_appserver_cloud_init['content'] }}"
+        vnic:
+            hostname_label: "{{ demo_appserver_2_host_name }}"
+            assign_pubic_ip: True
+            subnet_id: "{{ demo_public_subnet_ocid }}"
+        freeform_tags:
+            infra: "{{ infra_name }}"
+            type: appserver
+  register: demoas2
+- name: Set AS2 Instance OCID
+  set_fact: 
+    demo_appserver_2_ocid: "{{ demoas2.instance.id }}"
+    demo_appserver_2_dns_label: "{{ demo_appserver_2_host_name }}"
+- debug: msg="AS2 OCID {{ demo_appserver_2_ocid }}"
+
+- name: Get the VNIC attachment details of application server 2
+  oci_vnic_attachment_facts:
+    compartment_id: "{{ compartment_id }}"
+    instance_id: "{{ demo_appserver_2_ocid }}"
+  register: result
+
+- name: Get details of the VNIC
+  oci_vnic_facts:
+    id: "{{ result.vnic_attachments[0].vnic_id }}"
+  register: result
+
+- set_fact:
+    appserver_2_private_ip: "{{ result.vnic.private_ip }}"
+
 
 # Wait for sometime for the app server cloud init commands to complete.
 - pause:

--- a/samples/solutions/secure-mongodb-deployment/roles/appserver/tasks/templates/updated_public_subnet_egress_security_rules.yaml.j2
+++ b/samples/solutions/secure-mongodb-deployment/roles/appserver/tasks/templates/updated_public_subnet_egress_security_rules.yaml.j2
@@ -12,3 +12,18 @@ demo_public_subnet_egress_security_rules:
       destination_port_range:
         min: {{ MONGODB_port }}
         max: {{ MONGODB_port }}
+  # Allow HTTP and HTTPS traffic to internet. This is required for accessing 
+  # the application through Load Balancer.
+  - destination: "{{ demo_public_subnet_ad1_cidr }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTP_port }}
+        max: {{ HTTP_port }}
+
+  - destination: "{{ demo_public_subnet_ad1_cidr }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTPS_port }}
+        max: {{ HTTPS_port }}

--- a/samples/solutions/secure-mongodb-deployment/roles/appserver/vars/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/appserver/vars/main.yml
@@ -6,7 +6,9 @@
 # See LICENSE.TXT for details.
 
 demo_appserver_image_ocid: "{{ lookup('env', 'SAMPLE_OEL_IMAGE_OCID') }}"
-demo_appserver_availability_domain: "{{ lookup('env', 'SAMPLE_AD1_NAME') }}"
+demo_appserver_availability_domain_ad1: "{{ lookup('env', 'SAMPLE_AD1_NAME') }}"
 demo_appserver_1_name: "{{ demo_var_prefix }}_appserver_1"
+demo_appserver_2_name: "{{ demo_var_prefix }}_appserver_2"
 # no underscores in host names
 demo_appserver_1_host_name: "{{ demo_var_prefix }}-appserver-1"
+demo_appserver_2_host_name: "{{ demo_var_prefix }}-appserver-2"

--- a/samples/solutions/secure-mongodb-deployment/roles/bastion/tasks/create_bastion_server.yaml
+++ b/samples/solutions/secure-mongodb-deployment/roles/bastion/tasks/create_bastion_server.yaml
@@ -27,28 +27,3 @@
 - set_fact:
     bastion_instance_ocid: "{{ result.instance.id }}"
 
-# Generate the list of OCIDs corresponding to the various artifacts
-# created by this playbook and write to a file so that check_secure_mongodb_deployment.yaml
-# can use it to test the deployment.
-- copy:
-    content: |
-          compartment_id: "{{ compartment_id }}"
-          vcn_id: "{{ demo_vcn_ocid }}"
-          demo_ig_ocid: "{{ demo_ig_ocid }}"
-          demo_core_rt_ocid: "{{ demo_core_rt_ocid }}"
-          private_subnet_ad1_rt_id: "{{ private_subnet_ad1_rt_id }}"
-          private_subnet_ad2_rt_id: "{{ private_subnet_ad2_rt_id }}"
-          demo_appserver_1_ocid: "{{ demo_appserver_1_ocid }}"
-          demo_public_subnet_ocid: "{{ demo_public_subnet_ocid }}"
-          demo_public_subnet_seclist_ocid: "{{ demo_public_subnet_seclist_ocid }}"
-          private_sec_list_ad1_id: "{{ private_sec_list_ad1_id }}"
-          private_sec_list_ad2_id: "{{ private_sec_list_ad2_id }}"
-          private_subnet_ad1_id: "{{ private_subnet_ad1_id }}"
-          private_subnet_ad2_id: "{{ private_subnet_ad2_id }}"
-          mongodb1_id: "{{ mongodb1_id }}"
-          mongodb2_id: "{{ mongodb2_id }}"
-          bastion_security_list_ocid: "{{ bastion_security_list_ocid }}"
-          bastion_subnet_ocid: "{{ bastion_subnet_ocid }}"
-          bastion_instance_ocid: "{{ bastion_instance_ocid }}"
-          nat_instance_ocid: "{{ nat_instance_id }}"
-    dest: ./demo_artifacts_info.yaml

--- a/samples/solutions/secure-mongodb-deployment/roles/bastion/vars/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/bastion/vars/main.yml
@@ -5,7 +5,6 @@
 # Apache License v2.0
 # See LICENSE.TXT for details.
 
-bastion_subnet_cidr_block: "10.0.0.48/28"
 bastion_image_ocid: "{{ lookup('env', 'SAMPLE_OEL_IMAGE_OCID') }}"
 bastion_shape: "VM.Standard1.2"
 bastion_availability_domain: "{{ lookup('env', 'SAMPLE_AD1_NAME') }}"

--- a/samples/solutions/secure-mongodb-deployment/roles/common/tasks/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/common/tasks/main.yml
@@ -75,3 +75,40 @@
 
 - set_fact:
     demo_core_rt_ocid: "{{ democoreroutetable.route_table.id }}"
+
+# Use a jinja2 template of the ingress and egress security rules to generate
+# a templated version of the final rules.
+- name: create ingress rules yaml body
+  template: src=templates/demo_public_subnet_ingress_security_rules.yaml.j2 dest=/tmp/demo_public_subnet_ingress_security_rules.yaml
+- name: create egress yaml body
+  template: src=templates/demo_public_subnet_egress_security_rules.yaml.j2 dest=/tmp/demo_public_subnet_egress_security_rules.yaml
+
+# Load the variables defined in the generated files
+- name: load the variables defined in the ingress rules yaml body
+  include_vars:
+    file: /tmp/demo_public_subnet_ingress_security_rules.yaml
+    name: loaded_ingress
+- name: print loaded_ingress
+  debug:
+    msg: "loaded ingress is {{loaded_ingress}}"
+- name: load the variables defined in the egress rules yaml body
+  include_vars:
+    file: /tmp/demo_public_subnet_egress_security_rules.yaml
+    name: loaded_egress
+- name: print loaded_egress
+  debug:
+    msg: "loaded egress is {{loaded_egress}}"
+
+- name: Create Public Subnet's security list
+  oci_security_list:
+    name: "{{ demo_public_subnet_security_list_name }}"
+    compartment_id: "{{ demo_compartment_ocid }}"
+    vcn_id: "{{ demo_vcn_ocid }}"
+    ingress_security_rules: "{{ loaded_ingress.demo_public_subnet_ingress_security_rules }}"
+    egress_security_rules: "{{ loaded_egress.demo_public_subnet_egress_security_rules }}"
+    state: 'present'
+  register: demopublicsubnetseclist
+- set_fact:
+    demo_public_subnet_seclist_ocid: "{{ demopublicsubnetseclist.security_list.id}}"
+
+

--- a/samples/solutions/secure-mongodb-deployment/roles/common/tasks/templates/demo_public_subnet_egress_security_rules.yaml.j2
+++ b/samples/solutions/secure-mongodb-deployment/roles/common/tasks/templates/demo_public_subnet_egress_security_rules.yaml.j2
@@ -1,0 +1,28 @@
+demo_public_subnet_egress_security_rules:
+  # Allow app-servers to access MongoDB
+  - destination: "{{ demo_private_subnet_mongo_ad1_cidr }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ MONGODB_port }}
+        max: {{ MONGODB_port }}
+  - destination: "{{ demo_private_subnet_mongo_ad2_cidr }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ MONGODB_port }}
+        max: {{ MONGODB_port }}
+  # Allow access to HTTP(S) for cloud-init (yum, pip to work)
+  - destination: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTP_port }}
+        max: {{ HTTP_port }}
+  - destination: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTPS_port }}
+        max: {{ HTTPS_port }}
+

--- a/samples/solutions/secure-mongodb-deployment/roles/common/tasks/templates/demo_public_subnet_ingress_security_rules.yaml.j2
+++ b/samples/solutions/secure-mongodb-deployment/roles/common/tasks/templates/demo_public_subnet_ingress_security_rules.yaml.j2
@@ -1,0 +1,47 @@
+demo_public_subnet_ingress_security_rules:
+  - source: "{{ demo_private_subnet_mongo_ad1_cidr }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTP_port }}
+        max: {{ HTTP_port }}
+  - source: "{{ demo_private_subnet_mongo_ad1_cidr }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTPS_port }}
+        max: {{ HTTPS_port }}
+  - source: "{{ demo_private_subnet_mongo_ad2_cidr }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTP_port }}
+        max: {{ HTTP_port }}
+  - source: "{{ demo_private_subnet_mongo_ad1_cidr }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTPS_port }}
+        max: {{ HTTPS_port }}
+  # HTTP
+  - source: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTP_port }}
+        max: {{ HTTP_port }}
+  # SSL/TLS
+  - source: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ HTTPS_port }}
+        max: {{ HTTPS_port }}
+  # Enable SSH access from Bastion
+  - source: "{{ bastion_subnet_cidr_block }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ SSH_port }}
+        max: {{ SSH_port }}
+

--- a/samples/solutions/secure-mongodb-deployment/roles/load_balancer/tasks/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/load_balancer/tasks/main.yml
@@ -1,0 +1,245 @@
+---
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+# ===========================================================================================
+- name: Create a subnet in AD1
+  oci_subnet:
+    availability_domain: "{{ availability_domain_1 }}"
+    name: '{{ lb_subnet_ad1 }}'
+    dns_label: '{{ lb_dns_label_ad1 }}'
+    route_table_id: '{{ demo_core_rt_ocid }}'
+    security_list_ids: ['{{ demo_public_subnet_seclist_ocid }}']
+    cidr_block: "{{ demo_lb_subnet_ad1_cidr }}"
+    compartment_id: "{{ compartment_id }}"
+    vcn_id: '{{ demo_vcn_ocid }}'
+  register: result
+
+- set_fact:
+    sample_subnet_id_ad1: "{{ result.subnet.id }}"
+# ===========================================================================================
+- name: Create a subnet in AD2
+  oci_subnet:
+    availability_domain: "{{ availability_domain_2 }}"
+    name: '{{ lb_subnet_ad2 }}'
+    dns_label: '{{ lb_dns_label_ad2 }}'
+    route_table_id: '{{ demo_core_rt_ocid }}'
+    security_list_ids: ['{{ demo_public_subnet_seclist_ocid }}']
+    cidr_block: "{{ demo_lb_subnet_ad2_cidr }}"
+    compartment_id: "{{ compartment_id }}"
+    vcn_id: '{{ demo_vcn_ocid }}'
+  register: result
+
+- set_fact:
+    sample_subnet_id_ad2: "{{ result.subnet.id }}"
+# ===========================================================================================
+# A self-singed temporary certificate is used in this sample, so that the sample can be run without any dependencies,
+# and the certificate can be validated. In production environment, a valid certificate should be used.
+- name: create temporary directory for certificates
+  tempfile:
+    state: directory
+    suffix: cert
+  register: result
+
+- set_fact:
+    cert_path: "{{ result.path }}"
+# ===========================================================================================
+- name: Generate CA Cert Key
+  openssl_privatekey:
+    path: "{{cert_path}}/ca_key.pem"
+    type: RSA
+    size: 2048
+# ===========================================================================================
+- name: Generate CA cert
+  command: openssl req \
+        -x509 -new -days 365 \
+        -subj '/C=IN/ST=KA/L=Bangalore/O=Ansible/CN=www.ansible.oracle.com'
+        -key "{{cert_path}}/ca_key.pem" \
+        -out "{{cert_path}}/ca_cert.pem"
+  args:
+      creates: "{{cert_path}}/ca_cert.pem"
+# ===========================================================================================
+- name: Generate Server Private Key Without Passphrase
+  openssl_privatekey:
+      path: "{{cert_path}}/private_key.pem"
+      type: RSA
+      size: 2048
+# ===========================================================================================
+- name: Generate Certificate Signing Request With Normal Private Key
+  openssl_csr:
+    path: "{{cert_path}}/csr.pem"
+    privatekey_path: "{{cert_path}}/private_key.pem"
+    country_name: IN
+    organization_name: Ansible
+    state_or_province_name: KA
+    locality_name: Bangalore
+    common_name: www.ansible.oracle.com
+# ===========================================================================================
+- name: Generate CA signed Certificate Without Passphrase
+  command: openssl x509 -req \
+        -days 1825 -CA "{{cert_path}}/ca_cert.pem" -CAkey "{{cert_path}}/ca_key.pem" -CAcreateserial \
+        -in "{{cert_path}}/csr.pem" \
+        -out "{{cert_path}}/cert.pem"
+  args:
+    creates: "{{cert_path}}/cert.pem"
+# ===========================================================================================
+- name: Create Public Load Balancer
+  oci_load_balancer:
+      compartment_id: "{{ compartment_id }}"
+      name: "{{ lb_name }}"
+      shape_name: "{{ sample_shape }}"
+      #A public load balancer is regional in scope and requires two subnets, each
+      #in a separate availability domain. One subnet hosts the primary load balancer
+      #and the other hosts a standby load balancer to ensure accessibility even during
+      #an availability domain outage.
+      subnet_ids:
+        - "{{ sample_subnet_id_ad1 }}"
+        - "{{ sample_subnet_id_ad2 }}"
+      state: 'present'
+  register: result
+- debug:
+      msg: "Load balancer details: {{ result.load_balancer}}"
+- set_fact:
+      public_load_balancer_id: "{{ result.load_balancer.id }}"
+      public_load_balancer_ip_addresses: "{{ result.load_balancer.ip_addresses }}"
+#==========================================================================================
+- name: Create First Sample Backend Set
+  oci_load_balancer_backend_set:
+    load_balancer_id: "{{ public_load_balancer_id }}"
+    name: '{{ sample_first_backend_set_name }}'
+    policy: '{{ sample_first_backend_set_policy }}'
+    health_checker:
+        interval_in_millis: 30000
+        port: '{{ http_port }}'
+        protocol: "HTTP"
+        response_body_regex: ".*"
+        retries: 3
+        timeout_in_millis: 10000
+        return_code: 200
+        url_path: "/healthcheck"
+    state: 'present'
+#==========================================================================================
+- name: Create Second Sample Backend Set
+  oci_load_balancer_backend_set:
+    load_balancer_id: "{{ public_load_balancer_id }}"
+    name: '{{ sample_second_backend_set_name }}'
+    policy: '{{ sample_second_backend_set_policy }}'
+    health_checker:
+        interval_in_millis: 30000
+        port: '{{ http_port }}'
+        protocol: "HTTP"
+        response_body_regex: ".*"
+        retries: 3
+        timeout_in_millis: 10000
+        return_code: 200
+        url_path: "/healthcheck"
+    state: 'present'
+#==========================================================================================
+- name: Create Path Route For First Sample Backend Set
+  oci_load_balancer_path_route_set:
+    load_balancer_id: "{{ public_load_balancer_id }}"
+    name: "{{ http_path_route_set_name }}"
+    path_routes:
+          - backend_set_name: "{{ sample_first_backend_set_name }}"
+            path: "/http_host"
+            path_match_type:
+                 match_type: 'EXACT_MATCH'
+    state: 'present'
+#==========================================================================================
+- name: Create Path Route For Second Sample Backend Set
+  oci_load_balancer_path_route_set:
+    load_balancer_id: "{{ public_load_balancer_id }}"
+    name: "{{ https_path_route_set_name }}"
+    path_routes:
+          - backend_set_name: "{{ sample_second_backend_set_name }}"
+            path: "/https_host"
+            path_match_type:
+                 match_type: 'EXACT_MATCH'
+    state: 'present'
+#==========================================================================================
+- name: Create Certificate for Listener
+  oci_load_balancer_certificate:
+    load_balancer_id: "{{ public_load_balancer_id }}"
+    name: '{{ sample_certificate_name }}'
+    ca_certificate: '{{ sample_ca_certificate }}'
+    private_key: '{{ sample_private_key }}'
+    public_certificate: '{{ sample_public_certificate }}'
+    state: 'present'
+ #==========================================================================================
+- name: Create Listener for HTTP traffic
+  oci_load_balancer_listener:
+    load_balancer_id: "{{ public_load_balancer_id }}"
+    name: '{{ http_listener_name }}'
+    default_backend_set_name: '{{ sample_first_backend_set_name }}'
+    port: '{{ http_port }}'
+    protocol: "HTTP"
+    path_route_set_name: "{{ http_path_route_set_name }}"
+    connection_configuration:
+        idle_timeout: 300
+    state: 'present'
+#==========================================================================================
+- name: Create Listener for HTTPS traffic
+  oci_load_balancer_listener:
+    load_balancer_id: "{{ public_load_balancer_id }}"
+    name: '{{ https_listener_name }}'
+    default_backend_set_name: '{{ sample_second_backend_set_name }}'
+    port: '{{ https_port }}'
+    protocol: "HTTP"
+    path_route_set_name: "{{ https_path_route_set_name }}"
+    ssl_configuration:
+        certificate_name: '{{ sample_certificate_name }}'
+        verify_peer_certificate: False
+    state: 'present'
+#==========================================================================================
+- name: Create First Backend
+  oci_load_balancer_backend:
+    load_balancer_id: "{{ public_load_balancer_id }}"
+    backend_set_name: "{{ sample_first_backend_set_name }}"
+    ip_address: "{{ appserver_1_private_ip }}"
+    port: '{{ http_port }}'
+    backup: False
+    drain: False
+    offline: False
+    weight: 1
+    state: 'present'
+#==========================================================================================
+- name: Create Second Backend
+  oci_load_balancer_backend:
+    load_balancer_id: "{{ public_load_balancer_id }}"
+    backend_set_name: "{{ sample_second_backend_set_name }}"
+    ip_address: "{{ appserver_2_private_ip }}"
+    port: '{{ http_port }}'
+    backup: False
+    drain: False
+    offline: False
+    weight: 1
+    state: 'present'
+
+# Generate the list of OCIDs corresponding to the various artifacts
+# created by this playbook and write to a file so that check_secure_mongodb_deployment.yaml
+# can use it to test the deployment.
+- copy:
+    content: |
+          compartment_id: "{{ compartment_id }}"
+          vcn_id: "{{ demo_vcn_ocid }}"
+          demo_ig_ocid: "{{ demo_ig_ocid }}"
+          demo_core_rt_ocid: "{{ demo_core_rt_ocid }}"
+          private_subnet_ad1_rt_id: "{{ private_subnet_ad1_rt_id }}"
+          private_subnet_ad2_rt_id: "{{ private_subnet_ad2_rt_id }}"
+          demo_appserver_1_ocid: "{{ demo_appserver_1_ocid }}"
+          demo_public_subnet_ocid: "{{ demo_public_subnet_ocid }}"
+          demo_public_subnet_seclist_ocid: "{{ demo_public_subnet_seclist_ocid }}"
+          private_sec_list_ad1_id: "{{ private_sec_list_ad1_id }}"
+          private_sec_list_ad2_id: "{{ private_sec_list_ad2_id }}"
+          private_subnet_ad1_id: "{{ private_subnet_ad1_id }}"
+          private_subnet_ad2_id: "{{ private_subnet_ad2_id }}"
+          mongodb1_id: "{{ mongodb1_id }}"
+          mongodb2_id: "{{ mongodb2_id }}"
+          bastion_security_list_ocid: "{{ bastion_security_list_ocid }}"
+          bastion_subnet_ocid: "{{ bastion_subnet_ocid }}"
+          bastion_instance_ocid: "{{ bastion_instance_ocid }}"
+          nat_instance_ocid: "{{ nat_instance_id }}"
+          public_load_balancer_ip_address: "{{ public_load_balancer_ip_addresses[0].ip_address }}"
+    dest: ./demo_artifacts_info.yaml

--- a/samples/solutions/secure-mongodb-deployment/roles/load_balancer/vars/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/load_balancer/vars/main.yml
@@ -1,0 +1,40 @@
+---
+# Copyright (c) 2018, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+compartment_id: "{{ demo_compartment_ocid }}"
+
+availability_domain_1: "{{ lookup('env', 'SAMPLE_AD1_NAME') }}"
+availability_domain_2: "{{ lookup('env', 'SAMPLE_AD2_NAME') }}"
+
+lb_dns_label_ad1: 'lbdnsad1'
+lb_dns_label_ad2: 'lbdnsad2'
+
+lb_subnet_ad1: 'lb_subnet_ad1'
+lb_subnet_ad2: 'lb_subnet_ad2'
+demo_public_subnet_security_list_name: "{{ demo_var_prefix }}_public_subnet"
+
+lb_name: "{{ demo_var_prefix }}_load_balancer"
+sample_shape: "100Mbps"
+sample_first_backend_set_name: 'sample_first_backend_set'
+sample_first_backend_set_policy: 'ROUND_ROBIN'
+
+sample_second_backend_set_name: 'sample_second_backend_set'
+sample_second_backend_set_policy: 'IP_HASH'
+
+http_path_route_set_name: 'http_path_route_set'
+https_path_route_set_name: 'https_path_route_set'
+
+# Initialize values for certificates
+sample_ca_certificate: "{{cert_path}}/ca_cert.pem"
+sample_private_key: "{{cert_path}}/private_key.pem"
+sample_public_certificate: "{{cert_path}}/cert.pem"
+sample_certificate_name: "sample_certs"
+
+# Initialize values for listeners
+http_listener_name: 'http_listener1'
+https_listener_name: 'https_listener'
+http_port: 80
+https_port: 443

--- a/samples/solutions/secure-mongodb-deployment/roles/nat_instance/tasks/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/nat_instance/tasks/main.yml
@@ -5,41 +5,6 @@
 # Apache License v2.0
 # See LICENSE.TXT for details.
 
-# Use a jinja2 template of the ingress and egress security rules to generate
-# a templated version of the final rules.
-- name: create ingress rules yaml body
-  template: src=templates/demo_public_subnet_ingress_security_rules.yaml.j2 dest=/tmp/demo_public_subnet_ingress_security_rules.yaml
-- name: create egress yaml body
-  template: src=templates/demo_public_subnet_egress_security_rules.yaml.j2 dest=/tmp/demo_public_subnet_egress_security_rules.yaml
-
-# Load the variables defined in the generated files
-- name: load the variables defined in the ingress rules yaml body
-  include_vars:
-    file: /tmp/demo_public_subnet_ingress_security_rules.yaml
-    name: loaded_ingress
-- name: print loaded_ingress
-  debug:
-    msg: "loaded ingress is {{loaded_ingress}}"
-- name: load the variables defined in the egress rules yaml body
-  include_vars:
-    file: /tmp/demo_public_subnet_egress_security_rules.yaml
-    name: loaded_egress
-- name: print loaded_egress
-  debug:
-    msg: "loaded egress is {{loaded_egress}}"
-
-- name: Create Public Subnet's security list
-  oci_security_list:
-    name: "{{ demo_public_subnet_security_list_name }}"
-    compartment_id: "{{ demo_compartment_ocid }}"
-    vcn_id: "{{ demo_vcn_ocid }}"
-    ingress_security_rules: "{{ loaded_ingress.demo_public_subnet_ingress_security_rules }}"
-    egress_security_rules: "{{ loaded_egress.demo_public_subnet_egress_security_rules }}"
-    state: 'present'
-  register: demopublicsubnetseclist
-- set_fact:
-    demo_public_subnet_seclist_ocid: "{{ demopublicsubnetseclist.security_list.id}}"
-
 - debug:
     msg: "{{ lookup('env', 'SAMPLE_AD1_NAME') }}"
 

--- a/samples/solutions/secure-mongodb-deployment/sample.yaml
+++ b/samples/solutions/secure-mongodb-deployment/sample.yaml
@@ -16,6 +16,7 @@
       - { role: roles/mongo }
       - { role: roles/appserver }
       - { role: roles/bastion }
+      - { role: roles/load_balancer }
   tasks:
     - debug:
-        msg: "The appserver is available at http://{{ appserver_public_ip }}:80"
+        msg: "The appserver is available at http://{{ public_load_balancer_ip_addresses[0].ip_address }}:80 and https://{{ public_load_balancer_ip_addresses[0].ip_address }}:443"

--- a/test/units/test_oci_db_home_facts.py
+++ b/test/units/test_oci_db_home_facts.py
@@ -49,7 +49,8 @@ def setUpModule():
     oci_db_home_facts.set_logger(logging)
 
 def test_list_db_homes_list_all(db_client, list_all_resources_patch):
-    module = get_module(dict({'compartment_id': 'ocid1.compartment.aaaa','db_system_id': 'ocid1.dbsystem.aaaa'}))
+    module = get_module(dict({'compartment_id': 'ocid1.compartment.aaaa','db_system_id': 'ocid1.dbsystem.aaaa',
+                              'display_name': None}))
     list_all_resources_patch.return_value = get_db_homes()
     result = oci_db_home_facts.list_db_homes(db_client, module)
     assert len(result['db_homes']) is 2

--- a/test/units/test_oci_db_system_facts.py
+++ b/test/units/test_oci_db_system_facts.py
@@ -53,7 +53,7 @@ def setUpModule():
 
 
 def test_list_db_systems_list_all(db_client, list_all_resources_patch):
-    module = get_module(dict({'compartment_id': 'ocid1.compartment.aaaa'}))
+    module = get_module(dict({'compartment_id': 'ocid1.compartment.aaaa', 'display_name': None}))
     list_all_resources_patch.return_value = get_db_systems()
     result = oci_db_system_facts.list_db_systems(db_client, module)
     assert len(result['db_systems']) is 2

--- a/test/units/test_oci_db_system_shape_facts.py
+++ b/test/units/test_oci_db_system_shape_facts.py
@@ -50,7 +50,7 @@ def setUpModule():
 
 
 def test_list_db_system_shapes(db_client, list_all_resources_patch):
-    module = get_module(dict({'compartment_id': 'ocid1.compartment.aaaa', 'availability_domain': 'AD2'}))
+    module = get_module(dict({'compartment_id': 'ocid1.compartment.aaaa', 'availability_domain': 'AD2', 'name': None}))
     list_all_resources_patch.return_value = [get_db_system_shapes()]
     result = oci_db_system_shape_facts.list_db_system_shapes(db_client, module)
     assert result['db_system_shapes'][0]['name'] is get_db_system_shapes().name
@@ -58,7 +58,7 @@ def test_list_db_system_shapes(db_client, list_all_resources_patch):
 
 def test_list_db_system_shapes_service_error(db_client, list_all_resources_patch):
     error_message = 'Internal Server Error'
-    module = get_module(dict({'compartment_id': 'ocid1.compartment.aaaa', 'availability_domain': 'AD2'}))
+    module = get_module(dict({'compartment_id': 'ocid1.compartment.aaaa', 'availability_domain': 'AD2', 'name': None}))
     list_all_resources_patch.side_effect = ServiceError(
         499, 'InternalServerError', dict(), error_message)
     try:

--- a/test/units/test_oci_dhcp_options.py
+++ b/test/units/test_oci_dhcp_options.py
@@ -44,11 +44,6 @@ def oci_wait_until_patch(mocker):
 
 
 @pytest.fixture()
-def get_options_difference_patch(mocker):
-    return mocker.patch.object(oci_dhcp_options, 'get_options_difference')
-
-
-@pytest.fixture()
 def check_and_create_resource_patch(mocker):
     return mocker.patch.object(oci_utils, 'check_and_create_resource')
 
@@ -155,18 +150,17 @@ def test_update_dhcp_options_defined_tags_changed(virtual_network_client, update
     oci_dhcp_options.update_dhcp_options(virtual_network_client, dhcp_options, module)
     assert update_and_wait_patch.called
 
-def test_update_dhcp_options_options_changed(virtual_network_client, get_options_difference_patch, update_and_wait_patch):
+def test_update_dhcp_options_options_changed(virtual_network_client, update_and_wait_patch):
     dhcp_dns_options = get_options(
         'DomainNameServer', 'VcnLocalPlusInternet', [], None)
     dhcp_search_domain = get_options('SearchDomain', None, None, [
                                      'ansibletestvcn.oraclevcn.com'])
     options = [dhcp_dns_options, dhcp_search_domain]
     input_options = [{"custom_dns_servers": [], "server_type": "VcnLocalPlusInternet", "type": "DomainNameServer"},
-                     {"search_domain_names": ["ansibletestvcn.oraclevcn.com"], "type": "SearchDomain"}]
+                     {"search_domain_names": ["ansibletestvcn.oracle.com"], "type": "SearchDomain"}]
     module = get_module(dict(options=input_options, purge_dhcp_options=False))
     dhcp_options = get_dhcp_options('ansible_dhcp_options', options)
     update_and_wait_patch.return_value = dict({'dhcp_options': dhcp_options, 'changed': True})
-    get_options_difference_patch.return_value = None, True
     oci_dhcp_options.update_dhcp_options(virtual_network_client, dhcp_options, module)
     assert update_and_wait_patch.called
 
@@ -176,7 +170,7 @@ def test_get_options_difference_no_existing_dns():
         'DomainNameServer', 'VcnLocalPlusInternet', [], None)
     dhcp_search_domain = get_options('SearchDomain', None, None, [
                                      'ansibletestvcn.oraclevcn.com'])
-    result, changed = oci_dhcp_options.get_options_difference(
+    result, changed = oci_utils.get_component_list_difference(
         [dhcp_dns_options, dhcp_search_domain], [], True)
     assert changed is True
 
@@ -192,7 +186,7 @@ def test_update_dhcp_options_dns_changed_append():
     input_dhcp_search_domain = get_options('SearchDomain', None, None, [
         'ansibletestvcn.oraclevcn.com'])
     input_options = [input_dhcp_dns_options, input_dhcp_search_domain]
-    result, changed = oci_dhcp_options.get_options_difference(
+    result, changed = oci_utils.get_component_list_difference(
         input_options, existing_options, False)
     assert changed is True
     assert len(result) is 3
@@ -209,7 +203,7 @@ def test_update_dhcp_options_searchdomain_changed_append():
     input_dhcp_search_domain = get_options('SearchDomain', None, None, [
         'ansiblevcn.oraclevcn.com'])
     input_options = [input_dhcp_dns_options, input_dhcp_search_domain]
-    result, changed = oci_dhcp_options.get_options_difference(
+    result, changed = oci_utils.get_component_list_difference(
         input_options, existing_options, False)
     assert changed is True
     assert len(result) is 3
@@ -226,7 +220,7 @@ def test_update_dhcp_options_dns_changed_purged():
     input_dhcp_search_domain = get_options('SearchDomain', None, None, [
         'ansibletestvcn.oraclevcn.com'])
     input_options = [input_dhcp_dns_options, input_dhcp_search_domain]
-    result, changed = oci_dhcp_options.get_options_difference(
+    result, changed = oci_utils.get_component_list_difference(
         input_options, existing_options, False)
     assert changed is True
     for option in result:
@@ -245,7 +239,7 @@ def test_update_dhcp_options_searchdomain_changed_purged():
     input_dhcp_search_domain = get_options('SearchDomain', None, None, [
         'ansiblevcn.oraclevcn.com'])
     input_options = [input_dhcp_dns_options, input_dhcp_search_domain]
-    result, changed = oci_dhcp_options.get_options_difference(
+    result, changed = oci_utils.get_component_list_difference(
         input_options, existing_options, True)
     assert changed is True
     for option in result:

--- a/test/units/test_oci_dhcp_options_facts.py
+++ b/test/units/test_oci_dhcp_options_facts.py
@@ -96,7 +96,8 @@ def get_response(status, header, data, request):
 def get_module():
     params = {'compartment_id': 'ocid1.comp..axsd',
               'vcn_id': 'ocid1.vcn..fxdv',
-              'dhcp_id': None}
+              'dhcp_id': None,
+              'display_name': None}
     module = FakeModule(**params)
     return module
 

--- a/test/units/test_oci_group_facts.py
+++ b/test/units/test_oci_group_facts.py
@@ -60,7 +60,7 @@ def test_list_user_groups_failure_service_error(identity_client, list_all_resour
         499, 'InternalError', dict(), error_message)
     try:
         oci_group_facts.list_user_groups(
-            identity_client, get_module(dict()))
+            identity_client, get_module(dict({'name': None})))
     except Exception as ex:
         assert error_message in ex.args[0]
 
@@ -71,7 +71,7 @@ def test_list_user_groups_failure_timeout_error(identity_client, list_all_resour
         400, 'TimeOutError', dict(), error_message)
     try:
         oci_group_facts.list_user_groups(
-            identity_client, get_module(dict()))
+            identity_client, get_module(dict({'name': None})))
     except Exception as ex:
         assert error_message in ex.args[0]
 

--- a/test/units/test_oci_instance.py
+++ b/test/units/test_oci_instance.py
@@ -57,6 +57,7 @@ def get_module():
               'availability_domain': 'BnQb:PHX-AD-1',
               'compartment_id': 'ocid1.compartment.oc1.....vm62xq',
               'image_id': 'ocid1.image.oc1.phx....sa7klnoa',
+              'fault_domain': 'FAULT-DOMAIN-1',
               'shape': 'BM.Standard1.36',
               'metadata': {'foo': 'bar'},
               'extended_metadata': {'baz': 'quux'},

--- a/test/units/test_oci_internet_gateway_facts.py
+++ b/test/units/test_oci_internet_gateway_facts.py
@@ -95,7 +95,8 @@ def get_response(status, header, data, request):
 def get_module():
     params = {'compartment_id': 'ocid1.comp..axsd',
               'vcn_id': 'ocid1.vcn..fxdv',
-              'ig_id': ''}
+              'ig_id': '',
+              'display_name': None}
     module = FakeModule(**params)
     return module
 
@@ -103,6 +104,7 @@ def get_module():
 def get_module_with_ig_id():
     params = {'compartment_id': '',
               'vcn_id': '',
-              'ig_id': 'ocid1.internetgateway..fxdv'}
+              'ig_id': 'ocid1.internetgateway..fxdv',
+              'display_name': None}
     module = FakeModule(**params)
     return module

--- a/test/units/test_oci_load_balancer_policy_facts.py
+++ b/test/units/test_oci_load_balancer_policy_facts.py
@@ -83,7 +83,7 @@ def get_response(status, header, data, request):
 
 
 def get_module():
-    params = {'compartment_id': 'ocid1.compartment.xcds'}
+    params = {'compartment_id': 'ocid1.compartment.xcds', 'name': None}
     module = FakeModule(**params)
     return module
 

--- a/test/units/test_oci_load_balancer_protocol_facts.py
+++ b/test/units/test_oci_load_balancer_protocol_facts.py
@@ -83,7 +83,7 @@ def get_response(status, header, data, request):
 
 
 def get_module():
-    params = {'compartment_id': 'ocid1.compartment.xcds'}
+    params = {'compartment_id': 'ocid1.compartment.xcds', 'name': None}
     module = FakeModule(**params)
     return module
 

--- a/test/units/test_oci_route_table_facts.py
+++ b/test/units/test_oci_route_table_facts.py
@@ -102,7 +102,8 @@ def get_response(status, header, data, request):
 def get_module():
     params = {'compartment_id': 'ocid1.comp..axsd',
               'vcn_id': 'ocid1.vcn..fxdv',
-              'rt_id': ''}
+              'rt_id': '',
+              'display_name': None}
     module = FakeModule(**params)
     return module
 
@@ -110,6 +111,7 @@ def get_module():
 def get_module_with_ig_id():
     params = {'compartment_id': '',
               'vcn_id': '',
-              'rt_id': 'ocid1.internetgateway..fxdv'}
+              'rt_id': 'ocid1.internetgateway..fxdv',
+              'display_name': None}
     module = FakeModule(**params)
     return module

--- a/test/units/test_oci_security_list.py
+++ b/test/units/test_oci_security_list.py
@@ -51,11 +51,6 @@ def get_security_rules_patch(mocker):
 
 
 @pytest.fixture()
-def get_security_rules_difference_patch(mocker):
-    return mocker.patch.object(oci_security_list, 'get_security_rules_difference')
-
-
-@pytest.fixture()
 def create_security_list_patch(mocker):
     return mocker.patch.object(oci_security_list, 'create_security_list')
 
@@ -69,17 +64,21 @@ def update_security_list_patch(mocker):
 def check_and_create_resource_patch(mocker):
     return mocker.patch.object(oci_utils, 'check_and_create_resource')
 
+
 @pytest.fixture()
 def get_existing_resource_patch(mocker):
     return mocker.patch.object(oci_utils, 'get_existing_resource')
+
 
 @pytest.fixture()
 def create_and_wait_patch(mocker):
     return mocker.patch.object(oci_utils, 'create_and_wait')
 
+
 @pytest.fixture()
 def update_and_wait_patch(mocker):
     return mocker.patch.object(oci_utils, 'update_and_wait')
+
 
 @pytest.fixture()
 def delete_and_wait_patch(mocker):
@@ -161,6 +160,7 @@ def test_update_security_list_no_security_list_for_update(virtual_network_client
     except Exception as ex:
         assert error_message in str(ex.args)
 
+
 def test_update_security_list_name_changed(virtual_network_client, update_and_wait_patch):
     module = get_module(dict({'egress_security_rules': None,
                               'ingress_security_rules': None, 'purge_security_rules': True}))
@@ -170,6 +170,7 @@ def test_update_security_list_name_changed(virtual_network_client, update_and_wa
 
     assert result['changed'] is True
 
+
 def test_update_security_list_freeform_tags_changed(virtual_network_client, update_and_wait_patch):
     module = get_module(dict(freeform_tags=dict(security_level='strict')))
     security_list = get_security_list(None, None, 'ansible_security_list')
@@ -177,6 +178,7 @@ def test_update_security_list_freeform_tags_changed(virtual_network_client, upda
     result = oci_security_list.update_security_list(virtual_network_client, security_list, module)
 
     assert result['changed'] is True
+
 
 def test_update_security_list_defined_tags_changed(virtual_network_client, update_and_wait_patch):
     module = get_module(dict(defined_tags=dict(department=dict(department_type='commericial'))))
@@ -186,15 +188,15 @@ def test_update_security_list_defined_tags_changed(virtual_network_client, updat
 
     assert result['changed'] is True
 
+
 def test_get_security_rules_difference_ingress_tcp_options_append():
     input_ingress_rules = get_security_rules(
         'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False,  None, None, None, '3', '4')
 
     existing_ingress_rules = get_security_rules(
-        'ingress', None, '10.0.0.0/8', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
+        'ingress', 'hashed', '10.0.0.0/8', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_ingress_rules, input_ingress_rules, 'ingress_security_rules', False)
+    result, changed = oci_utils.get_component_list_difference(input_ingress_rules, existing_ingress_rules, False)
 
     assert changed is True
     assert result[0].source == '10.0.0.0/0'
@@ -205,10 +207,9 @@ def test_get_security_rules_difference_ingress_udp_options_append():
         'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/12',  False, None, None, None, '3', '4')
 
     existing_ingress_rules = get_security_rules(
-        'ingress', None, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
+        'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_ingress_rules, input_ingress_rules, 'ingress_security_rules', False)
+    result, changed = oci_utils.get_component_list_difference(input_ingress_rules, existing_ingress_rules, False)
 
     assert changed is True
     assert result[0].source == '10.0.0.0/12'
@@ -219,10 +220,10 @@ def test_get_security_rules_difference_ingress_icmp_options_append():
         'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16',  False, None, None, None, '3', '4')
 
     existing_ingress_rules = get_security_rules(
-        'ingress', None, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', None)
+        'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', None)
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_ingress_rules, input_ingress_rules, 'ingress_security_rules', False)
+    result, changed = oci_utils.get_component_list_difference(
+        existing_ingress_rules, input_ingress_rules, False)
 
     assert changed is True
     assert result[0].source == '0.0.0.0/0'
@@ -233,10 +234,9 @@ def test_get_security_rules_difference_ingress_tcp_options_purge():
         'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
 
     existing_ingress_rules = get_security_rules(
-        'ingress', None, '10.0.0.0/8', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
+        'ingress', 'hashed', '10.0.0.0/8', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_ingress_rules, input_ingress_rules, 'ingress_security_rules', True)
+    result, changed = oci_utils.get_component_list_difference(input_ingress_rules,  existing_ingress_rules, True)
 
     assert changed is True
     assert len(result) is 3
@@ -247,10 +247,10 @@ def test_get_security_rules_difference_ingress_udp_options_purge():
         'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/12', False, None, None, None, '3', '4')
 
     existing_ingress_rules = get_security_rules(
-        'ingress', None, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
+        'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_ingress_rules, input_ingress_rules, 'ingress_security_rules', True)
+    result, changed = oci_utils.get_component_list_difference(
+        existing_ingress_rules, input_ingress_rules, True)
 
     assert changed is True
     assert len(result) is 3
@@ -261,10 +261,10 @@ def test_get_security_rules_difference_ingress_icmp_options_purge():
         'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
 
     existing_ingress_rules = get_security_rules(
-        'ingress', None, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', None)
+        'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', None)
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_ingress_rules, input_ingress_rules, 'ingress_security_rules', True)
+    result, changed = oci_utils.get_component_list_difference(
+        existing_ingress_rules, input_ingress_rules, True)
 
     assert changed is True
     assert len(result) is 3
@@ -275,10 +275,9 @@ def test_get_security_rules_difference_egress_tcp_options_append():
         'egress', 'hashed', None, None, None, False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
 
     existing_egress_rules = get_security_rules(
-        'egress', None, None,  None, None,  False, '10.0.0.0/8', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
+        'egress', 'hashed', None,  None, None,  False, '10.0.0.0/8', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_egress_rules, input_egress_rules, 'egress_security_rules', False)
+    result, changed = oci_utils.get_component_list_difference(input_egress_rules, existing_egress_rules, False)
     assert changed is True
     assert result[0].destination == '10.0.0.0/0'
 
@@ -288,10 +287,9 @@ def test_get_security_rules_difference_egress_udp_options_append():
         'egress', 'hashed', None, None, None, False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
 
     existing_egress_rules = get_security_rules(
-        'egress', None, None,  None, None,  False, '10.0.0.0/0', '10.0.0.0/0', '10.0.0.0/16', '3', '4')
+        'egress', 'hashed', None,  None, None,  False, '10.0.0.0/0', '10.0.0.0/0', '10.0.0.0/16', '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_egress_rules, input_egress_rules, 'egress_security_rules', False)
+    result, changed = oci_utils.get_component_list_difference(input_egress_rules, existing_egress_rules, False)
     assert changed is True
     assert result[0].destination == '0.0.0.0/0'
 
@@ -301,10 +299,9 @@ def test_get_security_rules_difference_egress_icmp_options_append():
         'egress', 'hashed', None, None, None, False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
 
     existing_egress_rules = get_security_rules(
-        'egress', None, None,  None, None,  False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', None)
+        'egress', 'hashed', None,  None, None,  False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', None)
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_egress_rules, input_egress_rules, 'egress_security_rules', False)
+    result, changed = oci_utils.get_component_list_difference(input_egress_rules, existing_egress_rules, False)
     assert changed is True
     assert result[0].destination == '10.0.0.0/16'
 
@@ -314,10 +311,9 @@ def test_get_security_rules_difference_egress_state_changed():
         'egress', 'hashed', None, None, None, True, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
 
     existing_egress_rules = get_security_rules(
-        'egress', None, None,  None, None,  False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
+        'egress', 'hashed', None,  None, None,  False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_egress_rules, input_egress_rules, 'egress_security_rules', False)
+    result, changed = oci_utils.get_component_list_difference(input_egress_rules, existing_egress_rules, False)
     assert changed is True
     assert len(result) is 6
 
@@ -327,10 +323,9 @@ def test_get_security_rules_difference_egress_tcp_options_purge():
         'egress', 'hashed', None, None, None, False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
 
     existing_egress_rules = get_security_rules(
-        'egress', None, None,  None, None,  False, '10.0.0.0/8', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
+        'egress', 'hashed', None,  None, None,  False, '10.0.0.0/8', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_egress_rules, input_egress_rules, 'egress_security_rules', True)
+    result, changed = oci_utils.get_component_list_difference(input_egress_rules, existing_egress_rules, True)
     assert changed is True
     assert len(result) is 3
 
@@ -340,10 +335,9 @@ def test_get_security_rules_difference_egress_udp_options_purge():
         'egress', 'hashed', None, None, None, False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
 
     existing_egress_rules = get_security_rules(
-        'egress', None, None,  None, None,  False, '10.0.0.0/0', '10.0.0.0/0', '10.0.0.0/16', '3', '4')
+        'egress', 'hashed', None,  None, None,  False, '10.0.0.0/0', '10.0.0.0/0', '10.0.0.0/16', '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_egress_rules, input_egress_rules, 'egress_security_rules', True)
+    result, changed = oci_utils.get_component_list_difference(input_egress_rules, existing_egress_rules, True)
     assert changed is True
     assert len(result) is 3
 
@@ -353,10 +347,9 @@ def test_get_security_rules_difference_egress_icmp_options_purge():
         'egress', 'hashed', None, None, None, False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', '4')
 
     existing_egress_rules = get_security_rules(
-        'egress', None, None,  None, None,  False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', None)
+        'egress', 'hashed', None,  None, None,  False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', None)
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_egress_rules, input_egress_rules, 'egress_security_rules', True)
+    result, changed = oci_utils.get_component_list_difference(input_egress_rules, existing_egress_rules, True)
     assert changed is True
     assert len(result) is 3
 
@@ -365,32 +358,29 @@ def test_get_security_rules_difference_no_existing_rule():
     input_ingress_rules = get_security_rules(
         'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        None, input_ingress_rules, 'ingress_security_rules', True)
+    result, changed = oci_utils.get_component_list_difference(
+        input_ingress_rules, None, True)
 
     assert changed is True
     assert len(result) is 3
 
 
+
 def test_get_final_security_rules_empty_input_security_rule():
     existing_egress_rules = get_security_rules(
-        'egress', None, None,  None, None,  False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', None)
+        'egress', 'hashed', None,  None, None,  False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', None)
 
-    result, changed = oci_security_list.\
-        get_final_security_rules(None, existing_egress_rules,
-                                 'egress_security_rules', False)
+    result, changed = oci_utils.check_and_return_component_list_difference(None, existing_egress_rules, False)
     assert changed is True
     assert not result
 
 
-def test_get_final_security_rules_rule_changed(get_security_rules_patch, get_security_rules_difference_patch):
-    final_security_rules = get_security_rules(
-        'egress', None, None,  None, None,  False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', None)
 
-    get_security_rules_difference_patch.return_value = final_security_rules, True
-    result, changed = oci_security_list.\
-        get_final_security_rules(final_security_rules, final_security_rules,
-                                 'egress_security_rules', False)
+def test_get_final_security_rules_rule_changed(get_security_rules_patch):
+    final_security_rules = get_security_rules(
+        'egress', 'hashed', None,  None, None,  False, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', '3', None)
+
+    result, changed = oci_utils.check_and_return_component_list_difference(final_security_rules, None, False)
     assert changed is True
     assert len(result) is 3
 
@@ -408,10 +398,10 @@ def test_get_security_rules_difference_ingress_same_rules_state_unchanged():
         'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False,  None, None, None, '3', '4')
 
     existing_ingress_rules = get_security_rules(
-        'ingress', None, '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
+        'ingress', 'hashed', '10.0.0.0/0', '0.0.0.0/0', '10.0.0.0/16', False, None, None, None, '3', '4')
 
-    result, changed = oci_security_list.get_security_rules_difference(
-        existing_ingress_rules, input_ingress_rules, 'ingress_security_rules', False)
+    result, changed = oci_utils.get_component_list_difference(
+        existing_ingress_rules, input_ingress_rules, False)
 
     assert changed is False
 


### PR DESCRIPTION
## Added
- Support for following services:
  - [Oracle Container Engine for Kubernetes Service (OKE)](https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm)
  - [Oracle Domain Name System (DNS) Service](https://docs.cloud.oracle.com/iaas/Content/DNS/Concepts/dnszonemanagement.htm)
- Modules to manage [IAM dynamic groups](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingdynamicgroups.htm?tocpath=Services|IAM|_____12)
- Support for [instance principal authorization](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm)
- Support wait options in load balancer service modules
- Support filtering of resources in facts modules using `display_name` or `name`
- Support to automatically redirect IAM operations to home region of tenancy
- Support for [Fault Domains](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/regions.htm#fault)
- Added samples to demonstrate:
  - the use of instance principal authorization
  - setting up prerequisites for OKE, provisioning OKE cluster and deploying a sample application
  - provisioning of a load balancer component in the Secure MongoDB deployment solution

## Changed
- Minimum supported OCI Python SDK to 2.0.2

Co-authored-by: Rohit Chaware <rohit.chaware@oracle.com>
Co-authored-by: Debayan Gupta <debayan.gupta@oracle.com>