### PR TITLE
Add 'documentation-table' class to override theme

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -14,3 +14,22 @@
 .wy-nav-content {
    max-width: 1400px !important;
 }
+
+/* documentation-table is used by tables in the generated module documentation. */
+.documentation-table td.elbow-placeholder {
+    border-left: 1px solid #000;
+    border-top: 0px;
+    width: 30px;
+    min-width: 30px;
+}
+
+.documentation-table th, .documentation-table td {
+    padding: 4px;
+    border-left: 1px solid #000;
+    border-top: 1px solid #000;
+}
+
+.documentation-table {
+    border-right: 1px solid #000;
+    border-bottom: 1px solid #000;
+}


### PR DESCRIPTION
Tables generated in module documentation look for style class named 'documentation-table' for
table properties.

Fixes: #2 