### PR TITLE
New release v1.5.0 of OCI Ansible Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2019-01-28
+
+### Added
+- Modules to manage
+    - [FastConnect](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnectoverview.htm) resources
+- Added the following features in existing modules:
+    - [Pre-Authenticated Requests](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/usingpreauthenticatedrequests.htm) in Object Storage Service.
+    - `force` option in `oci_bucket` now also supports automatic deletion of bucket-level PARs
+    - Support for listing multi-part uploads and multi-part upload parts, aborting a multi-part upload in `oci_object_facts` and `oci_object` modules
+    - In modules having a module option that supports a list of items, a `delete_*` option is now supported to delete specified list items. See `delete_security_rules` in `oci_security_list` for an example
+    - Options in `oci_tag` module to apply tags
+    - Option to filter by `display_name` in `oci_instance_configuration_facts` module
+- Added the following features in OCI dynamic inventory script:
+    - Option to build inventory from multiple regions
+
+### Changed
+- Minimum supported OCI Python SDK to `2.1.3`
+
 ## [1.4.0] - 2018-12-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Oracle Cloud Infrastructure Ansible Modules provide an easy way to create and pr
 - Object Storage
 - File Storage
 - Email Delivery
+- Search
 
 The OCI Ansible modules are built using the [Oracle Cloud Infrastructure Python SDK](https://docs.us-phoenix-1.oraclecloud.com/Content/API/SDKDocs/pythonsdk.htm). The OCI Ansible modules honour the [SDK configuration](https://docs.us-phoenix-1.oraclecloud.com/Content/ToolsConfig.htm) when available.
 
@@ -69,7 +70,7 @@ You can find information on any known issues with OCI [here](https://docs.us-pho
 
 ## License
 
-Copyright (c) 2018 Oracle and/or its affiliates.
+Copyright (c) 2018, 2019, Oracle and/or its affiliates.
 
 This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -28,7 +28,7 @@ import sphinx_rtd_theme
 # -- Project information -----------------------------------------------------
 
 project = 'Oracle Cloud Infrastructure Ansible Modules'
-copyright = '2017, 2018, Oracle and/or its affliates'
+copyright = '2017, 2018, 2019, Oracle and/or its affliates'
 author = 'Oracle Corporation'
 
 # XXX Fill in the version and release from the OCI ansible modules'

--- a/docs/dynamic-inventory-script.md
+++ b/docs/dynamic-inventory-script.md
@@ -30,7 +30,8 @@ usage: oci_inventory.py [-h] [--list] [--host HOST] [-config CONFIG_FILE]
                         [--enable-parallel-processing]
                         [--max-thread-count MAX_THREAD_COUNT]
                         [--freeform-tags FREEFORM_TAGS]
-                        [--defined-tags DEFINED_TAGS]
+                        [--defined-tags DEFINED_TAGS] [--regions REGIONS]
+                        [--exclude-regions EXCLUDE_REGIONS]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -40,15 +41,19 @@ optional arguments:
                         OCI config file location
   --profile PROFILE     OCI config profile for connecting to OCI
   --compartment COMPARTMENT
-                        Name of the compartment for which dynamic inventory must be generated. If you want to generate a
-                        dynamic inventory for the root compartment of the tenancy, specify the tenancy name as the name
-                        of the compartment.
-  --parent-compartment-ocid
-                        Only valid when --compartment is set. Parent compartment ocid of the specified compartment.
-                        Defaults to tenancy ocid.
+                        Name of the compartment for which dynamic inventory
+                        must be generated. If you want to generate a dynamic
+                        inventory for the root compartment of the tenancy,
+                        specify the tenancy name as the name of the
+                        compartment.
+  --parent-compartment-ocid PARENT_COMPARTMENT_OCID
+                        Only valid when --compartment is set. Parent
+                        compartment ocid of the specified compartment.Defaults
+                        to tenancy ocid.
   --fetch-hosts-from-subcompartments
-                        Only valid when --compartment is set. Default is false. When set to true, inventory
-                        is built with the entire hierarchy of the given compartment.
+                        Only valid when --compartment is set. Default is
+                        false. When set to true, inventory is built with the
+                        entire hierarchy of the given compartment.
   --refresh-cache, -r   Force refresh of cache by making API requests to OCI.
                         Use this option whenever you are building inventory
                         with new filter options to avoid reading cached
@@ -62,13 +67,17 @@ optional arguments:
                         value can also be provided in the
                         OCI_ANSIBLE_AUTH_TYPE environment variable.
   --enable-parallel-processing
-                        Inventory generation for tenants with huge number of instances might take a long time.
-                        When this flag is set, the inventory script uses thread pools to parallelise the
-                        inventory generation.
-  --max-thread-count
-                        Only valid when --enable-parallel-processing is set. When set, this script uses threads to
-                        improve the performance of building the inventory. This option specifies the maximum number of
-                        threads to use. Defaults to 50. This value can also be provided in the settings config file.
+                        Inventory generation for tenants with huge number of
+                        instances might take a long time.When this flag is
+                        set, the inventory script uses thread pools to
+                        parallelise the inventory generation.
+  --max-thread-count MAX_THREAD_COUNT
+                        Only valid when --enable-parallel-processing is set.
+                        When set, this script uses threads to improve the
+                        performance of building the inventory. This option
+                        specifies the maximum number of threads to use.
+                        Defaults to 50. This value can also be provided in the
+                        settings config file.
   --freeform-tags FREEFORM_TAGS
                         Freeform tags provided as a string in valid JSON
                         format. Example: { "stage": "dev", "app": "demo"} Use
@@ -82,6 +91,13 @@ optional arguments:
                         this option to build inventory of only those hosts
                         which are tagged with all the specified key-value
                         pairs.
+  --regions REGIONS     Comma separated region names to build the inventory
+                        from. Default is the region specified in the config.
+                        Please specify 'all' to build inventory from all the
+                        subscribed regions. Example: us-ashburn-1,us-phoenix-1
+  --exclude-regions EXCLUDE_REGIONS
+                        Comma separated region names to exclude while building
+                        the inventory. Example: us-ashburn-1,uk-london-1
 ```
 
 The `oci_inventory.py` script also accepts the following environment variables:
@@ -101,6 +117,8 @@ The `oci_inventory.py` script also accepts the following environment variables:
 | OCI_CACHE_MAX_AGE |  The number of seconds a cache file is considered valid. To disable caching and get the latest inventory from OCI, set this value to 0. |
 | OCI_HOSTNAME_FORMAT | Host naming format to use in the generated inventory. Use 'fqdn' to list hosts using the instance's Fully Qualified Domain Name (FQDN). Use 'public_ip' to list hosts using public IP address. Use 'private_ip' to list hosts using private IP address.|
 | OCI_ANSIBLE_AUTH_TYPE | Specifies the type of authentication to use for making API requests. By default, the API key in your config will be used. Set it to `instance_principal` to use instance principal based authentication.|
+| OCI_INVENTORY_REGIONS | Specifies names of the regions(separated by commas) for which inventory is to be built. Set it to 'all' to build inventory for all the subscribed regions. |
+| OCI_INVENTORY_EXCLUDE_REGIONS | Specifies names of the regions(separated by commas) to be skipped while building inventory. |
 
 The order of precedence for the configuration used by the inventory script is:
 1. command line arguments

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ Project URL: https://github.com/oracle/oci-ansible-modules
    Module Index <modules/list_of_cloud_modules>
 
 
-OCI Ansible Modules are Copyright (c) 2018 Oracle and/or its affiliates.
+OCI Ansible Modules are Copyright (c) 2018, 2019, Oracle and/or its affiliates.
 
 This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 See `LICENSE.txt <https://github.com/oracle/oci-ansible-modules/blob/master/LICENSE.txt>`_ for more details.

--- a/docs/modules/list_of_cloud_modules.rst
+++ b/docs/modules/list_of_cloud_modules.rst
@@ -45,6 +45,13 @@ Oracle
   * :ref:`oci_cost_tracking_tag_facts_module` 
   * :ref:`oci_cpe_module` 
   * :ref:`oci_cpe_facts_module` 
+  * :ref:`oci_cross_connect_module` 
+  * :ref:`oci_cross_connect_facts_module` 
+  * :ref:`oci_cross_connect_group_module` 
+  * :ref:`oci_cross_connect_group_facts_module` 
+  * :ref:`oci_cross_connect_location_facts_module` 
+  * :ref:`oci_cross_connect_port_speed_shape_facts_module` 
+  * :ref:`oci_cross_connect_status_facts_module` 
   * :ref:`oci_customer_secret_key_module` 
   * :ref:`oci_customer_secret_key_facts_module` 
   * :ref:`oci_data_guard_association_module` 
@@ -77,6 +84,8 @@ Oracle
   * :ref:`oci_export_facts_module` 
   * :ref:`oci_export_set_module` 
   * :ref:`oci_export_set_facts_module` 
+  * :ref:`oci_fast_connect_provider_service_facts_module` 
+  * :ref:`oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts_module` 
   * :ref:`oci_fault_domain_facts_module` 
   * :ref:`oci_file_system_module` 
   * :ref:`oci_file_system_facts_module` 
@@ -101,6 +110,7 @@ Oracle
   * :ref:`oci_ip_sec_connection_device_status_facts_module` 
   * :ref:`oci_ip_sec_connection_facts_module` 
   * :ref:`oci_kubeconfig_module` 
+  * :ref:`oci_letter_of_authority_facts_module` 
   * :ref:`oci_load_balancer_module` 
   * :ref:`oci_load_balancer_backend_module` 
   * :ref:`oci_load_balancer_backend_facts_module` 
@@ -143,6 +153,8 @@ Oracle
   * :ref:`oci_peer_region_for_remote_peering_facts_module` 
   * :ref:`oci_policy_module` 
   * :ref:`oci_policy_facts_module` 
+  * :ref:`oci_preauthenticated_request_module` 
+  * :ref:`oci_preauthenticated_request_facts_module` 
   * :ref:`oci_private_ip_module` 
   * :ref:`oci_private_ip_facts_module` 
   * :ref:`oci_public_ip_module` 
@@ -184,6 +196,10 @@ Oracle
   * :ref:`oci_user_facts_module` 
   * :ref:`oci_vcn_module` 
   * :ref:`oci_vcn_facts_module` 
+  * :ref:`oci_virtual_circuit_module` 
+  * :ref:`oci_virtual_circuit_bandwidth_shape_facts_module` 
+  * :ref:`oci_virtual_circuit_facts_module` 
+  * :ref:`oci_virtual_circuit_public_prefix_facts_module` 
   * :ref:`oci_vnic_module` 
   * :ref:`oci_vnic_attachment_module` 
   * :ref:`oci_vnic_attachment_facts_module` 

--- a/docs/modules/oci_bucket_module.rst
+++ b/docs/modules/oci_bucket_module.rst
@@ -138,7 +138,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>If <em>force='no'</em> and the bucket contains objects, bucket will not be deleted. To delete a bucket which has objects, <em>force='yes'</em> should be specified.</div>
+                                                                        <div>If <em>force='no'</em> and the bucket contains objects and pre-authenticared request at the bucket level, bucket will not be deleted. To delete a bucket which has objects and pre-authenticated request at the bucket level, <em>force='yes'</em> should be specified.</div>
                                                                                 </td>
             </tr>
                                 <tr>

--- a/docs/modules/oci_cross_connect_facts_module.rst
+++ b/docs/modules/oci_cross_connect_facts_module.rst
@@ -1,0 +1,418 @@
+:source: cloud/oracle/oci_cross_connect_facts.py
+
+:orphan:
+
+.. _oci_cross_connect_facts_module:
+
+
+oci_cross_connect_facts - Fetches details of one or more OCI cross-connects
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of a specified OCI cross-connect or all cross-connects in a specified compartment or cross-connect group.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which the specified cross-connect exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cross_connect_group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the cross-connect group under  which the specified cross-connect exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cross_connect_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the cross-connect whose details needs to be fetched</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>PENDING_CUSTOMER</li>
+                                                                                                                                                                                                <li>PROVISIONING</li>
+                                                                                                                                                                                                <li>PROVISIONED</li>
+                                                                                                                                                                                                <li>INACTIVE</li>
+                                                                                                                                                                                                <li>TERMINATING</li>
+                                                                                                                                                                                                <li>TERMINATED</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive. Allowed values are &quot;PENDING_CUSTOMER&quot;, &quot;PROVISIONING&quot;, &quot;PROVISIONED&quot;, &quot;INACTIVE&quot;, &quot;TERMINATING&quot;, &quot;TERMINATED&quot;</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch All cross-connects under a specific compartment
+    - name: Fetch All cross-connects under a specific compartment
+      oci_cross_connect_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+    # Fetch All cross-connects under a specific cross-connect Group
+    - name: Fetch All cross-connects under a specific cross-connect Group
+      oci_cross_connect_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+          cross_connect_group_id: 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx'
+
+    # Fetch All cross-connects under a specific cross-connect Group, filtered by
+    # display name and lifecycle state
+    - name: Fetch All cross-connects under a specific cross-connect Group, filtered by display name and lifecycle state
+      oci_cross_connect_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+          cross_connect_group_id: 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx'
+          display_name: 'ansible-cross-connect'
+          lifecycle_state: 'PROVISIOING'
+
+    # Fetch a specific cross-connect
+    - name: Fetch a specific cross-connect
+      oci_cross_connect_facts:
+          cross_connect_id: 'ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_cross_connects</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'PROVISIONING', 'port_speed_shape_name': '10 Gbps', 'location_name': 'EXAMPLE LOCATION', 'compartment_id': 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx', 'cross_connect_group_id': 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx', 'time_created': '2018-03-03T06:55:49.463000+00:00', 'port_name': 'EXAMPLE PORT', 'display_name': 'ansible-cross-connect', 'id': 'ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx'}, {'lifecycle_state': 'PROVISIONING', 'port_speed_shape_name': '10 Gbps', 'location_name': 'TEST LOCATION', 'compartment_id': 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx', 'cross_connect_group_id': 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx', 'time_created': '2018-03-04T06:55:49.463000+00:00', 'port_name': 'TEST PORT', 'display_name': 'test-cross-connect', 'id': 'ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PROVISIONED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port_speed_shape_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The port speed for this cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10 Gbps</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-cross-connect</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the cross-connect group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cross_connect_group_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the cross-connect group this cross-connect belongs to (if any).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the cross-connect was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A string identifying the meet-me room port for this cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">EXAMPLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>location_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the FastConnect location where this cross-connect is installed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">EXAMPLE LOCATION</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_cross_connect_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_cross_connect_group_facts_module.rst
+++ b/docs/modules/oci_cross_connect_group_facts_module.rst
@@ -1,0 +1,345 @@
+:source: cloud/oracle/oci_cross_connect_group_facts.py
+
+:orphan:
+
+.. _oci_cross_connect_group_facts_module:
+
+
+oci_cross_connect_group_facts - Fetches details of one or more OCI cross-connect groups
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of a specified OCI cross-connect group or all cross-connect groups in a specified compartment.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which the specified cross-connect group exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cross_connect_group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the cross-connect whose details needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>PROVISIONING</li>
+                                                                                                                                                                                                <li>PROVISIONED</li>
+                                                                                                                                                                                                <li>INACTIVE</li>
+                                                                                                                                                                                                <li>TERMINATING</li>
+                                                                                                                                                                                                <li>TERMINATED</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>A filter to return only resources that match the given lifecycle state.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch All Cross Connects Groups under a specific compartment
+    - name: Fetch All Cross Connects Groups under a specific compartment
+      oci_cross_connect_group_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+    # Fetch All cross-connect groups under a specific compartment, filtered by
+    # display name and lifecycle state
+    - name: Fetch All cross-connect groups under a specific compartment, filtered by display name and lifecycle state
+      oci_cross_connect_group_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+          display_name: 'ansible-cross-connect-group'
+          lifecycle_state: 'PROVISIOING'
+
+    # Fetch a specific cross-connect group
+    - name: Fetch a specific cross-connect group
+      oci_cross_connect_group_facts:
+          cross_connect_group_id: 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_cross_connect_groups</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the cross-connect group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'PROVISIONING', 'display_name': 'ansible-cross-connect-group', 'id': 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx', 'compartment_id': 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx', 'time_created': '2018-03-03T06:55:49.463000+00:00'}, {'lifecycle_state': 'PROVISIONING', 'display_name': 'test-cross-connect', 'id': 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx', 'compartment_id': 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx', 'time_created': '2018-03-04T06:55:49.463000+00:00'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Cross Connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PROVISIONED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-cross-connect-group</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the cross-connect group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the cross-connect group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Cross Connect was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_cross_connect_group_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_cross_connect_group_module.rst
+++ b/docs/modules/oci_cross_connect_group_module.rst
@@ -1,0 +1,405 @@
+:source: cloud/oracle/oci_cross_connect_group.py
+
+:orphan:
+
+.. _oci_cross_connect_group_module:
+
+
+oci_cross_connect_group - Create, update and delete OCI cross-connect groups
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Create an OCI cross-connect group to use with Oracle Cloud Infrastructure FastConnect
+- Update an OCI cross-connect group, if present, with a new display name
+- Delete an OCI cross-connect group, if present.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which this cross-connect group would be created. Mandatory for create operation.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cross_connect_group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the cross-connect group. Mandatory for update and delete.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete cross-connect group. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Create cross-connect group
+    - name: Create cross-connect group
+      oci_cross_connect_group:
+          compartment_id: 'ocid1.compartment..xxxxxEXAMPLExxxxx'
+          display_name: 'ansible-cross-connect-group'
+          state: 'present'
+
+    # Update cross-connect group's Display Name
+    - name: Update cross-connect group's Display Name
+      oci_cross_connect_group:
+          cross_connect_grou_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+          display_name: 'cross-connect-group-updated'
+          state: 'present'
+
+    # Delete cross-connect
+    - name: Delete cross-connect group
+      oci_cross_connect_group:
+          cross_connect_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+          state: 'absent'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_cross_connect_group</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the cross-connect group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'PROVISIONING', 'display_name': 'ansible-cross-connect-group', 'id': 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx', 'compartment_id': 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx', 'time_created': '2018-03-03T06:55:49.463000+00:00'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the cross-connect group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PROVISIONED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-cross-connect-group</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the cross-connect group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the cross-connect group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the cross-connect group was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_cross_connect_group.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_cross_connect_location_facts_module.rst
+++ b/docs/modules/oci_cross_connect_location_facts_module.rst
@@ -1,0 +1,237 @@
+:source: cloud/oracle/oci_cross_connect_location_facts.py
+
+:orphan:
+
+.. _oci_cross_connect_location_facts_module:
+
+
+oci_cross_connect_location_facts - Fetches details of one or more OCI cross-connect Locations
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of the OCI cross-connect Locations
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which cross-connect Locations exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch All cross-connect Locations under a specific compartment
+    - name: Fetch All cross-connect Locations under a specific compartment
+      oci_cross_connect_location_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_cross_connect_locations</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the cross-connect Location.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'description': 'Equinix', 'name': 'Equinix'}, {'description': 'CoreSite', 'name': 'CoreSite'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the cross-connect location.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_cross_connect_location_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_cross_connect_module.rst
+++ b/docs/modules/oci_cross_connect_module.rst
@@ -1,0 +1,533 @@
+:source: cloud/oracle/oci_cross_connect.py
+
+:orphan:
+
+.. _oci_cross_connect_module:
+
+
+oci_cross_connect - Create,update and delete OCI cross-connects
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Create an OCI cross-connect
+- Update an OCI cross-connect, if present, with a new display name
+- Activate an OCI cross-connect
+- Delete an OCI cross-connect, if present.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which this cross-connect would be created. Mandatory for create operation. Mutually exclusive with <em>cross_connect_id</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cross_connect_group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the cross-connect group to put this cross-connect in.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cross_connect_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the cross-connect. Mandatory for delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>far_cross_connect_or_cross_connect_group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>If you already have an existing cross-connect or cross-connect group at this FastConnect location, and you want this new cross-connect to be on a different router (for the purposes of redundancy), provide the OCID of that existing cross-connect or cross-connect group.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>is_active</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Set to true to activate the cross-connect. You activate it after the physical cabling is complete, and you've confirmed the cross-connect's light levels are good and your side of the interface is up. Activation indicates to Oracle that the physical connection is ready.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>location_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the FastConnect location where this cross-connect will be installed.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>near_cross_connect_or_cross_connect_group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>If you already have an existing cross-connect or cross-connect group at this FastConnect location, and you want this new cross-connect to be on the same router, provide the OCID of that existing cross-connect or cross-connect group.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>port_speed_shape_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The port speed for this cross-connect.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete cross-connect. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Create a new cross-connect
+    - name: Create a new cross-connect
+      oci_cross_connect:
+          compartment_id: 'ocid1.compartment..xxxxxEXAMPLExxxxx'
+          display_name: 'ansible-cross-connect'
+          cross_connect_group_id: 'ocid1.crossconnectgroup..xvdf'
+          far_cross_connect_or_cross_connect_group_id: 'ocid1.crossconnect..xxxxxEXAMPLExxxxx'
+          location_name: 'EXAMPLE LOCATION'
+          port_speed_shape_name: '10 Gbps'
+          state: 'present'
+
+    # Update an existing cross-connect's display Name
+    - name: Update an existing cross-connect's display Name
+      oci_cross_connect:
+          cross_connect_id: 'ocid1.crossconnect..xxxxxEXAMPLExxxxx'
+          display_name: 'cross-connect-updated'
+          state: 'present'
+
+    # Activate a cross-connect
+    - name: Update cross-connect Active state
+      oci_cross_connect:
+          cross_connect_id: 'ocid1.crossconnect..xxxxxEXAMPLExxxxx'
+          is_active: True
+          state: 'present'
+
+    # Delete a cross-connect
+    - name: Delete cross-connect
+      oci_cross_connect:
+          cross_connect_id: 'ocid1.crossconnect..xxxxxEXAMPLExxxxx'
+          state: 'absent'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>cross_connect</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'PROVISIONING', 'port_speed_shape_name': '10 Gbps', 'location_name': 'EXAMPLE LOCATION', 'compartment_id': 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx', 'cross_connect_group_id': 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx', 'time_created': '2018-03-03T06:55:49.463000+00:00', 'port_name': 'EXAMPLE PORT', 'display_name': 'ansible-cross-connect', 'id': 'ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PROVISIONED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port_speed_shape_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The port speed for this cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10 Gbps</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-cross-connect</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the cross-connect group.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cross_connect_group_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the cross-connect group this cross-connect belongs to (if any).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the cross-connect was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A string identifying the meet-me room port for this cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">EXAMPLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>location_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the FastConnect location where this cross-connect is installed.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">EXAMPLE LOCATION</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_cross_connect.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_cross_connect_port_speed_shape_facts_module.rst
+++ b/docs/modules/oci_cross_connect_port_speed_shape_facts_module.rst
@@ -1,0 +1,251 @@
+:source: cloud/oracle/oci_cross_connect_port_speed_shape_facts.py
+
+:orphan:
+
+.. _oci_cross_connect_port_speed_shape_facts_module:
+
+
+oci_cross_connect_port_speed_shape_facts - Fetches details of one or more OCI cross-connect port speed shapes
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of the OCI cross-connect port speed shapes
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which cross-connect Port Speed Shapes exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch All cross-connect Port Speed Shapes under a specific compartment
+    - name: Fetch All cross-connect Port Speed Shapes under a specific compartment
+      oci_cross_connect_port_speed_shape_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_cross_connect_port_speed_shapes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the cross-connect Port Speed Shape.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'name': '10 Gbps', 'port_speed_in_gbps': 10}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the port speed shape.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10 Gbps</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port_speed_in_gbps</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The port speed in Gbps.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_cross_connect_port_speed_shape_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_cross_connect_status_facts_module.rst
+++ b/docs/modules/oci_cross_connect_status_facts_module.rst
@@ -1,0 +1,280 @@
+:source: cloud/oracle/oci_cross_connect_status_facts.py
+
+:orphan:
+
+.. _oci_cross_connect_status_facts_module:
+
+
+oci_cross_connect_status_facts - Fetches details of OCI cross-connect status
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of the OCI cross-connect status
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cross_connect_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the cross-connect whose status needs to be fetched</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch cross-connect status
+    - name: Fetch cross-connect status
+      oci_cross_connect_status_facts:
+          cross_connect_id: 'ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_cross_connect_status</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the cross-connect Status.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'light_level_indicator': 'GOOD', 'interface_state': 'UP', 'cross_connect_id': 'ocid1.crossconect.oc1.iad.xxxxxEXAMPLExxxxx', 'light_level_ind_bm': 14.0}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>light_level_indicator</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>tatus indicator corresponding to the light level.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">GOOD</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>interface_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether Oracle's side of the interface is up or down.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">UP</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cross_connect_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.crossconect.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>light_level_ind_bm</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The light level of the cross-connect (in dBm).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">14.0</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_cross_connect_status_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_db_system_module.rst
+++ b/docs/modules/oci_db_system_module.rst
@@ -271,6 +271,21 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="2">
+                    <b>delete_ssh_public_keys</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                                                                                    <li>yes</li>
+                                                                                                                                                                                                                                                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                                    <b>Default:</b><br/><div style="color: blue">no</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Delete ssh public keys from DB System which are present in the provided ssh public keys. If <em>delete_ssh_public_keys=yes</em>, ssh public keys provided by <em>ssh_public_keys</em> would be deleted from existing ssh public keys, if they are part of existing ssh public keys. If they are not part of existing ssh public keys, they will be ignored. <em>delete_ssh_public_keys</em> and <em>purge_ssh_public_keys</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
                     <b>disk_redundancy</b>
                                                                             </td>
                                 <td>
@@ -393,7 +408,7 @@ Parameters
                                                                                     <b>Default:</b><br/><div style="color: blue">yes</div>
                                     </td>
                                                                 <td>
-                                                                        <div>Purge ssh public keys  from DB System which are not present in the provided ssh public keys. If <em>purge_ssh_public_keys=no</em>, provided ssh public keys would be appended to existing ssh public keys.</div>
+                                                                        <div>Purge ssh public keys  from DB System which are not present in the provided ssh public keys. If <em>purge_ssh_public_keys=no</em>, provided ssh public keys would be appended to existing ssh public keys. <em>purge_ssh_public_keys</em> and <em>delete_ssh_public_keys</em> are mutually exclusive.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -632,6 +647,14 @@ Examples
         db_system_id: "ocid1.dbsystem.aaaa"
         ssh_public_keys: ["/tmp/id_rsa_updated.pub"]
         purge_ssh_public_keys: False
+        state: 'present'
+
+    # Deleting SSH public keys from a database system
+    - name: Update DB System by deleting SSH Public keys
+      oci_db_system:
+        db_system_id: "ocid1.dbsystem.aaaa"
+        ssh_public_keys: ["/tmp/id_rsa_updated.pub"]
+        delete_ssh_public_keys: True
         state: 'present'
 
     # Terminate DB System

--- a/docs/modules/oci_dhcp_options_module.rst
+++ b/docs/modules/oci_dhcp_options_module.rst
@@ -141,6 +141,20 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="2">
+                    <b>delete_dhcp_options</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Delete existing Dhcp Options which are present in the Dhcp Options provided by <em>options</em>. If <em>delete_dhcp_options=yes</em>, options provided by <em>options</em> would be deleted from existing options, if they are part of existing dhcp options. If they are not part of existing dhcp options, they will be ignored. <em>delete_dhcp_options</em> and <em>purge_dhcp_options</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
                     <b>dhcp_id</b>
                                                                             </td>
                                 <td>
@@ -269,7 +283,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>Purge existing Dhcp Options which are not present in the provided Dhcp Options. If <em>purge_dhcp_options=no</em>, provided options would be appended to existing options.</div>
+                                                                        <div>Purge existing Dhcp Options which are not present in the provided Dhcp Options. If <em>purge_dhcp_options=no</em>, provided options would be appended to existing options. <em>purge_dhcp_options</em> and <em>delete_dhcp_options</em> are mutually exclusive.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -370,7 +384,7 @@ Examples
     
     #Note: These examples do not set authentication details.
     #Create/update Dhcp Options
-    - name: Create dhcp options
+    - name: Create Dhcp options
       oci_dhcp_options:
         compartment_id: 'ocid1.compartment..xdsc'
         name: 'ansible_dhcp_options'
@@ -388,8 +402,8 @@ Examples
                 capacity: 'medium'
         state: 'present'
 
-    #Update Dhcp Options by appending new options
-    - name: Update the display name of a Dhcp Options
+    # Update Dhcp Options by appending new options
+    - name: Update Dhcp Options by appending new options
       oci_dhcp_options:
         id: 'ocid1.dhcpoptions.oc1.aaa'
         purge_dhcp_options: 'no'
@@ -401,8 +415,8 @@ Examples
                 search_domain_names: ['ansibletestvcn.oraclevcn.com']
         state: 'present'
 
-    #Update Dhcp Options by purging existing options
-    - name: Update the display name of a Dhcp Options
+    # Update Dhcp Options by purging existing options
+    - name: Update Dhcp Options by purging existing options
       oci_dhcp_options:
         dhcp_id: 'ocid1.dhcpoptions.oc1.aaa'
         options:
@@ -411,6 +425,17 @@ Examples
                 custom_dns_servers: ['10.0.0.8', '10.0.0.10', '10.0.0.12']
               - type: 'SearchDomain'
                 search_domain_names: ['ansibletestvcn.oraclevcn.com']
+        state: 'present'
+
+    # Update Dhcp Options by deleting existing options
+    - name: Update Dhcp Options by deleting existing options
+      oci_dhcp_options:
+        dhcp_id: 'ocid1.dhcpoptions.oc1.aaa'
+        options:
+              - type: 'DomainNameServer'
+                server_type: 'CustomDnsServer'
+                custom_dns_servers: ['10.0.0.8', '10.0.0.10', '10.0.0.12']
+        delete_dhcp_options: 'yes'
         state: 'present'
 
     #Delete Dhcp Options

--- a/docs/modules/oci_export_module.rst
+++ b/docs/modules/oci_export_module.rst
@@ -119,6 +119,20 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="2">
+                    <b>delete_export_options</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Delete any export options in the Export that is specified in <em>export_options</em>. If <em>delete_export_options=yes</em>, export options provided by <em>export_options</em> would be deleted from existing export options, if they are part of existing export options. If they are not part of existing export options, they will be ignored. <em>delete_export_options</em> and <em>purge_export_options</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
                     <b>export_id</b>
                                                                             </td>
                                 <td>
@@ -270,7 +284,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>Purge any export options in the  Export that is not specified in <em>export_options</em>. If <em>purge_export_options=no</em>, provided export options would be appended to existing export options.</div>
+                                                                        <div>Purge any export options in the  Export that is not specified in <em>export_options</em>. If <em>purge_export_options=no</em>, provided export options would be appended to existing export options. <em>purge_export_options</em> and <em>delete_export_options</em> are mutually exclusive.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -394,6 +408,18 @@ Examples
                 access: 'READ_ONLY'
                 identity_squash: 'ALL'
         purge_export_options: False
+        state: 'present'
+
+    # Update Export's Export Options by deleting an Export Options
+    - name: Update Export's Export Options by deleting an Export Options
+      oci_export:
+        export_id: 'ocid1.export.oc1..xxxxxEXAMPLExxxxx'
+        export_options:
+              - source: '10.0.0.100'
+                require_privileged_source_port: False
+                access: 'READ_ONLY'
+                identity_squash: 'ALL'
+        delete_export_options: True
         state: 'present'
 
     # Delete Export

--- a/docs/modules/oci_fast_connect_provider_service_facts_module.rst
+++ b/docs/modules/oci_fast_connect_provider_service_facts_module.rst
@@ -1,0 +1,351 @@
+:source: cloud/oracle/oci_fast_connect_provider_service_facts.py
+
+:orphan:
+
+.. _oci_fast_connect_provider_service_facts_module:
+
+
+oci_fast_connect_provider_service_facts - Fetches details of one or more OCI Fast Connect Provider Services
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of the OCI Fast Connect Provider Services
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which the specified fast connect provider service exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>provider_service_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the fast connect provider service whose details needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch All Fast Connect Provider Services under a specific compartment
+    - name: Fetch All Fast Connect Provider Services under a specific compartment
+      oci_fast_connect_provider_service_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+    # Fetch a specific Fast Connect Provider Service
+    - name: Fetch a specific Fast Connect Provider Service
+      oci_fast_connect_provider_service_facts:
+          provider_service_id: 'ocid1.serviceprovider.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_fast_connect_provider_services</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Fast Connect Provider Service.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'private_peering_bgp_management': 'CUSTOMER_MANAGED', 'description': 'https://megaport.al/', 'provider_service_name': 'Service', 'public_peering_bgp_management': 'ORACLE_MANAGED', 'provider_name': 'Megaport', 'supported_virtual_circuit_types': None, 'type': 'LAYER2', 'id': 'ocid1.providerservice.oc1.iad.xxxxxEXAMPLExxxxx'}, {'private_peering_bgp_management': 'CUSTOMER_MANAGED', 'description': 'https://marketplaceportal.com/web/guest/login', 'provider_service_name': 'Service Exchange', 'public_peering_bgp_management': 'ORACLE_MANAGED', 'provider_name': 'Digital Realty', 'supported_virtual_circuit_types': ['PRIVATE', 'PUBLIC'], 'type': 'LAYER2', 'id': 'ocid1.providerservice.oc1.iad.xxxxxEXAMPLExxxxx'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>private_peering_bgp_management</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Who is responsible for managing the private peering BGP information.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CUSTOMER_MANAGED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A description of the service offered by the provider.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">https://megaport.al/</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>provider_service_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the service offered by the provider.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Service</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>public_peering_bgp_management</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Who is responsible for managing the public peering BGP information.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ORACLE_MANAGED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>provider_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the provider.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Megaport</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>supported_virtual_circuit_types</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>An array of virtual circuit types supported by this service.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">['PRIVATE', 'PUBLIC']</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>type</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Provider service type.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">LAYER2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Fast Connect Provider Service</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.providerservice.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_fast_connect_provider_service_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts_module.rst
+++ b/docs/modules/oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts_module.rst
@@ -1,0 +1,252 @@
+:source: cloud/oracle/oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts.py
+
+:orphan:
+
+.. _oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts_module:
+
+
+oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts - Fetches details of one or more OCI Fast Connect Provider Virtual Circuit Bandwidth
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of the OCI Fast Connect Provider Virtual Circuit Bandwidth
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>provider_service_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the fast connect provider service whose virtual circuit bandwidth needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch All Fast Connect Provider Virtual Circuit Bandwidth under a specific Provider Service
+    - name: Fetch All Fast Connect Provider Virtual Circuit Bandwidth under a specific Provider Service
+      oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts:
+          provider_service_id: 'ocid1.serviceprovider.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_fast_connect_provider_virtual_circuit_bandwidth_shapes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Fast Connect Provider Service.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'bandwidth_in_mbps': 1000, 'name': '1 Gbps'}, {'bandwidth_in_mbps': 2000, 'name': '2 Gbps'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>bandwidth_in_mbps</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The bandwidth in Mbps.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the bandwidth shape.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1 Gbps</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_group_module.rst
+++ b/docs/modules/oci_group_module.rst
@@ -132,6 +132,20 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>delete_user_memberships</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Delete users in existing memberships which are present in the users memberships provided by <em>users</em>. If <em>delete_user_memberships=yes</em>, users provided by <em>users</em> would be deleted from existing user memberships, if they are part of existing user memberships. If they are not part of existing user memberships, they will be ignored. <em>delete_user_memberships</em> and <em>purge_user_memberships</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>description</b>
                                                                             </td>
                                 <td>
@@ -193,7 +207,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>Purge users in existing memberships which are not present in the provided users memberships. If <em>purge_user_memberships=no</em>, provided users would be appended to existing user memberships.</div>
+                                                                        <div>Purge users in existing memberships which are not present in the provided users memberships. If <em>purge_user_memberships=no</em>, provided users would be appended to existing user memberships. <em>purge_user_memberships</em> and <em>delete_user_memberships</em> are mutually exclusive.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -313,6 +327,14 @@ Examples
                 description: 'Group for Testing Ansible Module'
                 purge_user_memberships: True
                 users: ['user1','user3']
+                state: 'present'
+
+    - name: Update group by deleting existing user memberships
+      oci_group:
+                id: ocid1.group.oc1..xxxxxEXAMPLExxxxx
+                description: 'Group for Testing Ansible Module'
+                delete_user_memberships: True
+                users: ['user1']
                 state: 'present'
 
     - name: Create group without users associations

--- a/docs/modules/oci_instance_configuration_facts_module.rst
+++ b/docs/modules/oci_instance_configuration_facts_module.rst
@@ -127,6 +127,16 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>instance_configuration_id</b>
                                                                             </td>
                                 <td>

--- a/docs/modules/oci_letter_of_authority_facts_module.rst
+++ b/docs/modules/oci_letter_of_authority_facts_module.rst
@@ -1,0 +1,322 @@
+:source: cloud/oracle/oci_letter_of_authority_facts.py
+
+:orphan:
+
+.. _oci_letter_of_authority_facts_module:
+
+
+oci_letter_of_authority_facts - Fetches details of OCI cross-connect Letter of Authority
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of OCI Letter of Authority
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>cross_connect_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the cross-connect whose letter of authority needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch Letter of Authority
+    - name: Fetch Letter of Authority
+      oci_letter_of_authority_facts:
+          cross_connect_id: 'ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_letter_of_authorities</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Letter of Authority.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'facility_location': 'Equinox', 'port_name': 'Example Port Name', 'cross_connect_id': 'ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx', 'circuit_type': 'Single_mode_LC', 'authorized_entity_name': 'Example Authorized Entity Name', 'time_expires': '2018-03-03T06:55:49.463000+00:00', 'time_issued': '2018-02-03T06:55:49.463000+00:00'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>facility_location</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The address of the FastConnect location.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Equinox</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The meet-me room port for this cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Example Port Name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cross_connect_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>circuit_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The type of cross-connect fiber, termination, and optical specification.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Single_mode_LC</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>authorized_entity_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the entity authorized by this Letter of Authority.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Example Authorized Entity</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_expires</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time when the Letter of Authority expires, in the format defined by RFC3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-03-03 06:55:49.463000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_issued</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date and time the Letter of Authority was created, in the format defined by RFC3339..</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-03-03 06:55:49.463000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_letter_of_authority_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_load_balancer_backend_set_module.rst
+++ b/docs/modules/oci_load_balancer_backend_set_module.rst
@@ -200,6 +200,20 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="2">
+                    <b>delete_backends</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Delete any backends in the  Backend Set named <em>name</em> that is specified in <em>backends</em>. If <em>delete_backends=yes</em>, backends provided by <em>backends</em> would be deleted from existing backends, if they are part of existing backends. If they are not part of existing backends, they will be ignored. <em>delete_backends</em> and <em>purge_backends</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
                     <b>health_checker</b>
                                                                             </td>
                                 <td>
@@ -349,7 +363,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>Purge any backends in the  Backend Set named <em>name</em> that is not specified in <em>backends</em>. If <em>purge_backends=no</em>, provided backends would be appended to existing backends.</div>
+                                                                        <div>Purge any backends in the  Backend Set named <em>name</em> that is not specified in <em>backends</em>. If <em>purge_backends=no</em>, provided backends would be appended to existing backends. <em>purge_backends</em> and <em>delete_backends</em> are mutually exclusive.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -554,6 +568,18 @@ Examples
                 port: 8282
         purge_backends: 'no'
         state: 'present'
+
+    # Update Load Balancer Backend Set by deleting backends
+    - name: Update Load Balancer Backend Set by deleting backends
+      oci_load_balancer_backend_set:
+        load_balancer_id: "ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx"
+        name: "ansible_backend_set"
+        backends:
+              - ip_address: "10.159.34.25"
+                port: 8282
+        delete_backends: 'yes'
+        state: 'present'
+
     # Deleted Load Balancer Backend Set
     - name: Update Load Balancer Backend Set
       oci_load_balancer_backend_set:

--- a/docs/modules/oci_load_balancer_listener_module.rst
+++ b/docs/modules/oci_load_balancer_listener_module.rst
@@ -151,6 +151,20 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="2">
+                    <b>delete_hostname_names</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Delete any Hostname names in the  Listener named <em>name</em> that is specified in <em>hostname_names</em>. This is only applicable in case of updating Listener.If <em>delete_hostname_names=yes</em>, provided <em>hostname_names</em> would be deleted from existing <em>hostname_names</em>, if they are part of existing hostname names. If they are not part of existing hostname names, they will be ignored. <em>delete_hostname_names</em> and <em>purge_hostname_names</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
                     <b>hostname_names</b>
                                                                             </td>
                                 <td>
@@ -221,7 +235,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>Purge any Hostname names in the  Listener named <em>name</em> that is not specified in <em>hostname_names</em>. This is only applicable in case of updating Listener.If <em>purge_hostname_names=no</em>, provided <em>hostname_names</em> would be appended to existing <em>hostname_names</em>.</div>
+                                                                        <div>Purge any Hostname names in the  Listener named <em>name</em> that is not specified in <em>hostname_names</em>. This is only applicable in case of updating Listener.If <em>purge_hostname_names=no</em>, provided <em>hostname_names</em> would be appended to existing <em>hostname_names</em>. <em>purge_hostname_names</em> and <em>delete_hostname_names</em> are mutually exclusive.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -412,6 +426,14 @@ Examples
         name: "ansible_listener"
         hostname_names: ['hostname_002']
         purge_hostname_names: False
+        state: 'present'
+
+    - name: Update Listener's Hostname Names by deleting hostname name
+      oci_load_balancer_listener:
+        load_balancer_id: "ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx"
+        name: "ansible_listener"
+        hostname_names: ['hostname_002']
+        delete_hostname_names: True
         state: 'present'
 
     - name: Update Listener's Hostname Names by replacing existing names

--- a/docs/modules/oci_load_balancer_path_route_set_module.rst
+++ b/docs/modules/oci_load_balancer_path_route_set_module.rst
@@ -119,6 +119,20 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="2">
+                    <b>delete_path_routes</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Delete any Path Route in the  Path Route Set named <em>name</em> that is specified in <em>path_routes</em>. This is only applicable in case of updating path route set.If <em>delete_path_routes=yes</em>, path routes provided by <em>path_routes</em> would be deleted from existing path routes, if they are part of existing path route. If they are not part of existing path routes, they will be ignored. <em>delete_path_routes</em> and <em>purge_path_routes</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
                     <b>load_balancer_id</b>
                                         <br/><div style="font-size: small; color: red">required</div>                                    </td>
                                 <td>
@@ -193,7 +207,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>Purge any Path Route in the  Path Route Set named <em>name</em> that is not specified in <em>path_routes</em>. This is only applicable in case of updating path route set.If <em>purge_path_routes=no</em>, provided path_routes would be appended to existing path_routes.</div>
+                                                                        <div>Purge any Path Route in the  Path Route Set named <em>name</em> that is not specified in <em>path_routes</em>. This is only applicable in case of updating path route set.If <em>purge_path_routes=no</em>, provided path_routes would be appended to existing path_routes.  <em>purge_path_routes</em> and <em>delete_path_routes</em> are mutually exclusive.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -318,6 +332,19 @@ Examples
                 path_match_type:
                      match_type: 'FORCE_LONGEST_PREFIX_MATCH'
         purge_path_routes: False
+        state: 'present'
+
+    # Update Load Balancer Path Route Set by deleting a path route
+    - name: Update Load Balancer Path Route Set by deleting a path route
+      oci_load_balancer_path_route_set:
+        load_balancer_id: "ocid1.loadbalancer.oc1.iad.xxxxxEXAMPLExxxxx"
+        name: "ansible_backend_set"
+        path_routes:
+              - backend_set_name: "ansible_backend_set"
+                path: "/admin"
+                path_match_type:
+                     match_type: 'FORCE_LONGEST_PREFIX_MATCH'
+        delete_path_routes: True
         state: 'present'
 
     # Delete Load Balancer Path Route Set

--- a/docs/modules/oci_object_facts_module.rst
+++ b/docs/modules/oci_object_facts_module.rst
@@ -161,6 +161,17 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>list_multipart_uploads</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                                                                <b>Default:</b><br/><div style="color: blue">no</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>If <em>list_multipart_uploads=True</em>, all in-progress multipart uploads for the given <em>bucket</em> would be listed.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>namespace_name</b>
                                         <br/><div style="font-size: small; color: red">required</div>                                    </td>
                                 <td>
@@ -221,6 +232,16 @@ Parameters
                                                                         <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
                                                                                 </td>
             </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>upload_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The upload ID for a multipart upload. When <em>upload_id</em> is specified, all the parts of the specified in-progress multipart upload is listed.</div>
+                                                                                </td>
+            </tr>
                         </table>
     <br/>
 
@@ -255,6 +276,19 @@ Examples
         bucket: mybucket
         object: myobject
 
+    - name: Get details of all in-progress multipart uploads for the given bucket
+      oci_object_facts:
+        name: mynamespace
+        bucket: mybucket
+        list_multipart_uploads: True
+
+    - name: Get details of all the parts of an in-progress multipart upload for a specific object
+      oci_object_facts:
+        name: mynamespace
+        bucket: mybucket
+        object: myobject
+        upload_id: 951f4759-f910-50b4-udf99gf
+
 
 
 
@@ -280,24 +314,10 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                             <div>List of object details</div>
                                         <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'md5': '3zBENq6MBnedDrpl2+SttQ==', 'name': 'image2a343.png', 'time_created': '2017-10-09T10:27:53.688000+00:00', 'size': 165661}, {'md5': 'LWX13se0YFa6VVlv0R3hqA==', 'name': 'info1.txt', 'time_created': '2017-10-09T08:39:17.411000+00:00', 'size': 1084}]</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'md5': '3zBENq6MBnedDrpl2+SttQ==', 'name': 'image2a343.png', 'time_created': '2017-10-09T10:27:53.688000+00:00', 'size': 165661}, {'md5': 'LWX13se0YFa6VVlv0R3hqA==', 'name': 'info1.txt', 'time_created': '2017-10-09T08:39:17.411000+00:00', 'size': 1084}, {'namespace': 'ansible_namespace', 'object': 'ansible_object', 'bucket': 'ansible_bucket', 'upload_id': '3f7c3d1f-15cf-97a6-c6d7-f319', 'time_created': '2018-12-26T13:48:18.326000+00:00'}, {'part_number': 2, 'etag': '7DF108FC90D40327E053821BC20AC918', 'md5': 'J0doWIKY7JfZTrS1IPEGvA==', 'size': 28282272}]</div>
                                     </td>
             </tr>
                                                             <tr>
-                                    <td class="elbow-placeholder">&nbsp;</td>
-                                <td colspan="1">
-                    <b>md5</b>
-                    <br/><div style="font-size: small; color: red">string</div>
-                                    </td>
-                <td>always</td>
-                <td>
-                                            <div>Base64-encoded MD5 hash of the object data</div>
-                                        <br/>
-                                            <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3zBENq6MBnedDrpl2+SttQ==</div>
-                                    </td>
-            </tr>
-                                <tr>
                                     <td class="elbow-placeholder">&nbsp;</td>
                                 <td colspan="1">
                     <b>name</b>
@@ -309,6 +329,48 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                         <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">image2a343.png</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>part_size</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>multipart upload parts listing</td>
+                <td>
+                                            <div>The part number for this part.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>object</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>multipart uploads listing</td>
+                <td>
+                                            <div>The object name of the in-progress multipart upload.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_object</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>namespace</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>multipart uploads listing</td>
+                <td>
+                                            <div>The Object Storage namespace in which the in-progress multipart upload is stored.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_namespace</div>
                                     </td>
             </tr>
                                 <tr>
@@ -328,6 +390,48 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                 <tr>
                                     <td class="elbow-placeholder">&nbsp;</td>
                                 <td colspan="1">
+                    <b>etag</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>multipart upload parts listing</td>
+                <td>
+                                            <div>The current entity tag for the part.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">7DF108FC90D40327E053821BC20</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>upload_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>multipart uploads listing</td>
+                <td>
+                                            <div>The unique identifier for the in-progress multipart upload.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3f7c3d1f-15cf-97a6-c6d7-f31</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>bucket</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>multipart uploads listing</td>
+                <td>
+                                            <div>The bucket in which the in-progress multipart upload is stored.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_bucket</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
                     <b>size</b>
                     <br/><div style="font-size: small; color: red">int</div>
                                     </td>
@@ -337,6 +441,20 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                         <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">165661</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>md5</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Base64-encoded MD5 hash of the object data</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3zBENq6MBnedDrpl2+SttQ==</div>
                                     </td>
             </tr>
                     

--- a/docs/modules/oci_object_module.rst
+++ b/docs/modules/oci_object_module.rst
@@ -295,10 +295,11 @@ Parameters
                                                                                                                             <ul><b>Choices:</b>
                                                                                                                                                                 <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
                                                                                                                                                                                                 <li>absent</li>
+                                                                                                                                                                                                <li>abort_multipart_upload</li>
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>The final state of the object after the task. Use <em>state=absent</em> with <em>object</em> to delete a specific object. Use <em>state=present</em> with <em>dest</em> to download an object. Use <em>state=present</em> with <em>src</em> to upload an object.</div>
+                                                                        <div>The final state of the object after the task. Use <em>state=absent</em> with <em>object</em> to delete a specific object. Use <em>state=present</em> with <em>dest</em> to download an object. Use <em>state=present</em> with <em>src</em> to upload an object. Use <em>state=abort_multipart_upload</em> with <em>object</em> and <em>upload_id</em> to abort a specific multipart object upload.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -309,6 +310,16 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                                                         <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>upload_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The upload ID for a multipart upload. Use with <em>state=abort_multipart_upload</em> to abort an in-progress multipart upload, and delete all the parts that have been uploaded.</div>
                                                                                 </td>
             </tr>
                         </table>
@@ -361,6 +372,14 @@ Examples
         object: key.txt
         dest: /usr/local/myfile.txt
         force: false
+
+    - name: Abort multipart upload
+      oci_object:
+        namespace: mynamespace
+        bucket: mybucket
+        object: mydata.txt
+        upload_id: 951f4759-f910-50b4-udf99gf
+        state: 'abort_multipart_upload'
 
     - name: Delete an object
       oci_object:

--- a/docs/modules/oci_preauthenticated_request_facts_module.rst
+++ b/docs/modules/oci_preauthenticated_request_facts_module.rst
@@ -1,0 +1,352 @@
+:source: cloud/oracle/oci_preauthenticated_request_facts.py
+
+:orphan:
+
+.. _oci_preauthenticated_request_facts_module:
+
+
+oci_preauthenticated_request_facts - Fetches details of existing OCI Preauthenticated Requests.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of all OCI Preauthenticated Requests for a specific Bucket or an OCI Preauthenticated Request
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>bucket_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Bucket name from which details of all preauthenticated-requests must be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>namespace_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Namespace name from which details of all preauthenticated-requests must be fetched.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>object_name_prefix</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>User-specified object name prefixes can be used to query and return a list of pre-authenticated requests.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>par_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the preauthenticated-request. Required if the details of a specific preauthenticated-request details needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Fetch Preauthenticated Request
+    - name: List all Preauthenticated Request of a Bucket
+      oci_preauthenticated_request_facts:
+        namespace_name: 'us-example-1'
+        bucket_name: 'ansible_bucket'
+
+    # Fetch Preauthenticated Request for a specific Object
+    - name: List Preauthenticated Request for objects with a specified name prefix
+      oci_preauthenticated_request_facts:
+        namespace_name: 'us-example-1'
+        bucket_name: 'ansible_bucket'
+        object_name_prefix: 'ansible_object'
+
+    # Fetch a specific Preauthenticated Request
+    - name: List a specific Preauthenticated Request
+      oci_preauthenticated_request_facts:
+        namespace_name: 'us-example-1'
+        bucket_name: 'ansible_bucket'
+        par_id: 'fEbFqu0/thO3JqpA/MRVbD/BpE='
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>preauthenticated_requests</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Fetched Preauthenticated Request.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'object_name': 'ansible_object', 'name': 'ansible_bucket_par', 'access_type': 'AnyObjectWrite', 'time_expires': '2018-12-23T17:31:35+00:00', 'id': 'EbFqu0/thO3/MRVb/XmZ0iaT6IA=', 'time_created': '2018-12-22T12:04:02.229000+00:00'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>object_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the object that is being granted access to by the pre-authenticated request.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_object</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The user-provided name of the pre-authenticated request.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_bucker_par</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>access_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The collection of rules for routing destination IPs to network devices.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AnyObjectWrite</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_expires</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The expiration date for the pre-authenticated request as per RFC 3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-12-22 00:00:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Preauthenticated Request</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">fEbFqu0/thO3JqpA/MRVbD/BpE=</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date when the pre-authenticated request was created as per specification RFC 3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-12-22 12:04:02.229000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_preauthenticated_request_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_preauthenticated_request_module.rst
+++ b/docs/modules/oci_preauthenticated_request_module.rst
@@ -1,0 +1,488 @@
+:source: cloud/oracle/oci_preauthenticated_request.py
+
+:orphan:
+
+.. _oci_preauthenticated_request_module:
+
+
+oci_preauthenticated_request - Create and delete an OCI Preauthenticated Request
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Create a new OCI Preauthenticated Request for a bucket or an object
+- Delete an OCI Preauthenticated Request, if present
+- Note that the unique URL provided by the system when you create a pre-authenticated request is the only way a user can access the bucket or object specified as the request target. Copy the URL to durable storage. The URL is returned only at the time of creation and cannot be retrieved later.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>access_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>ObjectRead</li>
+                                                                                                                                                                                                <li>ObjectWrite</li>
+                                                                                                                                                                                                <li>ObjectReadWrite</li>
+                                                                                                                                                                                                <li>AnyObjectWrite</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The expiration date for the pre-authenticated request as per RFC 3339. After this date the pre-authenticated request will no longer be valid. Required while creating a Preauthenticated request with <em>state=present</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>bucket_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the bucket. Avoid entering confidential information.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-specified name for the pre-authenticated request. Names can be helpful in managing pre-authenticated requests. Required while creating a Preauthenticated request with <em>state=present</em>.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: display_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>namespace_name</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Object Storage namespace used for the request.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>object_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The name of the object that is being granted access to by the pre-authenticated request. Avoid entering confidential information. The object name can be null and if so, the pre-authenticated request grants access to the entire bucket.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>par_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Preauthenticated Request. Mandatory for delete.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create or delete Preauthenticated Request. Use <em>state=present</em> to create a Preauthenticated request and <em>state=absent</em> to delete a Preauthenticated request.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>time_expires</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The expiration date for the pre-authenticated request as per RFC 3339. After this date the pre-authenticated request will no longer be valid.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Create Preauthenticated Request for Entire Bucket
+    - name: Create Preauthenticated Request for a Bucket and permit uploading one or more objects to it
+      oci_preauthenticated_request:
+        namespace_name: 'us-example-1'
+        bucket_name: 'ansible_bucket'
+        name: 'ansible_bucket_par'
+        access_type: 'AnyObjectWrite'
+        time_expires: '2018-12-22T00:00:00+00:00'
+        state: 'present'
+
+    # Create Preauthenticated Request for Entire Bucket
+    - name: Create Preauthenticated Request for a specific Object and permit writes to the object
+      oci_preauthenticated_request:
+        namespace_name: 'us-example-1'
+        bucket_name: 'ansible_bucket'
+        object_name: 'ansible_object'
+        name: 'ansible_object_par'
+        access_type: 'ObjectWrite'
+        time_expires: '2018-12-22T00:00:00+00:00'
+        state: 'present'
+
+    # Delete Preauthenticated Request
+    - name: Delete an existing Preauthenticated Request
+      oci_preauthenticated_request:
+        namespace_name: 'us-example-1'
+        bucket_name: 'ansible_bucket'
+        par_id: 'fEbFqu0/thO3JqpA/MRVbD/BpE='
+        state: 'absent'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>preauthenticated_request</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the created Preauthenticated Request. For delete, deleted Preauthenticated Request description will be returned.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'object_name': 'ansible_object', 'name': 'ansible_bucket_par', 'access_type': 'AnyObjectWrite', 'time_expires': '2018-12-23T17:31:35+00:00', 'id': 'EbFqu0/thO3/MRVb/XmZ0iaT6IA=', 'time_created': '2018-12-22T12:04:02.229000+00:00', 'access_uri': '/p/TF0WATak/n/us-example-1/b/ansible_bucket/o/ansible_object'}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>object_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the object that is being granted access to by the pre-authenticated request.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_object</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The user-provided name of the pre-authenticated request.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible_bucker_par</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The date when the pre-authenticated request was created as per specification RFC 3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-12-22 12:04:02.229000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_expires</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The expiration date for the pre-authenticated request as per RFC 3339.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-12-22 00:00:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Preauthenticated Request</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">fEbFqu0/thO3JqpA/MRVbD/BpE=</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>access_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The collection of rules for routing destination IPs to network devices.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AnyObjectWrite</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>access_uri</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The URI to embed in the URL when using the pre-authenticated request.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">/p/TF0WATak6uM7AU4PXA/n/us-example-1/b/ansible_bucket/o/</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_preauthenticated_request.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_route_table_module.rst
+++ b/docs/modules/oci_route_table_module.rst
@@ -141,6 +141,20 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="2">
+                    <b>delete_route_rules</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Delete route rules in existing Route Table which are present in the provided Route Rules. If <em>delete_route_rules=yes</em>, route rules provided by <em>route_rules</em> would be deleted from existing route rules, if they are part of existing route rules. If they are not part of existing route rules, they will be ignored. <em>delete_route_rules</em> and <em>purge_route_rules</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
                     <b>display_name</b>
                                                                             </td>
                                 <td>
@@ -195,7 +209,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>Purge route rules in existing Route Table which are not present in the provided Route Rules. If <em>purge_route_rules=no</em>, provided route rules would be appended to existing route rules.</div>
+                                                                        <div>Purge route rules in existing Route Table which are not present in the provided Route Rules. If <em>purge_route_rules=no</em>, provided route rules would be appended to existing route rules. <em>purge_route_rules</em> and <em>delete_route_rules</em> are mutually exclusive.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -398,6 +412,15 @@ Examples
       oci_route_table:
         rt_id: 'ocid1.routetable..xxxxxEXAMPLExxxxx'
         purge_route_rules: 'yes'
+        route_rules:
+            - cidr_block: '10.0.0.0/12'
+              network_entity_id: 'ocid1.internetgateway..abcd'
+        state: 'present'
+
+    - name: Update a Route Table by deleting route rules
+      oci_route_table:
+        rt_id: 'ocid1.routetable..xxxxxEXAMPLExxxxx'
+        delete_route_rules: 'yes'
         route_rules:
             - cidr_block: '10.0.0.0/12'
               network_entity_id: 'ocid1.internetgateway..abcd'

--- a/docs/modules/oci_security_list_module.rst
+++ b/docs/modules/oci_security_list_module.rst
@@ -140,6 +140,20 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="2">
+                    <b>delete_security_rules</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Delete security rules from existing security list which are present in the security rules provided by <em>ingress_security_rules</em> and/or <em>egress_security_rules</em>. If <em>delete_security_rules=yes</em>, security rules provided by <em>ingress_security_rules</em> and/or <em>egress_security_rules</em> would be deleted to existing security list, if they are part of existing security list. If they are not part of existing security list, they will be ignored. <em>purge_security_rules</em> and <em>delete_security_rules</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
                     <b>display_name</b>
                                                                             </td>
                                 <td>
@@ -396,7 +410,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>Purge security rules  from security list which are not present in the provided group security list. If <em>purge_security_rules=no</em>, provided security rules would be appended to existing security rules.</div>
+                                                                        <div>Purge security rules  from security list which are not present in the provided group security list. If <em>purge_security_rules=no</em>, provided security rules would be appended to existing security rules. <em>purge_security_rules</em> and <em>delete_security_rules</em> are mutually exclusive.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -553,6 +567,20 @@ Examples
                      min: '25'
                      max: '30'
         purge_security_rules: 'yes'
+        state: 'present'
+
+    - name: Update a security list by deleting existing ingress rules
+      oci_security_list:
+        security_list_id: 'ocid1.securitylist.xxxxxEXAMPLExxxxx'
+        ingress_security_rules:
+            - source: '10.0.0.0/8'
+              is_stateless: False
+              protocol: '6'
+              tcp_options:
+                  destination_port_range:
+                     min: '25'
+                     max: '30'
+        delete_security_rules: 'yes'
         state: 'present'
 
     # Delete a security list

--- a/docs/modules/oci_tag_module.rst
+++ b/docs/modules/oci_tag_module.rst
@@ -117,12 +117,32 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>defined_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>description</b>
                                                                             </td>
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
                                                                         <div>A description to be associated with the tag definition during creation. This does not have to be unique, and can be changed later. Required when creating a tag definition with <em>state=present</em> The length of the description must be between 1 and 400 characters.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>freeform_tags</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
                                                                                 </td>
             </tr>
                                 <tr>

--- a/docs/modules/oci_user_module.rst
+++ b/docs/modules/oci_user_module.rst
@@ -163,6 +163,20 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>delete_group_memberships</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Delete groups from existing memberships which are present in group memberships provided by <em>user_groups</em>. If <em>delete_group_memberships=True</em>, groups provided by <em>user_groups</em> would be deleted from existing group memberships, if they are part of existing group memberships. If they are not part of existing group memberships, they will be ignored. <em>delete_group_memberships</em> and <em>purge_group_memberships</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>description</b>
                                                                             </td>
                                 <td>
@@ -216,7 +230,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>Purge groups from existing memberships which are not present in provided group memberships. If <em>purge_group_memberships=False</em>, provided groups would be appended to existing group memberships.</div>
+                                                                        <div>Purge groups from existing memberships which are not present in provided group memberships. If <em>purge_group_memberships=False</em>, provided groups would be appended to existing group memberships. <em>purge_group_memberships</em> and <em>delete_group_memberships</em> are mutually exclusive.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -379,6 +393,15 @@ Examples
           create_or_reset_ui_password: True
           state: 'present'
 
+    - name: Update user by deleting group memberships, after this
+            operation user would not longer be a member of ansible_group_B
+      oci_user:
+          user_id: "ocid1.user..abuwd"
+          description: 'Ansible User'
+          delete_group_memberships: True
+          user_groups: ['ansible_group_B']
+          create_or_reset_ui_password: True
+          state: 'present'
 
     # Delete group
     - name: Delete user with no force

--- a/docs/modules/oci_virtual_circuit_bandwidth_shape_facts_module.rst
+++ b/docs/modules/oci_virtual_circuit_bandwidth_shape_facts_module.rst
@@ -1,0 +1,251 @@
+:source: cloud/oracle/oci_virtual_circuit_bandwidth_shape_facts.py
+
+:orphan:
+
+.. _oci_virtual_circuit_bandwidth_shape_facts_module:
+
+
+oci_virtual_circuit_bandwidth_shape_facts - Fetches details of one or more OCI virtual circuit bandwidth shapes
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of the OCI virtual circuit bandwidth shapes
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which virtual circuit bandwidth shapes exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch All virtual circuit bandwidth shapes under a specific compartment
+    - name: FFetch All virtual circuit bandwidth shapes under a specific compartment
+      oci_virtual_circuit_bandwidth_shape_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_virtual_circuit_bandwidth_shapes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the virtual circuit bandwidth shapes.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'bandwidth_in_mbps': 1000, 'name': '1 Gbps'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>bandwidth_in_mbps</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The bandwidth in Mbps.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The name of the bandwidth shape.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10 Gbps</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_virtual_circuit_bandwidth_shape_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_virtual_circuit_facts_module.rst
+++ b/docs/modules/oci_virtual_circuit_facts_module.rst
@@ -1,0 +1,572 @@
+:source: cloud/oracle/oci_virtual_circuit_facts.py
+
+:orphan:
+
+.. _oci_virtual_circuit_facts_module:
+
+
+oci_virtual_circuit_facts - Fetches details of one or more OCI Virtual Circuits
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of a specified OCI Virtual Circuit or all Virtual Circuit in a specified compartment.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which the specified Virtual Circuit exists</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>PENDING_PROVIDER</li>
+                                                                                                                                                                                                <li>VERIFYING</li>
+                                                                                                                                                                                                <li>PROVISIONING</li>
+                                                                                                                                                                                                <li>PROVISIONED</li>
+                                                                                                                                                                                                <li>FAILED</li>
+                                                                                                                                                                                                <li>INACTIVE</li>
+                                                                                                                                                                                                <li>TERMINATING</li>
+                                                                                                                                                                                                <li>TERMINATED</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>A filter to return only resources that match the given lifecycle state.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>virtual_circuit_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Circuit whose details needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch All Virtual Circuits under a specific compartment
+    - name: Fetch All Virtual Circuits under a specific compartment
+      oci_virtual_circuit_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+    # Fetch All Virtual Circuits under a specific compartment, filtered by
+    # display name and lifecycle state
+    - name: Fetch All Virtual Circuits under a specific compartment, filtered by display name and lifecycle state
+      oci_virtual_circuit_facts:
+          compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+          display_name: 'ansible-virtual-circuit'
+          lifecycle_state: 'PROVISIONED'
+
+    # Fetch a specific Virtual Circuit
+    - name: Fetch a specific Virtual Circuit
+      oci_virtual_circuit_facts:
+          virtual_circuit_id: 'ocid1.virtualcircuit.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_virtual_circuits</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Fetched Virtual Circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'lifecycle_state': 'PROVISIONED', 'customer_bgp_asn': 5, 'time_created': '2018-12-15T12:09:34.999000+00:00', 'bgp_management': 'CUSTOMER_MANAGED', 'region': None, 'id': 'ocid1.virtualcircuit.oc1..xxxxxEXAMPLExxxxx', 'gateway_id': None, 'cross_connect_mappings': [{'cross_connect_or_cross_connect_group_id': 'ocid1.crossconnectgroup.xxxxxEXAMPLExxxxx', 'bgp_md5_auth_key': None, 'vlan': 105, 'customer_bgp_peering_ip': '169.254.203.202/30', 'oracle_bgp_peering_ip': '169.254.203.201/30'}], 'display_name': 'sample-virtual-circuit', 'oracle_bgp_asn': 31898, 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'reference_comment': None, 'provider_service_id': None, 'bandwidth_shape_name': '10 Gbps', 'provider_service_name': None, 'bgp_session_state': 'DOWN', 'provider_state': None, 'service_type': 'COLOCATED', 'provider_name': None, 'type': 'PUBLIC', 'public_prefixes': None}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cross_connect_mappings</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>An array of mappings, each containing properties for a cross-connect or cross-connect group that is associated with this virtual circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'cross_connect_or_cross_connect_group_id': None, 'bgp_md5_auth_key': None, 'vlan': None, 'customer_bgp_peering_ip': '10.0.0.18/31', 'oracle_bgp_peering_ip': '10.0.0.19/31'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>bgp_management</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>BGP management option.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CUSTOMER_MANAGED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Virtual Circuit was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>customer_bgp_asn</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The BGP ASN of the network at the other end of the BGP session from Oracle. If the session is between the customer's edge router and Oracle, the value is the customer's ASN. If the BGP session is between the provider's edge router and Oracle, the value is the provider's ASN.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>region</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Oracle Cloud Infrastructure region where this virtual circuit is located.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">phx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Virtual Circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.virtualcircuit.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>gateway_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the customer's dynamic routing gateway (DRG) that this virtual circuit uses. Applicable only to private virtual circuits.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.drg..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Virtual Circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PROVISIONED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port_speed_shape_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The port speed for this cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10 Gbps</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-virtual-circuit</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>oracle_bgp_asn</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Oracle BGP ASN.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">31898</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the Virtual Circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>reference_comment</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Provider-supplied reference information about this virtual circuit (if the customer is connecting via a provider).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">SAMPLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>provider_service_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the service offered by the provider (if the customer is connecting via a provider).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.providerservice.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>provider_service_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the Provider Service.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Service</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>bgp_session_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The state of the BGP session associated with the virtual circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">UP</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>provider_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The provider's state in relation to this virtual circuit (if the customer is connecting via a provider). ACTIVE means the provider has provisioned the virtual circuit from their end. INACTIVE means the provider has not yet provisioned the virtual circuit, or has de-provisioned it.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">INACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>service_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Provider service type.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">COLOCATED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>provider_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the Provider.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Megaport</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether the virtual circuit supports private or public peering.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PUBLIC</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>public_prefixes</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>For a public virtual circuit. The public IP prefixes (CIDRs) the customer wants to advertise across the connection. Each prefix must be /31 or less specific.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'cidr_block': '10.0.0.10/31'}]</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_virtual_circuit_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_virtual_circuit_module.rst
+++ b/docs/modules/oci_virtual_circuit_module.rst
@@ -1,0 +1,919 @@
+:source: cloud/oracle/oci_virtual_circuit.py
+
+:orphan:
+
+.. _oci_virtual_circuit_module:
+
+
+oci_virtual_circuit - Create, update and delete OCI Virtual Circuit
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Create an OCI Virtual Circuit to use with Oracle Cloud Infrastructure FastConnect
+- Update an OCI Virtual Circuit, if present
+- Delete an OCI Virtual Circuit, if present.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>bandwidth_shape_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The provisioned data rate of the connection.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>compartment_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the compartment under which this Virtual Circuit would be created. Mandatory for create operation.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>cross_connect_mappings</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>An array of mappings, each containing properties for a cross-connect or cross-connect group that is associated with this virtual circuit.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>cross_connect_or_cross_connect_group_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The OCID of the cross-connect or cross-connect group for this mapping. Specified by the owner of the cross-connect or cross-connect group (the customer if the customer is colocated with Oracle, or the provider if the customer is connecting via provider).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>bgp_md5_auth_key</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The key for BGP MD5 authentication. Only applicable if your system requires MD5 authentication. If empty or not set, that means you don't use BGP MD5 authentication.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>vlan</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The number of the specific VLAN (on the cross-connect or cross-connect group) that is assigned to this virtual circuit. Specified by the owner of the cross-connect or cross-connect group (the customer if the customer is colocated with Oracle, or the provider if the customer is connecting via provider).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>customer_bgp_peering_ip</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The BGP IP address for the router on the other end of the BGP session from Oracle. Specified by the owner of that router. If the session goes from Oracle to a customer, this is the BGP IP address of the customer's edge router. If the session goes from Oracle to a provider, this is the BGP IP address of the provider's edge router. Must use a /30 or /31 subnet mask. There's one exception, for a public virtual circuit, Oracle specifies the BGP IP addresses.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>oracle_bgp_peering_ip</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The IP address for Oracle's end of the BGP session. Must use a /30 or /31 subnet mask. If the session goes from Oracle to a customer's edge router, the customer specifies this information. If the session goes from Oracle to a provider's edge router, the provider specifies this. There's one exception, for a public virtual circuit, Oracle specifies the BGP IP addresses.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>customer_bgp_asn</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Your BGP ASN (either public or private). Provide this value only if there's a BGP session that goes from your edge router to Oracle. Otherwise, leave this empty or null.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>delete_cross_connect_mappings</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                        <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Delete any cross connect mappings in the virtual circuit that is specified in <em>cross_connect_mappings</em>. If <em>delete_cross_connect_mappings=yes</em>, cross connect mappings provided by <em>cross_connect_mappings</em> would be deleted from existing cross connect mappings, if they are part of existing cross connect mappings. If they are not part of existing cross connect mappings, they will be ignored. <em>delete_cross_connect_mappings</em> and <em>purge_cross_connect_mappings</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>delete_public_prefixes</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                                                                <b>Default:</b><br/><div style="color: blue">no</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Indicates whether public prefixes associated with a public virtual circuit needs to be deleted. If <em>delete_public_prefixes=false</em>, then input publi prefixes gets added.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>display_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>force_create</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn't create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>gateway_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>For private virtual circuits only. The OCID of the dynamic routing gateway (DRG) that this virtual circuit uses.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>key_by</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>provider_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Deprecated. Instead use provider_service_id.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>provider_service_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the service offered by the provider (if you're connecting via a provider).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>provider_service_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Deprecated. Instead use provider_service_id.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>provider_state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>ACTIVE</li>
+                                                                                                                                                                                                <li>INACTIVE</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The provider's state in relation to this virtual circuit. Relevant only if the customer is using FastConnect via a provider. ACTIVE means the provider has provisioned the virtual circuit from their end. INACTIVE means the provider has not yet provisioned the virtual circuit, or has de-provisioned it.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>public_prefixes</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>For a public virtual circuit. The public IP prefixes (CIDRs) the customer wants to advertise across the connection.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>cidr_block</b>
+                                        <br/><div style="font-size: small; color: red">required</div>                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>An individual public IP prefix (CIDR) to add to the public virtual circuit. Must be /31 or less specific.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <b>purge_cross_connect_mappings</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Purge cross connect mappings from virtual circuit which are not present in the provided cross connect mappings list.If <em>purge_cross_connect_mappings=no</em>, provided cross connect mappings would be appended to existing cross connect mappings. <em>purge_cross_connect_mappings</em> and <em>delete_cross_connect_mappings</em> are mutually exclusive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>reference_comment</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Provider-supplied reference information about this virtual circuit. Relevant only if the customer is using FastConnect via a provider. To be updated only by the provider.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region where this virtual circuit is located.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>absent</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Create,update or delete cross-connect group. For <em>state=present</em>, if it does not exists, it gets created. If exists, it gets updated.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>PUBLIC</li>
+                                                                                                                                                                                                <li>PRIVATE</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of IP addresses used in this virtual circuit. PRIVATE means RFC 1918 addresses (10.0.0.0/8, 172.16/12, and 192.168/16). Only PRIVATE is supported.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>virtual_circuit_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Circuit. Mandatory for delete and update.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait</b>
+                    <br/><div style="font-size: small; color: red">bool</div>                                                        </td>
+                                <td>
+                                                                                                                                                                                                                    <ul><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to wait for create or delete operation to complete.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_timeout</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>Time, in seconds, to wait when <em>wait=yes</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <b>wait_until</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The lifecycle state to wait for the resource to transition into when <em>wait=yes</em>. By default, when <em>wait=yes</em>, we wait for the resource to get into ACTIVE/ATTACHED/AVAILABLE/PROVISIONED/ RUNNING applicable lifecycle state during create operation &amp; to get into DELETED/DETACHED/ TERMINATED lifecycle state during delete operation.</div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Create a new colocated Virtual Circuit
+    - name: Create a new colocated Virtual Circuit
+      oci_virtual_circuit:
+          compartment_id: 'ocid1.compartment..xxxxxEXAMPLExxxxx'
+          display_name: 'ansible-virtual-circuit'
+          cross_connect_mappings:
+                - cross_connect_or_cross_connect_group_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+                  vlan: 100
+          public_prefixes:
+                 - 206.209.218.0/24
+          customer_bgp_asn: 5
+          type: 'PUBLIC'
+          port_speed_shape_name: '10 Gbps'
+          state: 'present'
+
+    # Create a new colocated Virtual Circuit
+    - name: Create a new colocated Virtual Circuit of private type
+      oci_virtual_circuit:
+          compartment_id: 'ocid1.compartment..xxxxxEXAMPLExxxxx'
+          display_name: 'ansible-virtual-circuit-private'
+          cross_connect_mappings:
+                - cross_connect_or_cross_connect_group_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+                  customer_bgp_peering_ip: '10.0.0.18/31'
+                  oracle_bgp_peering_ip: '10.0.0.19/31'
+                  vlan: 100
+          customer_bgp_asn: 5
+          type: 'PRIVATE'
+          port_speed_shape_name: '10 Gbps'
+          state: 'present'
+
+    # Create a Virtual Circuit using Provider
+    - name: Create a Virtual Circuit using Provider
+      oci_virtual_circuit:
+          compartment_id: 'ocid1.compartment..xxxxxEXAMPLExxxxx'
+          display_name: 'ansible-virtual-circuit'
+          provider_service_id: 'ocid1.providerservice...xxxxxEXAMPLExxxxx'
+          customer_bgp_asn: 5
+          type: 'PUBLIC'
+          port_speed_shape_name: '10 Gbps'
+          state: 'present'
+
+    # Update an existing Virtual Circuit's Cross Connect Mappings
+    - name: Update an existing Virtual Circuit's Cross Connect Mappings
+      oci_virtual_circuit:
+          virtual_circuit_id: 'ocid1.virtualcircuit..xxxxxEXAMPLExxxxx'
+          cross_connect_mappings:
+                - cross_connect_or_cross_connect_group_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+                  vlan: 105
+          state: 'present'
+
+    # Update an existing Virtual Circuit's Cross Connect Mappings by appending new Cross Connect Mappings
+    - name: Update an existing Virtual Circuit's Cross Connect Mappings by appending new Cross Connect Mappings
+      oci_virtual_circuit:
+          virtual_circuit_id: 'ocid1.virtualcircuit..xxxxxEXAMPLExxxxx'
+          cross_connect_mappings:
+                - cross_connect_or_cross_connect_group_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+                  vlan: 100
+          purge_cross_connect_mappings: false
+          state: 'present'
+
+    # Update an existing Virtual Circuit's Cross Connect Mappings by deleting a Cross Connect Mappings
+    - name: Update an existing Virtual Circuit's Cross Connect Mappings by deleting a Cross Connect Mappings
+      oci_virtual_circuit:
+          virtual_circuit_id: 'ocid1.virtualcircuit..xxxxxEXAMPLExxxxx'
+          cross_connect_mappings:
+                - cross_connect_or_cross_connect_group_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+                  vlan: 100
+          delete_cross_connect_mappings: false
+          state: 'present'
+
+    # Update an existing Virtual Circuit by deleting Public Prefixes
+    - name: Update an existing Virtual Circuit by deleting Public Prefixes
+      oci_virtual_circuit:
+          virtual_circuit_id: 'ocid1.virtualcircuit..xxxxxEXAMPLExxxxx'
+          public_prefixes:
+                - '10.0.0.21/31'
+          delete_public_prefixes: true
+          state: 'present'
+
+    # Delete Virtual Circuit
+    - name: Delete Virtual Circuit
+      oci_virtual_circuit:
+          virtual_circuit_id: 'ocid1.virtualcircuit..xxxxxEXAMPLExxxxx'
+          state: 'absent'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_virtual_circuit</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Virtual Circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{'lifecycle_state': 'PROVISIONED', 'customer_bgp_asn': 5, 'time_created': '2018-12-15T12:09:34.999000+00:00', 'bgp_management': 'CUSTOMER_MANAGED', 'region': None, 'id': 'ocid1.virtualcircuit.oc1..xxxxxEXAMPLExxxxx', 'gateway_id': None, 'cross_connect_mappings': [{'cross_connect_or_cross_connect_group_id': 'ocid1.crossconnectgroup.xxxxxEXAMPLExxxxx', 'bgp_md5_auth_key': None, 'vlan': 105, 'customer_bgp_peering_ip': '169.254.203.202/30', 'oracle_bgp_peering_ip': '169.254.203.201/30'}], 'display_name': 'sample-virtual-circuit', 'oracle_bgp_asn': 31898, 'compartment_id': 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx', 'reference_comment': None, 'provider_service_id': None, 'bandwidth_shape_name': '10 Gbps', 'provider_service_name': None, 'bgp_session_state': 'DOWN', 'provider_state': None, 'service_type': 'COLOCATED', 'provider_name': None, 'type': 'PUBLIC', 'public_prefixes': None}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cross_connect_mappings</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>An array of mappings, each containing properties for a cross-connect or cross-connect group that is associated with this virtual circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'cross_connect_or_cross_connect_group_id': None, 'bgp_md5_auth_key': None, 'vlan': None, 'customer_bgp_peering_ip': '10.0.0.18/31', 'oracle_bgp_peering_ip': '10.0.0.19/31'}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>bgp_management</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>BGP management option.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CUSTOMER_MANAGED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <br/><div style="font-size: small; color: red">datetime</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Date and time when the Virtual Circuit was created, in the format defined by RFC3339</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>customer_bgp_asn</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The BGP ASN of the network at the other end of the BGP session from Oracle. If the session is between the customer's edge router and Oracle, the value is the customer's ASN. If the BGP session is between the provider's edge router and Oracle, the value is the provider's ASN.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>region</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Oracle Cloud Infrastructure region where this virtual circuit is located.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">phx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Identifier of the Virtual Circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.virtualcircuit.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>gateway_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the customer's dynamic routing gateway (DRG) that this virtual circuit uses. Applicable only to private virtual circuits.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.drg..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The current state of the Virtual Circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PROVISIONED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port_speed_shape_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The port speed for this cross-connect.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10 Gbps</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansible-virtual-circuit</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>oracle_bgp_asn</b>
+                    <br/><div style="font-size: small; color: red">int</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The Oracle BGP ASN.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">31898</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the compartment containing the Virtual Circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>reference_comment</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Provider-supplied reference information about this virtual circuit (if the customer is connecting via a provider).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">SAMPLE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>provider_service_id</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The OCID of the service offered by the provider (if the customer is connecting via a provider).</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.providerservice.oc1..xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>provider_service_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the Provider Service.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Service</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>bgp_session_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The state of the BGP session associated with the virtual circuit.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">UP</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>provider_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>The provider's state in relation to this virtual circuit (if the customer is connecting via a provider). ACTIVE means the provider has provisioned the virtual circuit from their end. INACTIVE means the provider has not yet provisioned the virtual circuit, or has de-provisioned it.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">INACTIVE</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>service_type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Provider service type.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">COLOCATED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>provider_name</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Name of the Provider.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Megaport</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>type</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Whether the virtual circuit supports private or public peering.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PUBLIC</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>public_prefixes</b>
+                    <br/><div style="font-size: small; color: red">list</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>For a public virtual circuit. The public IP prefixes (CIDRs) the customer wants to advertise across the connection. Each prefix must be /31 or less specific.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'cidr_block': '10.0.0.10/31'}]</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_virtual_circuit.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_virtual_circuit_public_prefix_facts_module.rst
+++ b/docs/modules/oci_virtual_circuit_public_prefix_facts_module.rst
@@ -1,0 +1,275 @@
+:source: cloud/oracle/oci_virtual_circuit_public_prefix_facts.py
+
+:orphan:
+
+.. _oci_virtual_circuit_public_prefix_facts_module:
+
+
+oci_virtual_circuit_public_prefix_facts - Fetches details of one or more OCI Virtual Circuit Public Prefixes
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Synopsis
+--------
+- Fetches details of all Virtual Circuit Public Prefixes of a specified Virtual Circuit.
+
+
+
+Requirements
+~~~~~~~~~~~~
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user's OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair's fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this 'auth_type' module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">DEFAULT</div>
+                                    </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>verification_state</b>
+                                                                            </td>
+                                <td>
+                                                                                                                            <ul><b>Choices:</b>
+                                                                                                                                                                <li>IN_PROGRESS</li>
+                                                                                                                                                                                                <li>COMPLETED</li>
+                                                                                                                                                                                                <li>FAILED</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>A filter to return only resources that match the given verification state.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>virtual_circuit_id</b>
+                                                                            </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Identifier of the Virtual Circuit whose Public Prefixes needs to be fetched.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+    - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Note: These examples do not set authentication details.
+    # Fetch All Virtual Circuit Public Prefixes of a specific Virtual Circuit
+    - name: Fetch All Virtual Circuit Public Prefixes of a specific Virtual Circuit
+      oci_virtual_circuit_public_prefix_facts:
+          virtual_circuit_id: 'ocid1.virtualcircuit.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+    # Fetch All Virtual Circuit Public Prefixes of a specific Virtual Circuit, filtered by
+    # verification state
+    - name: Fetch All Virtual Circuits under a specific compartment, filtered by display name and lifecycle state
+      oci_virtual_circuit_public_prefix_facts:
+          virtual_circuit_id: 'ocid1.virtualcircuit.oc1.iad.xxxxxEXAMPLExxxxx'
+          verification_state: 'COMPLETED'
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <b>oci_virtual_circuit_public_prefixes</b>
+                    <br/><div style="font-size: small; color: red">complex</div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Attributes of the Fetched Virtual Circuit Public Prefixes.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{'verification_state': 'COMPLETED', 'cidr_block': '10.0.0.20/31'}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>verification_state</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Oracle must verify that the customer owns the public IP prefix before traffic for that prefix can flow across the virtual circuit. Verification can take a few business days. IN_PROGRESS means Oracle is verifying the prefix. COMPLETED means verification succeeded. FAILED means verification failed and traffic for this prefix will not flow across the connection.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">COMPLETED</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>cidr_block</b>
+                    <br/><div style="font-size: small; color: red">string</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Publix IP prefix (CIDR) that the customer specified.</div>
+                                        <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10.0.0.21/31</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+This module is flagged as **preview** which means that it is not guaranteed to have a backwards compatible interface.
+
+
+
+Author
+~~~~~~
+
+- Debayan Gupta(@debayan_gupta)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_virtual_circuit_public_prefix_facts.py?description=%3C!---%20Your%20description%20here%20--%3E%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -48,6 +48,7 @@ In the current version of the OCI Ansible modules, the following Services are su
 - Object Storage
 - File Storage
 - Email Delivery
+- Search
 
 Support for the following Services are not yet implemented. They would be implemented in future releases.
 - Audit

--- a/install.py
+++ b/install.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
 
-'''
-Oracle Cloud Infrastructure(OCI) Ansible Role Installer Script
+"""
+Oracle Cloud Infrastructure(OCI) Ansible Modules Installer Script
 ==============================================================
 This installer script installs OCI Ansible cloud modules, its documentation fragments and utility classes in the
 standard Ansible module library paths. You must have write permissions to the default Ansible installation module
 library directory to run this script.
 
-To install the OCI Ansible role, execute:
+To install OCI Ansible modules, execute:
 $ ./install.py
 To execute the script with debug messages, execute:
 $ ./install.py --debug
 
 author: "Rohit Chaware (@rohitChaware)"
-'''
+"""
 
 from __future__ import print_function
 import argparse
@@ -29,19 +29,28 @@ import sys
 
 try:
     import ansible
+
     ANSIBLE_IS_INSTALLED = True
 except ImportError:
     ANSIBLE_IS_INSTALLED = False
 
+import pkg_resources
+
 debug = False
+
+MIN_OCI_PYTHON_SDK_REQUIRED = "2.1.3"
 
 
 def parse_cli_args():
-    parser = argparse.ArgumentParser(description='Script to install oci-ansible-role')
-    parser.add_argument('--debug',
-                        action='store_true',
-                        default=False,
-                        help='Send debug messages to STDERR')
+    parser = argparse.ArgumentParser(
+        description="Script to install oci-ansible-modules"
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Send debug messages to STDERR",
+    )
     return parser.parse_args()
 
 
@@ -52,8 +61,30 @@ def log(*args, **kwargs):
 
 def main():
     if not ANSIBLE_IS_INSTALLED:
-        print("Could not load ansible module. To install ansible, use <pip install ansible>.")
+        print(
+            "Could not load ansible module. To install ansible, use <pip install ansible>."
+        )
         sys.exit(1)
+
+    installed_packages = dict(
+        [(pkg.project_name, pkg.version) for pkg in pkg_resources.working_set]
+    )
+
+    if "oci" not in installed_packages:
+        print(
+            "OCI Python SDK version-{0} is required for using oci-ansible-modules. To install OCI Python SDK, use"
+            " < pip install oci=={0} >.".format(MIN_OCI_PYTHON_SDK_REQUIRED)
+        )
+        sys.exit(1)
+
+    elif installed_packages["oci"] < MIN_OCI_PYTHON_SDK_REQUIRED:
+        print(
+            "Please install version >= {0} of OCI Python SDK. Use < pip install oci=={0} >.".format(
+                MIN_OCI_PYTHON_SDK_REQUIRED
+            )
+        )
+        sys.exit(1)
+
     global debug
     args = parse_cli_args()
     if args.debug:
@@ -62,7 +93,7 @@ def main():
     ansible_path = os.path.dirname(os.path.abspath(os.path.realpath(ansible.__file__)))
     log("Ansible path: {}".format(ansible_path))
 
-    module_utils_path = os.path.join(ansible_path, 'module_utils')
+    module_utils_path = os.path.join(ansible_path, "module_utils")
     if not os.path.exists(module_utils_path):
         print("Module utilities directory {} does not exist.".format(module_utils_path))
         sys.exit(1)
@@ -71,39 +102,63 @@ def main():
         sys.exit(1)
     log("Module utilities path: {}".format(module_utils_path))
 
-    document_fragments_path = os.path.join(ansible_path, 'utils', 'module_docs_fragments')
+    document_fragments_path = os.path.join(
+        ansible_path, "utils", "module_docs_fragments"
+    )
     if not os.path.exists(document_fragments_path):
-        print("Documentation fragments directory {} does not exist".format(document_fragments_path))
+        print(
+            "Documentation fragments directory {} does not exist".format(
+                document_fragments_path
+            )
+        )
         sys.exit(1)
     if not os.path.isdir(document_fragments_path):
-        print("Documentation fragments path {} is not a directory".format(document_fragments_path))
+        print(
+            "Documentation fragments path {} is not a directory".format(
+                document_fragments_path
+            )
+        )
         sys.exit(1)
     log("Documentation fragments path: {}".format(document_fragments_path))
 
     current_path = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
 
-    doc_src_path = os.path.join(current_path, 'module_docs_fragments')
-    print("Copying documentation fragments from {} to {}".format(doc_src_path, document_fragments_path))
+    doc_src_path = os.path.join(current_path, "module_docs_fragments")
+    print(
+        "Copying documentation fragments from {} to {}".format(
+            doc_src_path, document_fragments_path
+        )
+    )
     copy_files(os.listdir(doc_src_path), doc_src_path, document_fragments_path)
 
-    utilities_src_path = os.path.join(current_path, 'module_utils', 'oracle')
+    utilities_src_path = os.path.join(current_path, "module_utils", "oracle")
     utilities_dest_path = os.path.join(module_utils_path, "oracle")
     if not os.path.exists(utilities_dest_path):
         os.mkdir(utilities_dest_path)
-    print("Copying oracle utility files from {} to {}".format(utilities_src_path, utilities_dest_path))
+    print(
+        "Copying oracle utility files from {} to {}".format(
+            utilities_src_path, utilities_dest_path
+        )
+    )
     copy_files(os.listdir(utilities_src_path), utilities_src_path, utilities_dest_path)
 
-    oracle_module_dir_path = os.path.join(ansible_path, 'modules', 'cloud', 'oracle')
+    oracle_module_dir_path = os.path.join(ansible_path, "modules", "cloud", "oracle")
     if not os.path.exists(oracle_module_dir_path):
         print("Creating directory {}".format(oracle_module_dir_path))
         os.mkdir(oracle_module_dir_path)
 
-    # Modules in oci-ansible-role are stored in library directory.
-    roles_library_path = os.path.join(current_path, 'library')
+    # Modules in oci-ansible-modules are stored in library directory.
+    roles_library_path = os.path.join(current_path, "library")
     log("Roles library path: {}".format(roles_library_path))
 
-    print("Copying OCI Ansible modules from {} to {}".format(roles_library_path, oracle_module_dir_path))
-    copy_files(os.listdir(roles_library_path), roles_library_path, oracle_module_dir_path)
+    print(
+        "Copying OCI Ansible modules from {} to {}".format(
+            roles_library_path, oracle_module_dir_path
+        )
+    )
+    copy_files(
+        os.listdir(roles_library_path), roles_library_path, oracle_module_dir_path
+    )
 
     print("OCI Ansible modules installed successfully.")
 
@@ -122,5 +177,5 @@ def copy_files(files, src_dir, dest_dir):
             shutil.copy(src_file_path, dest_file_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/inventory-script/oci_inventory.ini
+++ b/inventory-script/oci_inventory.ini
@@ -1,6 +1,6 @@
 # Ansible OCI external inventory script settings.
 
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -16,6 +16,14 @@
 # Specify name of the configuration profile to use.
 profile = DEFAULT
 
+# OCI regions from which to build the inventory. Please specify 'all' to build inventory
+# from all the subscribed regions. Default is to build inventory from only the region
+# specified in the configuration.
+# regions = us-ashburn-1,us-phoenix-1
+
+# OCI regions to skip while building the inventory.
+# exclude_regions = us-frankfurt-1
+
 # Name of the compartment whose dynamic inventory is to be obtained. This parameter is optional.
 # If no value is provided for compartment, dynamic inventory for the entire tenancy is obtained.
 # compartment = AnsibleTestCompartment
@@ -28,8 +36,8 @@ profile = DEFAULT
 # fetch_hosts_from_subcompartments = False
 
 # To reuse a recent discovered inventory and avoid API calls to OCI, we cache the results of
-# an API call. Set this to the path you want the cache files to be written to. A cache file named
-# "ansible-oci.cache" will be written to this directory.
+# an API call. Set this to the path you want the cache files to be written to. A cache file
+# will be written to this directory.
 cache_dir = .
 
 # The number of seconds a cache file is considered valid. After the specified time period elapses,

--- a/library/oci_backup_facts.py
+++ b/library/oci_backup_facts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -173,7 +173,7 @@ def list_backups(db_client, module):
             existing_backups = oci_utils.list_all_resources(
                 db_client.list_backups,
                 database_id=database_id,
-                display_name=module.params["display_name"],
+                display_name=module.params.get("display_name"),
             )
         elif compartment_id:
             get_logger().debug(
@@ -182,7 +182,7 @@ def list_backups(db_client, module):
             existing_backups = oci_utils.list_all_resources(
                 db_client.list_backups,
                 compartment_id=compartment_id,
-                display_name=module.params["display_name"],
+                display_name=module.params.get("display_name"),
             )
     except ServiceError as ex:
         get_logger().error("Unable to list Database Backups due to %s", ex.message)

--- a/library/oci_console_history_content_facts.py
+++ b/library/oci_console_history_content_facts.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -66,6 +66,7 @@ console_history_content:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.oracle import oci_utils
+from ansible.module_utils._text import to_bytes
 import os
 
 try:
@@ -113,7 +114,7 @@ def main():
             **optional_kwargs
         ).data
         dest = module.params["dest"]
-        if module.params.get("force") or not os.path.isfile(dest):
+        if module.params.get("force") or not os.path.isfile(to_bytes(dest)):
             oci_utils.write_to_file(dest, console_history_data)
         else:
             module.fail_json(

--- a/library/oci_cross_connect.py
+++ b/library/oci_cross_connect.py
@@ -1,0 +1,313 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_cross_connect
+short_description: Create,update and delete OCI cross-connects
+description:
+    - Create an OCI cross-connect
+    - Update an OCI cross-connect, if present, with a new display name
+    - Activate an OCI cross-connect
+    - Delete an OCI cross-connect, if present.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: Identifier of the compartment under which this cross-connect would be created. Mandatory for
+                     create operation. Mutually exclusive with I(cross_connect_id).
+        required: false
+    cross_connect_group_id:
+        description: The OCID of the cross-connect group to put this cross-connect in.
+        required: false
+    cross_connect_id:
+        description: Identifier of the cross-connect. Mandatory for delete and update.
+        required: false
+        aliases: ['id']
+    display_name:
+        description: A user-friendly name. Does not have to be unique, and it's changeable.
+                     Avoid entering confidential information.
+        required: false
+        aliases: ['name']
+    far_cross_connect_or_cross_connect_group_id:
+        description: If you already have an existing cross-connect or cross-connect group at this FastConnect location,
+                     and you want this new cross-connect to be on a different router (for the purposes of redundancy),
+                     provide the OCID of that existing cross-connect or cross-connect group.
+        required: false
+    near_cross_connect_or_cross_connect_group_id:
+        description: If you already have an existing cross-connect or cross-connect group at this FastConnect location,
+                     and you want this new cross-connect to be on the same router, provide the OCID of that existing
+                     cross-connect or cross-connect group.
+        required: false
+    location_name:
+        description: The name of the FastConnect location where this cross-connect will be installed.
+        required: false
+    port_speed_shape_name:
+        description: The port speed for this cross-connect.
+        required: false
+    is_active:
+        description: Set to true to activate the cross-connect. You activate it after the physical cabling is complete,
+                     and you've confirmed the cross-connect's light levels are good and your side of the interface is up.
+                     Activation indicates to Oracle that the physical connection is ready.
+        required: false
+    state:
+        description: Create,update or delete cross-connect. For I(state=present), if it
+                     does not exists, it gets created. If exists, it gets updated.
+        required: false
+        default: 'present'
+        choices: ['present','absent']
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle, oracle_wait_options, oracle_creatable_resource ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Create a new cross-connect
+- name: Create a new cross-connect
+  oci_cross_connect:
+      compartment_id: 'ocid1.compartment..xxxxxEXAMPLExxxxx'
+      display_name: 'ansible-cross-connect'
+      cross_connect_group_id: 'ocid1.crossconnectgroup..xvdf'
+      far_cross_connect_or_cross_connect_group_id: 'ocid1.crossconnect..xxxxxEXAMPLExxxxx'
+      location_name: 'EXAMPLE LOCATION'
+      port_speed_shape_name: '10 Gbps'
+      state: 'present'
+
+# Update an existing cross-connect's display Name
+- name: Update an existing cross-connect's display Name
+  oci_cross_connect:
+      cross_connect_id: 'ocid1.crossconnect..xxxxxEXAMPLExxxxx'
+      display_name: 'cross-connect-updated'
+      state: 'present'
+
+# Activate a cross-connect
+- name: Update cross-connect Active state
+  oci_cross_connect:
+      cross_connect_id: 'ocid1.crossconnect..xxxxxEXAMPLExxxxx'
+      is_active: True
+      state: 'present'
+
+# Delete a cross-connect
+- name: Delete cross-connect
+  oci_cross_connect:
+      cross_connect_id: 'ocid1.crossconnect..xxxxxEXAMPLExxxxx'
+      state: 'absent'
+"""
+
+RETURN = """
+    cross_connect:
+        description: Attributes of the cross-connect.
+        returned: success
+        type: complex
+        contains:
+            compartment_id:
+                description: The OCID of the compartment containing the cross-connect group.
+                returned: always
+                type: string
+                sample: ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx
+            cross_connect_group_id:
+                description: The OCID of the cross-connect group this cross-connect belongs to (if any).
+                returned: always
+                type: string
+                sample: ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx
+            display_name:
+                description: A user-friendly name. Does not have to be unique, and it's changeable.
+                             Avoid entering confidential information.
+                returned: always
+                type: string
+                sample: ansible-cross-connect
+            id:
+                description: Identifier of the cross-connect.
+                returned: always
+                type: string
+                sample: ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx
+            time_created:
+                description: Date and time when the cross-connect was created, in
+                             the format defined by RFC3339
+                returned: always
+                type: datetime
+                sample: 2016-08-25T21:10:29.600Z
+            lifecycle_state:
+                description: The current state of the cross-connect.
+                returned: always
+                type: string
+                sample: PROVISIONED
+            location_name:
+                description: The name of the FastConnect location where this cross-connect is installed.
+                returned: always
+                type: string
+                sample: EXAMPLE LOCATION
+            port_name:
+                description: A string identifying the meet-me room port for this cross-connect.
+                returned: always
+                type: string
+                sample: EXAMPLE
+            port_speed_shape_name:
+                description: The port speed for this cross-connect.
+                returned: always
+                type: string
+                sample: 10 Gbps
+        sample: {
+                    "compartment_id":"ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "cross_connect_group_id":"ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "display_name":"ansible-cross-connect",
+                    "id":"ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "lifecycle_state":"PROVISIONING",
+                    "location_name":"EXAMPLE LOCATION",
+                    "port_name":"EXAMPLE PORT",
+                    "port_speed_shape_name":"10 Gbps",
+                    "time_created":"2018-03-03T06:55:49.463000+00:00"
+                }
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+    from oci.core.models import CreateCrossConnectDetails, UpdateCrossConnectDetails
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def create_or_update_cross_connect(virtual_network_client, module):
+    result = dict(changed=False, cross_connect="")
+    cross_connect_id = module.params.get("cross_connect_id")
+    exclude_attributes = {"display_name": True}
+    try:
+        if cross_connect_id:
+            existing_cross_connect = oci_utils.get_existing_resource(
+                virtual_network_client.get_cross_connect,
+                module,
+                cross_connect_id=cross_connect_id,
+            )
+            result = update_cross_connect(
+                virtual_network_client, existing_cross_connect, module
+            )
+        else:
+            result = oci_utils.check_and_create_resource(
+                resource_type="cross_connect",
+                create_fn=create_cross_connect,
+                kwargs_create={
+                    "virtual_network_client": virtual_network_client,
+                    "module": module,
+                },
+                list_fn=virtual_network_client.list_cross_connects,
+                kwargs_list={"compartment_id": module.params.get("compartment_id")},
+                module=module,
+                exclude_attributes=exclude_attributes,
+                model=CreateCrossConnectDetails(),
+            )
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    except MaximumWaitTimeExceeded as ex:
+        module.fail_json(msg=str(ex))
+
+    return result
+
+
+def create_cross_connect(virtual_network_client, module):
+    create_cross_connect_details = CreateCrossConnectDetails()
+    for attribute in create_cross_connect_details.attribute_map:
+        create_cross_connect_details.__setattr__(
+            attribute, module.params.get(attribute)
+        )
+    result = oci_utils.create_and_wait(
+        resource_type="cross_connect",
+        create_fn=virtual_network_client.create_cross_connect,
+        kwargs_create={"create_cross_connect_details": create_cross_connect_details},
+        client=virtual_network_client,
+        get_fn=virtual_network_client.get_cross_connect,
+        get_param="cross_connect_id",
+        module=module,
+        states=["PENDING_CUSTOMER", "PENDING_PROVIDER", "PROVISIONED"],
+    )
+    return result
+
+
+def update_cross_connect(virtual_network_client, existing_cross_connect, module):
+    result = oci_utils.check_and_update_resource(
+        resource_type="cross_connect",
+        get_fn=virtual_network_client.get_cross_connect,
+        kwargs_get={"cross_connect_id": module.params["cross_connect_id"]},
+        update_fn=virtual_network_client.update_cross_connect,
+        primitive_params_update=["cross_connect_id"],
+        kwargs_non_primitive_update={
+            UpdateCrossConnectDetails: "update_cross_connect_details"
+        },
+        module=module,
+        update_attributes=UpdateCrossConnectDetails().attribute_map.keys(),
+        states=["PENDING_CUSTOMER", "PENDING_PROVIDER", "PROVISIONED"],
+    )
+    return result
+
+
+def delete_cross_connect(virtual_network_client, module):
+    return oci_utils.delete_and_wait(
+        resource_type="cross_connect",
+        client=virtual_network_client,
+        get_fn=virtual_network_client.get_cross_connect,
+        kwargs_get={"cross_connect_id": module.params["cross_connect_id"]},
+        delete_fn=virtual_network_client.delete_cross_connect,
+        kwargs_delete={"cross_connect_id": module.params["cross_connect_id"]},
+        module=module,
+    )
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec(
+        supports_create=True, supports_wait=True
+    )
+    module_args.update(
+        compartment_id=dict(type="str", required=False),
+        display_name=dict(type="str", required=False, aliases=["name"]),
+        cross_connect_group_id=dict(type="str", required=False),
+        cross_connect_id=dict(type="str", required=False, aliases=["id"]),
+        state=dict(
+            type="str", required=False, default="present", choices=["present", "absent"]
+        ),
+        far_cross_connect_or_cross_connect_group_id=dict(type="str", required=False),
+        near_cross_connect_or_cross_connect_group_id=dict(type="str", required=False),
+        location_name=dict(type="str", required=False),
+        port_speed_shape_name=dict(type="str", required=False),
+        is_active=dict(type=bool, required=False),
+    )
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    state = module.params["state"]
+
+    if state == "present":
+        result = create_or_update_cross_connect(virtual_network_client, module)
+    elif state == "absent":
+        result = delete_cross_connect(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_cross_connect_facts.py
+++ b/library/oci_cross_connect_facts.py
@@ -1,0 +1,239 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_cross_connect_facts
+short_description: Fetches details of one or more OCI cross-connects
+description:
+     - Fetches details of a specified OCI cross-connect or all cross-connects in a specified compartment or
+       cross-connect group.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: Identifier of the compartment under which the specified cross-connect exists
+        required: false
+    cross_connect_group_id:
+        description: Identifier of the cross-connect group under  which the specified cross-connect exists
+        required: false
+    cross_connect_id:
+        description: Identifier of the cross-connect whose details needs to be fetched
+        required: false
+        aliases: ['id']
+    lifecycle_state:
+        description: A filter to only return resources that match the given lifecycle state.  The state value is
+                     case-insensitive. Allowed values are "PENDING_CUSTOMER", "PROVISIONING", "PROVISIONED", "INACTIVE",
+                     "TERMINATING", "TERMINATED"
+        required: false
+        choices: ["PENDING_CUSTOMER", "PROVISIONING", "PROVISIONED", "INACTIVE", "TERMINATING", "TERMINATED"]
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle, oracle_display_name_option  ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch All cross-connects under a specific compartment
+- name: Fetch All cross-connects under a specific compartment
+  oci_cross_connect_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+# Fetch All cross-connects under a specific cross-connect Group
+- name: Fetch All cross-connects under a specific cross-connect Group
+  oci_cross_connect_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+      cross_connect_group_id: 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx'
+
+# Fetch All cross-connects under a specific cross-connect Group, filtered by
+# display name and lifecycle state
+- name: Fetch All cross-connects under a specific cross-connect Group, filtered by display name and lifecycle state
+  oci_cross_connect_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+      cross_connect_group_id: 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx'
+      display_name: 'ansible-cross-connect'
+      lifecycle_state: 'PROVISIOING'
+
+# Fetch a specific cross-connect
+- name: Fetch a specific cross-connect
+  oci_cross_connect_facts:
+      cross_connect_id: 'ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx'
+"""
+
+RETURN = """
+    oci_cross_connects:
+        description: Attributes of the cross-connect.
+        returned: success
+        type: complex
+        contains:
+            compartment_id:
+                description: The OCID of the compartment containing the cross-connect group.
+                returned: always
+                type: string
+                sample: ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx
+            cross_connect_group_id:
+                description: The OCID of the cross-connect group this cross-connect belongs to (if any).
+                returned: always
+                type: string
+                sample: ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx
+            display_name:
+                description: A user-friendly name. Does not have to be unique, and it's changeable.
+                             Avoid entering confidential information.
+                returned: always
+                type: string
+                sample: ansible-cross-connect
+            id:
+                description: Identifier of the cross-connect.
+                returned: always
+                type: string
+                sample: ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx
+            time_created:
+                description: Date and time when the cross-connect was created, in
+                             the format defined by RFC3339
+                returned: always
+                type: datetime
+                sample: 2016-08-25T21:10:29.600Z
+            lifecycle_state:
+                description: The current state of the cross-connect.
+                returned: always
+                type: string
+                sample: PROVISIONED
+            location_name:
+                description: The name of the FastConnect location where this cross-connect is installed.
+                returned: always
+                type: string
+                sample: EXAMPLE LOCATION
+            port_name:
+                description: A string identifying the meet-me room port for this cross-connect.
+                returned: always
+                type: string
+                sample: EXAMPLE
+            port_speed_shape_name:
+                description: The port speed for this cross-connect.
+                returned: always
+                type: string
+                sample: 10 Gbps
+        sample: [{
+                    "compartment_id":"ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "cross_connect_group_id":"ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "display_name":"ansible-cross-connect",
+                    "id":"ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "lifecycle_state":"PROVISIONING",
+                    "location_name":"EXAMPLE LOCATION",
+                    "port_name":"EXAMPLE PORT",
+                    "port_speed_shape_name":"10 Gbps",
+                    "time_created":"2018-03-03T06:55:49.463000+00:00"
+                },
+                {
+                    "compartment_id":"ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "cross_connect_group_id":"ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "display_name":"test-cross-connect",
+                    "id":"ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "lifecycle_state":"PROVISIONING",
+                    "location_name":"TEST LOCATION",
+                    "port_name":"TEST PORT",
+                    "port_speed_shape_name":"10 Gbps",
+                    "time_created":"2018-03-04T06:55:49.463000+00:00"
+                }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def list_cross_connects(virtual_network_client, module):
+    result = dict(cross_connects="")
+    compartment_id = module.params.get("compartment_id")
+    cross_connect_id = module.params.get("cross_connect_id")
+    try:
+        if compartment_id:
+            optional_list_method_params = [
+                "display_name",
+                "cross_connect_group_id",
+                "lifecycle_state",
+            ]
+            optional_kwargs = {
+                param: module.params[param]
+                for param in optional_list_method_params
+                if module.params.get(param) is not None
+            }
+            existing_cross_connects = oci_utils.list_all_resources(
+                virtual_network_client.list_cross_connects,
+                compartment_id=compartment_id,
+                **optional_kwargs
+            )
+        elif cross_connect_id:
+            response = oci_utils.call_with_backoff(
+                virtual_network_client.list_cross_connects,
+                cross_connect_id=cross_connect_id,
+            )
+            existing_cross_connects = [response.data]
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    result["cross_connects"] = to_dict(existing_cross_connects)
+    return result
+
+
+def main():
+    module_args = oci_utils.get_facts_module_arg_spec()
+    module_args.update(
+        dict(
+            compartment_id=dict(type="str", required=False),
+            cross_connect_group_id=dict(type="str", required=False),
+            cross_connect_id=dict(type="str", required=False, aliases=["id"]),
+            lifecycle_state=dict(
+                type="str",
+                required=False,
+                choices=[
+                    "PENDING_CUSTOMER",
+                    "PROVISIONING",
+                    "PROVISIONED",
+                    "INACTIVE",
+                    "TERMINATING",
+                    "TERMINATED",
+                ],
+            ),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=module_args,
+        mutually_exclusive=[["compartment_id", "id"], ["cross_connect_group_id", "id"]],
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_cross_connects(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_cross_connect_group.py
+++ b/library/oci_cross_connect_group.py
@@ -1,0 +1,257 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_cross_connect_group
+short_description: Create, update and delete OCI cross-connect groups
+description:
+    - Create an OCI cross-connect group to use with Oracle Cloud Infrastructure FastConnect
+    - Update an OCI cross-connect group, if present, with a new display name
+    - Delete an OCI cross-connect group, if present.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: Identifier of the compartment under which this cross-connect group
+                     would be created. Mandatory for create operation.
+        required: false
+    display_name:
+        description: A user-friendly name. Does not have to be unique, and it's changeable.
+                     Avoid entering confidential information.
+        required: false
+        aliases: ['name']
+    cross_connect_group_id:
+        description: Identifier of the cross-connect group. Mandatory for update and delete.
+        required: false
+        aliases: ['id']
+    state:
+        description: Create,update or delete cross-connect group. For I(state=present), if it
+                     does not exists, it gets created. If exists, it gets updated.
+        required: false
+        default: 'present'
+        choices: ['present','absent']
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle, oracle_wait_options, oracle_creatable_resource ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Create cross-connect group
+- name: Create cross-connect group
+  oci_cross_connect_group:
+      compartment_id: 'ocid1.compartment..xxxxxEXAMPLExxxxx'
+      display_name: 'ansible-cross-connect-group'
+      state: 'present'
+
+# Update cross-connect group's Display Name
+- name: Update cross-connect group's Display Name
+  oci_cross_connect_group:
+      cross_connect_grou_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+      display_name: 'cross-connect-group-updated'
+      state: 'present'
+
+# Delete cross-connect
+- name: Delete cross-connect group
+  oci_cross_connect_group:
+      cross_connect_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+      state: 'absent'
+"""
+
+RETURN = """
+    oci_cross_connect_group:
+        description: Attributes of the cross-connect group.
+        returned: success
+        type: complex
+        contains:
+            compartment_id:
+                description: The OCID of the compartment containing the cross-connect group.
+                returned: always
+                type: string
+                sample: ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx
+            display_name:
+                description: A user-friendly name. Does not have to be unique, and it's changeable.
+                             Avoid entering confidential information.
+                returned: always
+                type: string
+                sample: ansible-cross-connect-group
+            id:
+                description: Identifier of the cross-connect group.
+                returned: always
+                type: string
+                sample: ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx
+            time_created:
+                description: Date and time when the cross-connect group was created, in
+                             the format defined by RFC3339
+                returned: always
+                type: datetime
+                sample: 2016-08-25T21:10:29.600Z
+            lifecycle_state:
+                description: The current state of the cross-connect group.
+                returned: always
+                type: string
+                sample: PROVISIONED
+        sample: {
+                    "compartment_id":"ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "display_name":"ansible-cross-connect-group",
+                    "id":"ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "lifecycle_state":"PROVISIONING",
+                    "time_created":"2018-03-03T06:55:49.463000+00:00"
+                }
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+    from oci.core.models import (
+        CreateCrossConnectGroupDetails,
+        UpdateCrossConnectGroupDetails,
+    )
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def create_or_update_cross_connect_group(virtual_network_client, module):
+    result = dict(changed=False, cross_connect_group="")
+    cross_connect_group_id = module.params.get("cross_connect_group_id")
+    exclude_attributes = {"display_name": True}
+    try:
+        if cross_connect_group_id:
+            existing_cross_connect_group = oci_utils.get_existing_resource(
+                virtual_network_client.get_cross_connect_group,
+                module,
+                cross_connect_group_id=cross_connect_group_id,
+            )
+            result = update_cross_connect_group(
+                virtual_network_client, existing_cross_connect_group, module
+            )
+        else:
+            result = oci_utils.check_and_create_resource(
+                resource_type="cross_connect_group",
+                create_fn=create_cross_connect_group,
+                kwargs_create={
+                    "virtual_network_client": virtual_network_client,
+                    "module": module,
+                },
+                list_fn=virtual_network_client.list_cross_connect_groups,
+                kwargs_list={"compartment_id": module.params.get("compartment_id")},
+                module=module,
+                exclude_attributes=exclude_attributes,
+                model=CreateCrossConnectGroupDetails(),
+            )
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    except MaximumWaitTimeExceeded as ex:
+        module.fail_json(msg=str(ex))
+
+    return result
+
+
+def create_cross_connect_group(virtual_network_client, module):
+    create_cross_connect_group_details = CreateCrossConnectGroupDetails()
+    for attribute in create_cross_connect_group_details.attribute_map:
+        create_cross_connect_group_details.__setattr__(
+            attribute, module.params.get(attribute)
+        )
+    result = oci_utils.create_and_wait(
+        resource_type="cross_connect_group",
+        create_fn=virtual_network_client.create_cross_connect_group,
+        kwargs_create={
+            "create_cross_connect_group_details": create_cross_connect_group_details
+        },
+        client=virtual_network_client,
+        get_fn=virtual_network_client.get_cross_connect_group,
+        get_param="cross_connect_group_id",
+        module=module,
+        states=["INACTIVE", "PROVISIONED"],
+    )
+    return result
+
+
+def update_cross_connect_group(
+    virtual_network_client, existing_cross_connect_group, module
+):
+    result = oci_utils.check_and_update_resource(
+        resource_type="cross_connect_group",
+        get_fn=virtual_network_client.get_cross_connect_group,
+        kwargs_get={"cross_connect_group_id": module.params["cross_connect_group_id"]},
+        update_fn=virtual_network_client.update_cross_connect_group,
+        primitive_params_update=["cross_connect_group_id"],
+        kwargs_non_primitive_update={
+            UpdateCrossConnectGroupDetails: "update_cross_connect_group_details"
+        },
+        module=module,
+        client=virtual_network_client,
+        update_attributes=UpdateCrossConnectGroupDetails().attribute_map.keys(),
+        states=["INACTIVE", "PROVISIONED"],
+    )
+    return result
+
+
+def delete_cross_connect_group(virtual_network_client, module):
+    return oci_utils.delete_and_wait(
+        resource_type="cross_connect_group",
+        client=virtual_network_client,
+        get_fn=virtual_network_client.get_cross_connect_group,
+        kwargs_get={"cross_connect_group_id": module.params["cross_connect_group_id"]},
+        delete_fn=virtual_network_client.delete_cross_connect_group,
+        kwargs_delete={
+            "cross_connect_group_id": module.params["cross_connect_group_id"]
+        },
+        module=module,
+    )
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec(
+        supports_create=True, supports_wait=True
+    )
+    module_args.update(
+        compartment_id=dict(type="str", required=False),
+        cross_connect_group_id=dict(type="str", required=False, aliases=["id"]),
+        display_name=dict(type="str", required=False, aliases=["name"]),
+        state=dict(
+            type="str", required=False, default="present", choices=["present", "absent"]
+        ),
+    )
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    state = module.params["state"]
+
+    if state == "present":
+        result = create_or_update_cross_connect_group(virtual_network_client, module)
+    elif state == "absent":
+        result = delete_cross_connect_group(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_cross_connect_group_facts.py
+++ b/library/oci_cross_connect_group_facts.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_cross_connect_group_facts
+short_description: Fetches details of one or more OCI cross-connect groups
+description:
+     - Fetches details of a specified OCI cross-connect group or all cross-connect groups in a specified compartment.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: Identifier of the compartment under which the specified cross-connect group exists
+        required: false
+    cross_connect_group_id:
+        description: Identifier of the cross-connect whose details needs to be fetched.
+        required: false
+        aliases: [ 'id' ]
+    lifecycle_state:
+        description: A filter to return only resources that match the given lifecycle state.
+        required: false
+        choices: ["PROVISIONING", "PROVISIONED", "INACTIVE", "TERMINATING", "TERMINATED"]
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle, oracle_display_name_option  ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch All Cross Connects Groups under a specific compartment
+- name: Fetch All Cross Connects Groups under a specific compartment
+  oci_cross_connect_group_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+# Fetch All cross-connect groups under a specific compartment, filtered by
+# display name and lifecycle state
+- name: Fetch All cross-connect groups under a specific compartment, filtered by display name and lifecycle state
+  oci_cross_connect_group_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+      display_name: 'ansible-cross-connect-group'
+      lifecycle_state: 'PROVISIOING'
+
+# Fetch a specific cross-connect group
+- name: Fetch a specific cross-connect group
+  oci_cross_connect_group_facts:
+      cross_connect_group_id: 'ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx'
+"""
+
+RETURN = """
+    oci_cross_connect_groups:
+        description: Attributes of the cross-connect group.
+        returned: success
+        type: complex
+        contains:
+            compartment_id:
+                description: The OCID of the compartment containing the cross-connect group.
+                returned: always
+                type: string
+                sample: ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx
+            display_name:
+                description: A user-friendly name. Does not have to be unique, and it's changeable.
+                             Avoid entering confidential information.
+                returned: always
+                type: string
+                sample: ansible-cross-connect-group
+            id:
+                description: Identifier of the cross-connect group.
+                returned: always
+                type: string
+                sample: ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx
+            time_created:
+                description: Date and time when the Cross Connect was created, in
+                             the format defined by RFC3339
+                returned: always
+                type: datetime
+                sample: 2016-08-25T21:10:29.600Z
+            lifecycle_state:
+                description: The current state of the Cross Connect.
+                returned: always
+                type: string
+                sample: PROVISIONED
+        sample: [{
+                    "compartment_id":"ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "display_name":"ansible-cross-connect-group",
+                    "id":"ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "lifecycle_state":"PROVISIONING",
+                    "time_created":"2018-03-03T06:55:49.463000+00:00"
+                },
+                {
+                    "compartment_id":"ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "display_name":"test-cross-connect",
+                    "id":"ocid1.crossconnectgroup.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "lifecycle_state":"PROVISIONING",
+                    "time_created":"2018-03-04T06:55:49.463000+00:00"
+                }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def list_cross_connect_groups(virtual_network_client, module):
+    result = dict(cross_connect_groups="")
+    compartment_id = module.params.get("compartment_id")
+    cross_connect_group_id = module.params.get("cross_connect_group_id")
+    try:
+        if compartment_id:
+            optional_list_method_params = ["display_name", "lifecycle_state"]
+            optional_kwargs = {
+                param: module.params[param]
+                for param in optional_list_method_params
+                if module.params.get(param) is not None
+            }
+            existing_cross_connect_groups = oci_utils.list_all_resources(
+                virtual_network_client.list_cross_connect_groups,
+                compartment_id=compartment_id,
+                **optional_kwargs
+            )
+        elif cross_connect_group_id:
+            response = oci_utils.call_with_backoff(
+                virtual_network_client.list_cross_connect_groups,
+                cross_connect_group_id=cross_connect_group_id,
+            )
+            existing_cross_connect_groups = [response.data]
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    result["cross_connect_groups"] = to_dict(existing_cross_connect_groups)
+    return result
+
+
+def main():
+    module_args = oci_utils.get_facts_module_arg_spec()
+    module_args.update(
+        dict(
+            compartment_id=dict(type="str", required=False),
+            cross_connect_group_id=dict(type="str", required=False, aliases=["id"]),
+            lifecycle_state=dict(
+                type="str",
+                required=False,
+                choices=[
+                    "PROVISIONING",
+                    "PROVISIONED",
+                    "INACTIVE",
+                    "TERMINATING",
+                    "TERMINATED",
+                ],
+            ),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=module_args, mutually_exclusive=[["compartment_id", "id"]]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_cross_connect_groups(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_cross_connect_location_facts.py
+++ b/library/oci_cross_connect_location_facts.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_cross_connect_location_facts
+short_description: Fetches details of one or more OCI cross-connect Locations
+description:
+     - Fetches details of the OCI cross-connect Locations
+version_added: "2.5"
+options:
+    compartment_id:
+        description: Identifier of the compartment under which cross-connect Locations exists
+        required: true
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch All cross-connect Locations under a specific compartment
+- name: Fetch All cross-connect Locations under a specific compartment
+  oci_cross_connect_location_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+"""
+
+RETURN = """
+    oci_cross_connect_locations:
+        description: Attributes of the cross-connect Location.
+        returned: success
+        type: complex
+        contains:
+            compartment_id:
+                description: The OCID of the compartment containing the cross-connect location.
+                returned: always
+                type: string
+                sample: ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx
+        sample: [{
+                    "description":"Equinix",
+                    "name":"Equinix"
+                },
+                {
+                    "description":"CoreSite",
+                    "name":"CoreSite"
+                }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+logger = None
+
+
+def list_cross_connect_locations(virtual_network_client, module):
+    result = dict(cross_connect_locations="")
+    compartment_id = module.params.get("compartment_id")
+    get_logger().info(
+        "Retrieving all cross-connect Locations in Compartment %s", compartment_id
+    )
+    try:
+        result["cross_connect_locations"] = to_dict(
+            oci_utils.list_all_resources(
+                virtual_network_client.list_cross_connect_locations,
+                compartment_id=compartment_id,
+            )
+        )
+    except ServiceError as ex:
+        get_logger().error(
+            "Unable to list all cross-connect Locations due to: %s", ex.message
+        )
+        module.fail_json(msg=ex.message)
+
+    return result
+
+
+def set_logger(input_logger):
+    global logger
+    logger = input_logger
+
+
+def get_logger():
+    return logger
+
+
+def main():
+    logger = oci_utils.get_logger("oci_cross_connect_location_facts")
+    set_logger(logger)
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(compartment_id=dict(type="str", required=True)))
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_cross_connect_locations(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_cross_connect_port_speed_shape_facts.py
+++ b/library/oci_cross_connect_port_speed_shape_facts.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_cross_connect_port_speed_shape_facts
+short_description: Fetches details of one or more OCI cross-connect port speed shapes
+description:
+     - Fetches details of the OCI cross-connect port speed shapes
+version_added: "2.5"
+options:
+    compartment_id:
+        description: Identifier of the compartment under which cross-connect Port Speed Shapes exists
+        required: true
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch All cross-connect Port Speed Shapes under a specific compartment
+- name: Fetch All cross-connect Port Speed Shapes under a specific compartment
+  oci_cross_connect_port_speed_shape_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+"""
+
+RETURN = """
+    oci_cross_connect_port_speed_shapes:
+        description: Attributes of the cross-connect Port Speed Shape.
+        returned: success
+        type: complex
+        contains:
+            name:
+                description: The name of the port speed shape.
+                returned: always
+                type: string
+                sample: 10 Gbps
+            port_speed_in_gbps:
+                description: The port speed in Gbps.
+                returned: always
+                type: int
+                sample: 10
+        sample: [{
+                    "name": "10 Gbps",
+                    "port_speed_in_gbps": 10
+                }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+logger = None
+
+
+def list_cross_connect_port_speed_shapes(virtual_network_client, module):
+    result = dict(cross_connect_port_speed_shapes="")
+    compartment_id = module.params.get("compartment_id")
+    get_logger().info(
+        "Retrieving all cross-connect Port Speed Shapes in Compartment %s",
+        compartment_id,
+    )
+    try:
+        result["cross_connect_port_speed_shapes"] = to_dict(
+            oci_utils.list_all_resources(
+                virtual_network_client.list_crossconnect_port_speed_shapes,
+                compartment_id=compartment_id,
+            )
+        )
+    except ServiceError as ex:
+        get_logger().error(
+            "Unable to list all cross-connect Port Speed Shapes due to: %s", ex.message
+        )
+        module.fail_json(msg=ex.message)
+
+    return result
+
+
+def set_logger(input_logger):
+    global logger
+    logger = input_logger
+
+
+def get_logger():
+    return logger
+
+
+def main():
+    logger = oci_utils.get_logger("oci_cross_connect_port_speed_shape_facts")
+    set_logger(logger)
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(compartment_id=dict(type="str", required=True)))
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_cross_connect_port_speed_shapes(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_cross_connect_status_facts.py
+++ b/library/oci_cross_connect_status_facts.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_cross_connect_status_facts
+short_description: Fetches details of OCI cross-connect status
+description:
+     - Fetches details of the OCI cross-connect status
+version_added: "2.5"
+options:
+    cross_connect_id:
+        description: Identifier of the cross-connect whose status needs to be fetched
+        required: true
+        aliases: ['id']
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch cross-connect status
+- name: Fetch cross-connect status
+  oci_cross_connect_status_facts:
+      cross_connect_id: 'ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx'
+"""
+
+RETURN = """
+    oci_cross_connect_status:
+        description: Attributes of the cross-connect Status.
+        returned: success
+        type: complex
+        contains:
+            cross_connect_id:
+                description: The OCID of the cross-connect.
+                returned: always
+                type: string
+                sample: ocid1.crossconect.oc1.iad.xxxxxEXAMPLExxxxx
+            interface_state:
+                description: Whether Oracle's side of the interface is up or down.
+                returned: always
+                type: string
+                sample: UP
+            light_level_ind_bm:
+                description: The light level of the cross-connect (in dBm).
+                returned: always
+                type: string
+                sample: 14.0
+            light_level_indicator:
+                description: tatus indicator corresponding to the light level.
+                returned: always
+                type: string
+                sample: GOOD
+        sample: [{
+                    "cross_connect_id": "ocid1.crossconect.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "interface_state": "UP",
+                    "light_level_ind_bm": 14.0,
+                    "light_level_indicator": "GOOD"
+                }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+logger = None
+
+
+def list_cross_connect_statuses(virtual_network_client, module):
+    result = dict(cross_connect_statuses="")
+    existing_cross_connect_statuses = None
+    cross_connect_id = module.params.get("cross_connect_id")
+    get_logger().info(
+        "Retrieving cross-connect Status for cross-connect %s", cross_connect_id
+    )
+    try:
+        existing_cross_connect_statuses = oci_utils.call_with_backoff(
+            virtual_network_client.get_cross_connect_status,
+            cross_connect_id=cross_connect_id,
+        )
+    except ServiceError as ex:
+        get_logger().error("Unable to list cross-connect Status due to: %s", ex.message)
+        module.fail_json(msg=ex.message)
+    result["cross_connect_statuses"] = to_dict(existing_cross_connect_statuses)
+
+    return result
+
+
+def set_logger(input_logger):
+    global logger
+    logger = input_logger
+
+
+def get_logger():
+    return logger
+
+
+def main():
+    logger = oci_utils.get_logger("oci_cross_connect_status_facts")
+    set_logger(logger)
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(
+        dict(cross_connect_id=dict(type="str", required=True, aliases=["id"]))
+    )
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_cross_connect_statuses(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_fast_connect_provider_service_facts.py
+++ b/library/oci_fast_connect_provider_service_facts.py
@@ -1,0 +1,187 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+
+DOCUMENTATION = """
+---
+module: oci_fast_connect_provider_service_facts
+short_description: Fetches details of one or more OCI Fast Connect Provider Services
+description:
+     - Fetches details of the OCI Fast Connect Provider Services
+version_added: "2.5"
+options:
+    compartment_id:
+        description: Identifier of the compartment under which the specified fast connect provider service exists
+        required: false
+    provider_service_id:
+        description: Identifier of the fast connect provider service whose details needs to be fetched.
+        required: false
+        aliases: [ 'id' ]
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch All Fast Connect Provider Services under a specific compartment
+- name: Fetch All Fast Connect Provider Services under a specific compartment
+  oci_fast_connect_provider_service_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+# Fetch a specific Fast Connect Provider Service
+- name: Fetch a specific Fast Connect Provider Service
+  oci_fast_connect_provider_service_facts:
+      provider_service_id: 'ocid1.serviceprovider.oc1.iad.xxxxxEXAMPLExxxxx'
+"""
+
+RETURN = """
+    oci_fast_connect_provider_services:
+        description: Attributes of the Fast Connect Provider Service.
+        returned: success
+        type: complex
+        contains:
+            description:
+                description: A description of the service offered by the provider.
+                returned: always
+                type: string
+                sample: https://megaport.al/
+            id:
+                description: Identifier of the Fast Connect Provider Service
+                returned: always
+                type: string
+                sample: ocid1.providerservice.oc1.iad.xxxxxEXAMPLExxxxx
+            private_peering_bgp_management:
+                description: Who is responsible for managing the private peering BGP information.
+                returned: always
+                type: string
+                sample: CUSTOMER_MANAGED
+            provider_name:
+                description: The name of the provider.
+                returned: always
+                type: string
+                sample: Megaport
+            provider_service_name:
+                description: The name of the service offered by the provider.
+                returned: always
+                type: string
+                sample: Service
+            public_peering_bgp_management:
+                description: Who is responsible for managing the public peering BGP information.
+                returned: always
+                type: string
+                sample: ORACLE_MANAGED
+            supported_virtual_circuit_types:
+                description: An array of virtual circuit types supported by this service.
+                returned: always
+                type: list
+                sample: ["PRIVATE", "PUBLIC"]
+            type:
+                description: Provider service type.
+                returned: always
+                type: list
+                sample: LAYER2
+        sample: [{
+                        "description":"https://megaport.al/",
+                        "id":"ocid1.providerservice.oc1.iad.xxxxxEXAMPLExxxxx",
+                        "private_peering_bgp_management":"CUSTOMER_MANAGED",
+                        "provider_name":"Megaport",
+                        "provider_service_name":"Service",
+                        "public_peering_bgp_management":"ORACLE_MANAGED",
+                        "supported_virtual_circuit_types":null,
+                        "type":"LAYER2"
+                },
+                {
+                         "description":"https://marketplaceportal.com/web/guest/login",
+                         "id":"ocid1.providerservice.oc1.iad.xxxxxEXAMPLExxxxx",
+                         "private_peering_bgp_management":"CUSTOMER_MANAGED",
+                         "provider_name":"Digital Realty",
+                         "provider_service_name":"Service Exchange",
+                         "public_peering_bgp_management":"ORACLE_MANAGED",
+                         "supported_virtual_circuit_types":[
+                                                             "PRIVATE",
+                                                             "PUBLIC"
+                                                           ],
+                         "type":"LAYER2"
+               }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def list_fast_connect_provider_services(virtual_network_client, module):
+    result = dict(fast_connect_provider_services="")
+    compartment_id = module.params.get("compartment_id")
+    provider_service_id = module.params.get("provider_service_id")
+    try:
+        if compartment_id:
+            existing_fast_connect_provider_services = oci_utils.list_all_resources(
+                virtual_network_client.list_fast_connect_provider_services,
+                compartment_id=compartment_id,
+            )
+        elif provider_service_id:
+            response = oci_utils.call_with_backoff(
+                virtual_network_client.get_fast_connect_provider_service,
+                provider_service_id=provider_service_id,
+            )
+            existing_fast_connect_provider_services = [response.data]
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    result["fast_connect_provider_services"] = to_dict(
+        existing_fast_connect_provider_services
+    )
+    return result
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(
+        dict(
+            compartment_id=dict(type="str", required=False),
+            provider_service_id=dict(type="str", required=False, aliases=["id"]),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=module_args, mutually_exclusive=[["compartment_id", "id"]]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_fast_connect_provider_services(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts.py
+++ b/library/oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts.py
@@ -1,0 +1,126 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+
+DOCUMENTATION = """
+---
+module: oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts
+short_description: Fetches details of one or more OCI Fast Connect Provider Virtual Circuit Bandwidth
+description:
+     - Fetches details of the OCI Fast Connect Provider Virtual Circuit Bandwidth
+version_added: "2.5"
+options:
+    provider_service_id:
+        description: Identifier of the fast connect provider service whose virtual circuit bandwidth needs to be fetched.
+        required: true
+        aliases: [ 'id' ]
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch All Fast Connect Provider Virtual Circuit Bandwidth under a specific Provider Service
+- name: Fetch All Fast Connect Provider Virtual Circuit Bandwidth under a specific Provider Service
+  oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts:
+      provider_service_id: 'ocid1.serviceprovider.oc1.iad.xxxxxEXAMPLExxxxx'
+"""
+
+RETURN = """
+    oci_fast_connect_provider_virtual_circuit_bandwidth_shapes:
+        description: Attributes of the Fast Connect Provider Service.
+        returned: success
+        type: complex
+        contains:
+            bandwidth_in_mbps:
+                description: The bandwidth in Mbps.
+                returned: always
+                type: int
+                sample: 1000
+            name:
+                description: The name of the bandwidth shape.
+                returned: always
+                type: string
+                sample: 1 Gbps
+        sample: [{
+                    "bandwidth_in_mbps":1000,
+                    "name":"1 Gbps"
+                },
+                {
+                    "bandwidth_in_mbps":2000,
+                    "name":"2 Gbps"
+                }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def list_fast_connect_provider_virtual_circuit_bandwidth_shapes(
+    virtual_network_client, module
+):
+    result = dict(fast_connect_provider_virtual_circuit_bandwidth_shapes="")
+    existing_fast_connect_provider_virtual_circuit_bandwidth_shapes = None
+    provider_service_id = module.params.get("provider_service_id")
+    try:
+        existing_fast_connect_provider_virtual_circuit_bandwidth_shapes = oci_utils.list_all_resources(
+            virtual_network_client.list_fast_connect_provider_virtual_circuit_bandwidth_shapes,
+            provider_service_id=provider_service_id,
+        )
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    result["fast_connect_provider_virtual_circuit_bandwidth_shapes"] = to_dict(
+        existing_fast_connect_provider_virtual_circuit_bandwidth_shapes
+    )
+    return result
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(
+        dict(provider_service_id=dict(type="str", required=True, aliases=["id"]))
+    )
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_fast_connect_provider_virtual_circuit_bandwidth_shapes(
+        virtual_network_client, module
+    )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_instance_configuration_facts.py
+++ b/library/oci_instance_configuration_facts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -33,7 +33,7 @@ options:
         required: false
         aliases: [ 'id' ]
 author: "Sivakumar Thyagarajan (@sivakumart)"
-extends_documentation_fragment: [ oracle ]
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 """
 
 EXAMPLES = """
@@ -403,7 +403,7 @@ except ImportError:
 
 
 def main():
-    module_args = oci_utils.get_common_arg_spec()
+    module_args = oci_utils.get_facts_module_arg_spec()
     module_args.update(
         dict(
             compartment_id=dict(type="str", required=False),

--- a/library/oci_kubeconfig.py
+++ b/library/oci_kubeconfig.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -72,6 +72,7 @@ kubeconfig:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.oracle import oci_utils
 from ansible.module_utils.oracle import oci_ce_utils
+from ansible.module_utils._text import to_bytes
 import os
 
 try:
@@ -110,7 +111,7 @@ def create_kubeconfig(container_engine_client, module):
     ).data.content
     if module.params.get("dest"):
         dest = module.params.get("dest")
-        if module.params.get("force") or not os.path.isfile(dest):
+        if module.params.get("force") or not os.path.isfile(to_bytes(dest)):
             oci_utils.write_to_file(dest, result["kubeconfig"])
             result["changed"] = True
 

--- a/library/oci_letter_of_authority_facts.py
+++ b/library/oci_letter_of_authority_facts.py
@@ -1,0 +1,147 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+
+DOCUMENTATION = """
+---
+module: oci_letter_of_authority_facts
+short_description: Fetches details of OCI cross-connect Letter of Authority
+description:
+     - Fetches details of OCI Letter of Authority
+version_added: "2.5"
+options:
+    cross_connect_id:
+        description: Identifier of the cross-connect whose letter of authority needs to be fetched.
+        required: true
+        aliases: [ 'id' ]
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch Letter of Authority
+- name: Fetch Letter of Authority
+  oci_letter_of_authority_facts:
+      cross_connect_id: 'ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx'
+"""
+
+RETURN = """
+    oci_letter_of_authorities:
+        description: Attributes of the Letter of Authority.
+        returned: success
+        type: complex
+        contains:
+            authorized_entity_name:
+                description: The name of the entity authorized by this Letter of Authority.
+                returned: always
+                type: string
+                sample: Example Authorized Entity
+            circuit_type:
+                description: The type of cross-connect fiber, termination, and optical specification.
+                returned: always
+                type: string
+                sample: Single_mode_LC
+            cross_connect_id:
+                description: The OCID of the cross-connect.
+                returned: always
+                type: string
+                sample: ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx
+            facility_location:
+                description: The address of the FastConnect location.
+                returned: always
+                type: string
+                sample: Equinox
+            port_name:
+                description: The meet-me room port for this cross-connect.
+                returned: always
+                type: string
+                sample: Example Port Name
+            time_expires:
+                description: The date and time when the Letter of Authority expires, in the format defined by RFC3339.
+                returned: always
+                type: string
+                sample: 2018-03-03T06:55:49.463000+00:00
+            time_issued:
+                description: The date and time the Letter of Authority was created, in the format defined by RFC3339..
+                returned: always
+                type: string
+                sample: 2018-03-03T06:55:49.463000+00:00
+        sample: [{
+                    "authorized_entity_name":"Example Authorized Entity Name",
+                    "circuit_type":"Single_mode_LC",
+                    "cross_connect_id":"ocid1.crossconnect.oc1.iad.xxxxxEXAMPLExxxxx",
+                    "facility_location":"Equinox",
+                    "port_name":"Example Port Name",
+                    "time_expires":"2018-03-03T06:55:49.463000+00:00",
+                    "time_issued":"2018-02-03T06:55:49.463000+00:00"
+                }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def list_letter_of_authorities(virtual_network_client, module):
+    result = dict(letter_of_authorities="")
+    existing_letter_of_authorities = None
+    cross_connect_id = module.params.get("cross_connect_id")
+    try:
+        response = oci_utils.call_with_backoff(
+            virtual_network_client.get_cross_connect_letter_of_authority,
+            cross_connect_id=cross_connect_id,
+        )
+        existing_letter_of_authorities = [response.data]
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    result["letter_of_authorities"] = to_dict(existing_letter_of_authorities)
+    return result
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(
+        dict(cross_connect_id=dict(type="str", required=True, aliases=["id"]))
+    )
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_letter_of_authorities(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_load_balancer.py
+++ b/library/oci_load_balancer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -489,8 +489,11 @@ def create_or_update_lb(lb_client, module):
                 "return_code": 200,
                 "timeout_in_millis": 3000,
             },
-            "listener": {"connection_configuration": {"idle_timeout": 60}},
-        }
+        },
+        "listeners": {
+            "connection_configuration": {"idle_timeout": 60},
+            "rule_set_names": [],
+        },
     }
     exclude_attributes = {"display_name": True}
 

--- a/library/oci_policy.py
+++ b/library/oci_policy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2017, 2018, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -105,6 +105,7 @@ policy:
 """
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes
 from ansible.module_utils.oracle import oci_utils
 from collections import Counter
 
@@ -121,9 +122,12 @@ except ImportError:
 
 
 def get_policy_statements(file_path):
-    with open(file_path, "r") as policy_file:
-        policy_statements = policy_file.readlines()
-    policy_statements = [x.strip() for x in policy_statements]
+    policy_statements = None
+    with open(to_bytes(file_path), "r") as policy_file:
+        policy_statements = []
+        for stmt in policy_file:
+            policy_statements.append(stmt.strip())
+
     return policy_statements
 
 

--- a/library/oci_preauthenticated_request.py
+++ b/library/oci_preauthenticated_request.py
@@ -1,0 +1,304 @@
+#!/usr/bin/python
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+
+DOCUMENTATION = """
+---
+module: oci_preauthenticated_request
+short_description: Create and delete an OCI Preauthenticated Request
+description:
+    - Create a new OCI Preauthenticated Request for a bucket or an object
+    - Delete an OCI Preauthenticated Request, if present
+    - Note that the unique URL provided by the system when you create a pre-authenticated request is the only way a
+      user can access the bucket or object specified as the request target. Copy the URL to durable storage. The URL is
+      returned only at the time of creation and cannot be retrieved later.
+version_added: "2.5"
+options:
+    namespace_name:
+        description: The Object Storage namespace used for the request.
+        required: true
+    bucket_name:
+        description: The name of the bucket. Avoid entering confidential information.
+        required: false
+    par_id:
+        description: Identifier of the Preauthenticated Request. Mandatory for delete.
+        required: false
+        aliases: ['id']
+    name:
+        description: A user-specified name for the pre-authenticated request. Names can be helpful in managing
+                     pre-authenticated requests. Required while creating a Preauthenticated request with
+                     I(state=present).
+        required: false
+        aliases: ['display_name']
+    object_name:
+        description: The name of the object that is being granted access to by the pre-authenticated request.
+                     Avoid entering confidential information. The object name can be null and if so, the
+                     pre-authenticated request grants access to the entire bucket.
+        required: false
+    time_expires:
+        description: The expiration date for the pre-authenticated request as per RFC 3339. After this date
+                     the pre-authenticated request will no longer be valid.
+        required: false
+    access_type:
+        description: The expiration date for the pre-authenticated request as per RFC 3339. After this date
+                     the pre-authenticated request will no longer be valid. Required while creating a Preauthenticated
+                     request with I(state=present).
+        required: false
+        choices: ["ObjectRead", "ObjectWrite", "ObjectReadWrite", "AnyObjectWrite"]
+    state:
+        description: Create or delete Preauthenticated Request. Use I(state=present) to create a Preauthenticated
+                     request and I(state=absent) to delete a Preauthenticated request.
+        required: false
+        default: 'present'
+        choices: ['present','absent']
+
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle, oracle_creatable_resource, oracle_wait_options ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Create Preauthenticated Request for Entire Bucket
+- name: Create Preauthenticated Request for a Bucket and permit uploading one or more objects to it
+  oci_preauthenticated_request:
+    namespace_name: 'us-example-1'
+    bucket_name: 'ansible_bucket'
+    name: 'ansible_bucket_par'
+    access_type: 'AnyObjectWrite'
+    time_expires: '2018-12-22T00:00:00+00:00'
+    state: 'present'
+
+# Create Preauthenticated Request for Entire Bucket
+- name: Create Preauthenticated Request for a specific Object and permit writes to the object
+  oci_preauthenticated_request:
+    namespace_name: 'us-example-1'
+    bucket_name: 'ansible_bucket'
+    object_name: 'ansible_object'
+    name: 'ansible_object_par'
+    access_type: 'ObjectWrite'
+    time_expires: '2018-12-22T00:00:00+00:00'
+    state: 'present'
+
+# Delete Preauthenticated Request
+- name: Delete an existing Preauthenticated Request
+  oci_preauthenticated_request:
+    namespace_name: 'us-example-1'
+    bucket_name: 'ansible_bucket'
+    par_id: 'fEbFqu0/thO3JqpA/MRVbD/BpE='
+    state: 'absent'
+"""
+
+RETURN = """
+    preauthenticated_request:
+        description: Attributes of the created Preauthenticated Request. For delete, deleted Preauthenticated Request
+                     description will be returned.
+        returned: success
+        type: complex
+        contains:
+            name:
+                description: The user-provided name of the pre-authenticated request.
+                returned: always
+                type: string
+                sample: ansible_bucker_par
+            id:
+                description: Identifier of the Preauthenticated Request
+                returned: always
+                type: string
+                sample: fEbFqu0/thO3JqpA/MRVbD/BpE=
+            access_uri:
+                description: The URI to embed in the URL when using the pre-authenticated request.
+                returned: always
+                type: string
+                sample: /p/TF0WATak6uM7AU4PXA/n/us-example-1/b/ansible_bucket/o/
+            object_name:
+                description: The name of the object that is being granted access to by the
+                             pre-authenticated request.
+                returned: always
+                type: string
+                sample: ansible_object
+            access_type:
+                description: The collection of rules for routing destination IPs to network devices.
+                returned: always
+                type: string
+                sample: AnyObjectWrite
+            time_expires:
+                description: The expiration date for the pre-authenticated request as per RFC 3339.
+                returned: always
+                type: datetime
+                sample: 2018-12-22T00:00:00+00:00
+            time_created:
+                description: The date when the pre-authenticated request was created as per specification
+                             RFC 3339.
+                returned: always
+                type: datetime
+                sample: 2018-12-22T12:04:02.229000+00:00
+        sample: {
+                   "access_type":"AnyObjectWrite",
+                   "access_uri":"/p/TF0WATak/n/us-example-1/b/ansible_bucket/o/ansible_object",
+                   "id":"EbFqu0/thO3/MRVb/XmZ0iaT6IA=",
+                   "name":"ansible_bucket_par",
+                   "object_name":"ansible_object",
+                   "time_created":"2018-12-22T12:04:02.229000+00:00",
+                   "time_expires":"2018-12-23T17:31:35+00:00"
+                }
+
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    from oci.object_storage.object_storage_client import ObjectStorageClient
+    from oci.exceptions import ServiceError, ClientError
+    from oci.object_storage.models import CreatePreauthenticatedRequestDetails
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+logger = None
+
+
+def create_preauthenticated_request(object_storage_client, module):
+    create_preauthenticated_request_details = CreatePreauthenticatedRequestDetails()
+    for attribute in create_preauthenticated_request_details.attribute_map:
+        create_preauthenticated_request_details.__setattr__(
+            attribute, module.params.get(attribute)
+        )
+    result = oci_utils.create_resource(
+        resource_type="preauthenticated_request",
+        create_fn=object_storage_client.create_preauthenticated_request,
+        kwargs_create={
+            "namespace_name": module.params.get("namespace_name"),
+            "bucket_name": module.params.get("bucket_name"),
+            "create_preauthenticated_request_details": create_preauthenticated_request_details,
+        },
+        module=module,
+    )
+    return result
+
+
+def delete_preauthenticated_request(object_storage_client, module):
+    result = oci_utils.delete_and_wait(
+        resource_type="preauthenticated_request",
+        client=object_storage_client,
+        get_fn=object_storage_client.get_preauthenticated_request,
+        kwargs_get={
+            "par_id": module.params["par_id"],
+            "namespace_name": module.params.get("namespace_name"),
+            "bucket_name": module.params.get("bucket_name"),
+        },
+        delete_fn=object_storage_client.delete_preauthenticated_request,
+        kwargs_delete={
+            "par_id": module.params["par_id"],
+            "namespace_name": module.params.get("namespace_name"),
+            "bucket_name": module.params.get("bucket_name"),
+        },
+        module=module,
+    )
+
+    return result
+
+
+def set_logger(input_logger):
+    global logger
+    logger = input_logger
+
+
+def get_logger():
+    return logger
+
+
+def main():
+    logger = oci_utils.get_logger("oci_preauthenticated_request")
+    set_logger(logger)
+
+    module_args = oci_utils.get_common_arg_spec(
+        supports_create=True, supports_wait=True
+    )
+    module_args.update(
+        dict(
+            namespace_name=dict(type="str", required=True),
+            bucket_name=dict(type="str", required=True),
+            par_id=dict(type="str", required=False, aliases=["id"]),
+            name=dict(type="str", required=False, aliases=["display_name"]),
+            object_name=dict(type="str", required=False),
+            time_expires=dict(type="str", required=False),
+            access_type=dict(
+                type="str",
+                required=False,
+                choices=[
+                    "ObjectRead",
+                    "ObjectWrite",
+                    "ObjectReadWrite",
+                    "AnyObjectWrite",
+                ],
+            ),
+            state=dict(
+                type="str",
+                required=False,
+                default="present",
+                choices=["present", "absent"],
+            ),
+        )
+    )
+
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    object_storage_client = oci_utils.create_service_client(module, ObjectStorageClient)
+    state = module.params["state"]
+
+    if state == "present":
+        try:
+            result = oci_utils.check_and_create_resource(
+                resource_type="preauthenticated_request",
+                create_fn=create_preauthenticated_request,
+                kwargs_create={
+                    "object_storage_client": object_storage_client,
+                    "module": module,
+                },
+                list_fn=object_storage_client.list_preauthenticated_requests,
+                kwargs_list={
+                    "namespace_name": module.params.get("namespace_name"),
+                    "bucket_name": module.params.get("bucket_name"),
+                },
+                module=module,
+                model=CreatePreauthenticatedRequestDetails(),
+            )
+        except ServiceError as ex:
+            get_logger().error(
+                "Unable to create Preauthenticated Request due to: %s", ex.message
+            )
+            module.fail_json(msg=ex.message)
+        except ClientError as ex:
+            get_logger().error(
+                "Unable to create Preauthenticated Request due to: %s", str(ex)
+            )
+            module.fail_json(msg=str(ex))
+    elif state == "absent":
+        result = delete_preauthenticated_request(object_storage_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_preauthenticated_request_facts.py
+++ b/library/oci_preauthenticated_request_facts.py
@@ -1,0 +1,209 @@
+#!/usr/bin/python
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_preauthenticated_request_facts
+short_description: Fetches details of existing OCI Preauthenticated Requests.
+description:
+    - Fetches details of all OCI Preauthenticated Requests for a specific Bucket or an OCI Preauthenticated Request
+version_added: "2.5"
+options:
+    namespace_name:
+        description: Namespace name from which details of all preauthenticated-requests must be fetched.
+        required: true
+    bucket_name:
+        description: Bucket name from which details of all preauthenticated-requests must be fetched.
+        required: true
+    par_id:
+        description: Identifier of the preauthenticated-request. Required if the details of a
+                     specific preauthenticated-request details needs to be fetched.
+        required: false
+        aliases: ['id']
+    object_name_prefix:
+        description: User-specified object name prefixes can be used to query and return a
+                     list of pre-authenticated requests.
+        required: false
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+# Fetch Preauthenticated Request
+- name: List all Preauthenticated Request of a Bucket
+  oci_preauthenticated_request_facts:
+    namespace_name: 'us-example-1'
+    bucket_name: 'ansible_bucket'
+
+# Fetch Preauthenticated Request for a specific Object
+- name: List Preauthenticated Request for objects with a specified name prefix
+  oci_preauthenticated_request_facts:
+    namespace_name: 'us-example-1'
+    bucket_name: 'ansible_bucket'
+    object_name_prefix: 'ansible_object'
+
+# Fetch a specific Preauthenticated Request
+- name: List a specific Preauthenticated Request
+  oci_preauthenticated_request_facts:
+    namespace_name: 'us-example-1'
+    bucket_name: 'ansible_bucket'
+    par_id: 'fEbFqu0/thO3JqpA/MRVbD/BpE='
+"""
+
+RETURN = """
+    preauthenticated_requests:
+        description: Attributes of the Fetched Preauthenticated Request.
+        returned: success
+        type: complex
+        contains:
+            name:
+                description: The user-provided name of the pre-authenticated request.
+                returned: always
+                type: string
+                sample: ansible_bucker_par
+            id:
+                description: Identifier of the Preauthenticated Request
+                returned: always
+                type: string
+                sample: fEbFqu0/thO3JqpA/MRVbD/BpE=
+            object_name:
+                description: The name of the object that is being granted access to by the
+                             pre-authenticated request.
+                returned: always
+                type: string
+                sample: ansible_object
+            access_type:
+                description: The collection of rules for routing destination IPs to network devices.
+                returned: always
+                type: string
+                sample: AnyObjectWrite
+            time_expires:
+                description: The expiration date for the pre-authenticated request as per RFC 3339.
+                returned: always
+                type: datetime
+                sample: 2018-12-22T00:00:00+00:00
+            time_created:
+                description: The date when the pre-authenticated request was created as per specification
+                             RFC 3339.
+                returned: always
+                type: datetime
+                sample: 2018-12-22T12:04:02.229000+00:00
+        sample: [{
+                   "access_type":"AnyObjectWrite",
+                   "id":"EbFqu0/thO3/MRVb/XmZ0iaT6IA=",
+                   "name":"ansible_bucket_par",
+                   "object_name":"ansible_object",
+                   "time_created":"2018-12-22T12:04:02.229000+00:00",
+                   "time_expires":"2018-12-23T17:31:35+00:00"
+                }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    from oci.object_storage.object_storage_client import ObjectStorageClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+logger = None
+
+
+def list_preauthenticated_requests(object_storage_client, module):
+    result = dict(preauthenticated_requests="")
+    namespace_name = module.params.get("namespace_name")
+    bucket_name = module.params.get("bucket_name")
+    par_id = module.params.get("par_id")
+    try:
+        if par_id:
+            get_logger().debug("Listing Preauthenticated Request Summary of %s", par_id)
+            response = oci_utils.call_with_backoff(
+                object_storage_client.get_preauthenticated_request,
+                namespace_name=namespace_name,
+                bucket_name=bucket_name,
+                par_id=par_id,
+            )
+            existing_preauthenticated_requests = [response.data]
+        else:
+            get_logger().debug(
+                "Listing all Preauthenticated Request Summaries under namespace %s and bucket %s",
+                namespace_name,
+                bucket_name,
+            )
+            optional_list_method_params = ["object_name_prefix"]
+            optional_kwargs = {
+                param: module.params[param]
+                for param in optional_list_method_params
+                if module.params.get(param) is not None
+            }
+            existing_preauthenticated_requests = to_dict(
+                oci_utils.list_all_resources(
+                    object_storage_client.list_preauthenticated_requests,
+                    namespace_name=namespace_name,
+                    bucket_name=bucket_name,
+                    **optional_kwargs
+                )
+            )
+    except ServiceError as ex:
+        get_logger().error(
+            "Unable to list Preauthenticated Requests due to %s", ex.message
+        )
+        module.fail_json(msg=ex.message)
+    result["preauthenticated_requests"] = to_dict(existing_preauthenticated_requests)
+    return result
+
+
+def set_logger(input_logger):
+    global logger
+    logger = input_logger
+
+
+def get_logger():
+    return logger
+
+
+def main():
+    logger = oci_utils.get_logger("oci_preauthenticated_request_facts")
+    set_logger(logger)
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(
+        dict(
+            namespace_name=dict(type="str", required=True),
+            bucket_name=dict(type="str", required=True),
+            par_id=dict(type="str", required=False, aliases=["id"]),
+            object_name_prefix=dict(type=str, required=False),
+        )
+    )
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    object_storage_client = oci_utils.create_service_client(module, ObjectStorageClient)
+    result = list_preauthenticated_requests(object_storage_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_virtual_circuit.py
+++ b/library/oci_virtual_circuit.py
@@ -1,0 +1,716 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_virtual_circuit
+short_description: Create, update and delete OCI Virtual Circuit
+description:
+    - Create an OCI Virtual Circuit to use with Oracle Cloud Infrastructure FastConnect
+    - Update an OCI Virtual Circuit, if present
+    - Delete an OCI Virtual Circuit, if present.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: Identifier of the compartment under which this Virtual Circuit
+                     would be created. Mandatory for create operation.
+        required: false
+    display_name:
+        description: A user-friendly name. Does not have to be unique, and it's changeable.
+                     Avoid entering confidential information.
+        required: false
+        aliases: ['name']
+    virtual_circuit_id:
+        description: Identifier of the Virtual Circuit. Mandatory for delete and update.
+        required: false
+        aliases: ['id']
+    bandwidth_shape_name:
+        description: The provisioned data rate of the connection.
+        required: false
+    cross_connect_mappings:
+        description: An array of mappings, each containing properties for a cross-connect or
+                     cross-connect group that is associated with this virtual circuit.
+        suboptions:
+            bgp_md5_auth_key:
+               description: The key for BGP MD5 authentication. Only applicable if your system
+                            requires MD5 authentication. If empty or not set, that means
+                            you don't use BGP MD5 authentication.
+               required: false
+            cross_connect_or_cross_connect_group_id:
+               description: The OCID of the cross-connect or cross-connect group for this mapping.
+                            Specified by the owner of the cross-connect or cross-connect group
+                            (the customer if the customer is colocated with Oracle, or the provider
+                            if the customer is connecting via provider).
+               required: false
+            customer_bgp_peering_ip:
+               description: The BGP IP address for the router on the other end of the BGP session from
+                            Oracle. Specified by the owner of that router. If the session goes from Oracle
+                            to a customer, this is the BGP IP address of the customer's edge router. If the
+                            session goes from Oracle to a provider, this is the BGP IP address of the provider's
+                            edge router. Must use a /30 or /31 subnet mask. There's one exception, for a public
+                            virtual circuit, Oracle specifies the BGP IP addresses.
+               required: false
+            oracle_bgp_peering_ip:
+               description: The IP address for Oracle's end of the BGP session. Must use a /30 or /31 subnet mask.
+                            If the session goes from Oracle to a customer's edge router, the customer specifies this
+                            information. If the session goes from Oracle to a provider's edge router, the provider
+                            specifies this. There's one exception, for a public virtual circuit, Oracle specifies the
+                            BGP IP addresses.
+               required: false
+            vlan:
+               description: The number of the specific VLAN (on the cross-connect or cross-connect group) that is assigned
+                            to this virtual circuit. Specified by the owner of the cross-connect or cross-connect group
+                            (the customer if the customer is colocated with Oracle, or the provider if the customer is
+                            connecting via provider).
+               required: false
+        required: false
+    customer_bgp_asn:
+        description: Your BGP ASN (either public or private). Provide this value only if there's a BGP session that goes from
+                     your edge router to Oracle. Otherwise, leave this empty or null.
+        required: false
+    gateway_id:
+        description: For private virtual circuits only. The OCID of the dynamic routing gateway (DRG) that this virtual circuit uses.
+        required: false
+    provider_name:
+        description: Deprecated. Instead use provider_service_id.
+        required: false
+    provider_service_id:
+        description: The OCID of the service offered by the provider (if you're connecting via a provider).
+        required: false
+    provider_service_name:
+        description: Deprecated. Instead use provider_service_id.
+        required: false
+    public_prefixes:
+        description: For a public virtual circuit. The public IP prefixes (CIDRs) the customer wants to advertise across the connection.
+        suboptions:
+              cidr_block:
+                    description: An individual public IP prefix (CIDR) to add to the public virtual circuit. Must be /31 or less specific.
+                    required: true
+        required: false
+    region:
+        description: The Oracle Cloud Infrastructure region where this virtual circuit is located.
+        required: false
+    type:
+        description: The type of IP addresses used in this virtual circuit. PRIVATE means RFC 1918 addresses (10.0.0.0/8, 172.16/12, and 192.168/16).
+                     Only PRIVATE is supported.
+        required: false
+        choices: ['PUBLIC','PRIVATE']
+    purge_cross_connect_mappings:
+        description: Purge cross connect mappings from virtual circuit which are not present in the provided cross connect
+                     mappings list.If I(purge_cross_connect_mappings=no), provided cross connect mappings would be appended to
+                     existing cross connect mappings. I(purge_cross_connect_mappings) and I(delete_cross_connect_mappings) are
+                     mutually exclusive.
+        required: false
+        default: true
+        type: bool
+    delete_cross_connect_mappings:
+        description: Delete any cross connect mappings in the virtual circuit that is specified in I(cross_connect_mappings).
+                     If I(delete_cross_connect_mappings=yes), cross connect mappings provided by I(cross_connect_mappings)
+                     would be deleted from existing cross connect mappings, if they are part of existing cross connect mappings.
+                     If they are not part of existing cross connect mappings, they will be ignored. I(delete_cross_connect_mappings)
+                     and I(purge_cross_connect_mappings) are mutually exclusive.
+        required: false
+        default: 'no'
+        type: bool
+    delete_public_prefixes:
+        description: Indicates whether public prefixes associated with a public virtual circuit needs to be deleted.
+                     If I(delete_public_prefixes=false), then input publi prefixes gets added.
+        required: false
+        default: false
+    reference_comment:
+        description: Provider-supplied reference information about this virtual circuit. Relevant only if the customer
+                     is using FastConnect via a provider. To be updated only by the provider.
+        required: false
+    provider_state:
+        description: The provider's state in relation to this virtual circuit. Relevant only if the customer is using
+                     FastConnect via a provider. ACTIVE means the provider has provisioned the virtual circuit from
+                     their end. INACTIVE means the provider has not yet provisioned the virtual circuit, or has
+                     de-provisioned it.
+        required: false
+        choices: ['ACTIVE','INACTIVE']
+    state:
+        description: Create,update or delete cross-connect group. For I(state=present), if it
+                     does not exists, it gets created. If exists, it gets updated.
+        required: false
+        default: 'present'
+        choices: ['present','absent']
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle, oracle_wait_options, oracle_creatable_resource ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Create a new colocated Virtual Circuit
+- name: Create a new colocated Virtual Circuit
+  oci_virtual_circuit:
+      compartment_id: 'ocid1.compartment..xxxxxEXAMPLExxxxx'
+      display_name: 'ansible-virtual-circuit'
+      cross_connect_mappings:
+            - cross_connect_or_cross_connect_group_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+              vlan: 100
+      public_prefixes:
+             - 206.209.218.0/24
+      customer_bgp_asn: 5
+      type: 'PUBLIC'
+      port_speed_shape_name: '10 Gbps'
+      state: 'present'
+
+# Create a new colocated Virtual Circuit
+- name: Create a new colocated Virtual Circuit of private type
+  oci_virtual_circuit:
+      compartment_id: 'ocid1.compartment..xxxxxEXAMPLExxxxx'
+      display_name: 'ansible-virtual-circuit-private'
+      cross_connect_mappings:
+            - cross_connect_or_cross_connect_group_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+              customer_bgp_peering_ip: '10.0.0.18/31'
+              oracle_bgp_peering_ip: '10.0.0.19/31'
+              vlan: 100
+      customer_bgp_asn: 5
+      type: 'PRIVATE'
+      port_speed_shape_name: '10 Gbps'
+      state: 'present'
+
+# Create a Virtual Circuit using Provider
+- name: Create a Virtual Circuit using Provider
+  oci_virtual_circuit:
+      compartment_id: 'ocid1.compartment..xxxxxEXAMPLExxxxx'
+      display_name: 'ansible-virtual-circuit'
+      provider_service_id: 'ocid1.providerservice...xxxxxEXAMPLExxxxx'
+      customer_bgp_asn: 5
+      type: 'PUBLIC'
+      port_speed_shape_name: '10 Gbps'
+      state: 'present'
+
+# Update an existing Virtual Circuit's Cross Connect Mappings
+- name: Update an existing Virtual Circuit's Cross Connect Mappings
+  oci_virtual_circuit:
+      virtual_circuit_id: 'ocid1.virtualcircuit..xxxxxEXAMPLExxxxx'
+      cross_connect_mappings:
+            - cross_connect_or_cross_connect_group_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+              vlan: 105
+      state: 'present'
+
+# Update an existing Virtual Circuit's Cross Connect Mappings by appending new Cross Connect Mappings
+- name: Update an existing Virtual Circuit's Cross Connect Mappings by appending new Cross Connect Mappings
+  oci_virtual_circuit:
+      virtual_circuit_id: 'ocid1.virtualcircuit..xxxxxEXAMPLExxxxx'
+      cross_connect_mappings:
+            - cross_connect_or_cross_connect_group_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+              vlan: 100
+      purge_cross_connect_mappings: false
+      state: 'present'
+
+# Update an existing Virtual Circuit's Cross Connect Mappings by deleting a Cross Connect Mappings
+- name: Update an existing Virtual Circuit's Cross Connect Mappings by deleting a Cross Connect Mappings
+  oci_virtual_circuit:
+      virtual_circuit_id: 'ocid1.virtualcircuit..xxxxxEXAMPLExxxxx'
+      cross_connect_mappings:
+            - cross_connect_or_cross_connect_group_id: 'ocid1.crossconnectgroup..xxxxxEXAMPLExxxxx'
+              vlan: 100
+      delete_cross_connect_mappings: false
+      state: 'present'
+
+# Update an existing Virtual Circuit by deleting Public Prefixes
+- name: Update an existing Virtual Circuit by deleting Public Prefixes
+  oci_virtual_circuit:
+      virtual_circuit_id: 'ocid1.virtualcircuit..xxxxxEXAMPLExxxxx'
+      public_prefixes:
+            - '10.0.0.21/31'
+      delete_public_prefixes: true
+      state: 'present'
+
+# Delete Virtual Circuit
+- name: Delete Virtual Circuit
+  oci_virtual_circuit:
+      virtual_circuit_id: 'ocid1.virtualcircuit..xxxxxEXAMPLExxxxx'
+      state: 'absent'
+"""
+
+RETURN = """
+    oci_virtual_circuit:
+        description: Attributes of the Virtual Circuit.
+        returned: success
+        type: complex
+        contains:
+            compartment_id:
+                description: The OCID of the compartment containing the Virtual Circuit.
+                returned: always
+                type: string
+                sample: ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx
+            display_name:
+                description: A user-friendly name. Does not have to be unique, and it's changeable.
+                             Avoid entering confidential information.
+                returned: always
+                type: string
+                sample: ansible-virtual-circuit
+            id:
+                description: Identifier of the Virtual Circuit.
+                returned: always
+                type: string
+                sample: ocid1.virtualcircuit.oc1.iad.xxxxxEXAMPLExxxxx
+            time_created:
+                description: Date and time when the Virtual Circuit was created, in
+                             the format defined by RFC3339
+                returned: always
+                type: datetime
+                sample: 2016-08-25T21:10:29.600Z
+            lifecycle_state:
+                description: The current state of the Virtual Circuit.
+                returned: always
+                type: string
+                sample: PROVISIONED
+            bgp_management:
+                description: BGP management option.
+                returned: always
+                type: string
+                sample: CUSTOMER_MANAGED
+            bgp_session_state:
+                description: The state of the BGP session associated with the virtual circuit.
+                returned: always
+                type: string
+                sample: UP
+            cross_connect_mappings:
+                description: An array of mappings, each containing properties for a cross-connect or
+                             cross-connect group that is associated with this virtual circuit.
+                returned: always
+                type: list
+                sample: [
+                          {
+                            "bgp_md5_auth_key":null,
+                            "cross_connect_or_cross_connect_group_id":null,
+                            "customer_bgp_peering_ip":"10.0.0.18/31",
+                            "oracle_bgp_peering_ip":"10.0.0.19/31",
+                            "vlan":null
+                          }
+                       ]
+            customer_bgp_asn:
+                description: The BGP ASN of the network at the other end of the BGP session from Oracle.
+                             If the session is between the customer's edge router and Oracle, the value is
+                             the customer's ASN. If the BGP session is between the provider's edge router
+                             and Oracle, the value is the provider's ASN.
+                returned: always
+                type: int
+                sample: 10
+            gateway_id:
+                description: The OCID of the customer's dynamic routing gateway (DRG) that this virtual
+                             circuit uses. Applicable only to private virtual circuits.
+                returned: always
+                type: string
+                sample: 'ocid1.drg..xxxxxEXAMPLExxxxx'
+            oracle_bgp_asn:
+                description: The Oracle BGP ASN.
+                returned: always
+                type: int
+                sample: 31898
+            provider_name:
+                description: Name of the Provider.
+                returned: always
+                type: string
+                sample: 'Megaport'
+            provider_service_id:
+                description: The OCID of the service offered by the provider (if the customer is
+                             connecting via a provider).
+                returned: always
+                type: string
+                sample: 'ocid1.providerservice.oc1..xxxxxEXAMPLExxxxx'
+            provider_service_name:
+                description: Name of the Provider Service.
+                returned: always
+                type: string
+                sample: 'Service'
+            provider_state:
+                description: The provider's state in relation to this virtual circuit (if the customer
+                             is connecting via a provider). ACTIVE means the provider has provisioned
+                             the virtual circuit from their end. INACTIVE means the provider has not
+                             yet provisioned the virtual circuit, or has de-provisioned it.
+                returned: always
+                type: string
+                sample: 'INACTIVE'
+            public_prefixes:
+                description: For a public virtual circuit. The public IP prefixes (CIDRs) the customer
+                             wants to advertise across the connection. Each prefix must be /31 or less
+                             specific.
+                returned: always
+                type: list
+                sample: [{
+                           'cidr_block': '10.0.0.10/31'
+
+                        }]
+            reference_comment:
+                description: Provider-supplied reference information about this virtual circuit
+                             (if the customer is connecting via a provider).
+                returned: always
+                type: string
+                sample: 'SAMPLE'
+            region:
+                description: The Oracle Cloud Infrastructure region where this virtual circuit is located.
+                returned: always
+                type: string
+                sample: 'phx'
+            service_type:
+                description: Provider service type.
+                returned: always
+                type: string
+                sample: 'COLOCATED'
+            type:
+                description: Whether the virtual circuit supports private or public peering.
+                returned: always
+                type: string
+                sample: 'PUBLIC'
+            port_speed_shape_name:
+                description: The port speed for this cross-connect.
+                returned: always
+                type: string
+                sample: 10 Gbps
+        sample: {
+                    "bandwidth_shape_name":"10 Gbps",
+                    "bgp_management":"CUSTOMER_MANAGED",
+                    "bgp_session_state":"DOWN",
+                    "compartment_id":"ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+                    "cross_connect_mappings":[
+                                              {
+                                                "bgp_md5_auth_key":null,
+                                                "cross_connect_or_cross_connect_group_id":"ocid1.crossconnectgroup.xxxxxEXAMPLExxxxx",
+                                                "customer_bgp_peering_ip":"169.254.203.202/30",
+                                                "oracle_bgp_peering_ip":"169.254.203.201/30",
+                                                "vlan":105
+                                              }
+                                             ],
+                    "customer_bgp_asn":5,
+                    "display_name":"sample-virtual-circuit",
+                    "gateway_id":null,
+                    "id":"ocid1.virtualcircuit.oc1..xxxxxEXAMPLExxxxx",
+                    "lifecycle_state":"PROVISIONED",
+                    "oracle_bgp_asn":31898,
+                    "provider_name":null,
+                    "provider_service_id":null,
+                    "provider_service_name":null,
+                    "provider_state":null,
+                    "public_prefixes":null,
+                    "reference_comment":null,
+                    "region":null,
+                    "service_type":"COLOCATED",
+                    "time_created":"2018-12-15T12:09:34.999000+00:00",
+                    "type":"PUBLIC"
+                }
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+    from oci.util import to_dict
+    from oci.core.models import (
+        CreateVirtualCircuitDetails,
+        CrossConnectMapping,
+        CreateVirtualCircuitPublicPrefixDetails,
+        DeleteVirtualCircuitPublicPrefixDetails,
+        UpdateVirtualCircuitDetails,
+        BulkAddVirtualCircuitPublicPrefixesDetails,
+        BulkDeleteVirtualCircuitPublicPrefixesDetails,
+    )
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def create_or_update_virtual_circuit(virtual_network_client, module):
+    result = dict(changed=False, virtual_circuit="")
+    virtual_circuit_id = module.params.get("virtual_circuit_id")
+    exclude_attributes = {"display_name": True, "public_prefixes": True}
+    try:
+        if virtual_circuit_id:
+            existing_virtual_circuit = oci_utils.get_existing_resource(
+                virtual_network_client.get_virtual_circuit,
+                module,
+                virtual_circuit_id=virtual_circuit_id,
+            )
+            result = update_virtual_circuit(
+                virtual_network_client, existing_virtual_circuit, module
+            )
+        else:
+            result = oci_utils.check_and_create_resource(
+                resource_type="virtual_circuit",
+                create_fn=create_virtual_circuit,
+                kwargs_create={
+                    "virtual_network_client": virtual_network_client,
+                    "module": module,
+                },
+                list_fn=virtual_network_client.list_virtual_circuits,
+                kwargs_list={"compartment_id": module.params.get("compartment_id")},
+                module=module,
+                exclude_attributes=exclude_attributes,
+                model=CreateVirtualCircuitDetails(),
+            )
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    except MaximumWaitTimeExceeded as ex:
+        module.fail_json(msg=str(ex))
+
+    return result
+
+
+def create_virtual_circuit(virtual_network_client, module):
+    create_virtual_circuit_details = CreateVirtualCircuitDetails()
+    for attribute in create_virtual_circuit_details.attribute_map:
+        create_virtual_circuit_details.__setattr__(
+            attribute, module.params.get(attribute)
+        )
+    create_virtual_circuit_details.cross_connect_mappings = get_cross_connect_mappings(
+        module
+    )
+    create_virtual_circuit_details.public_prefixes = get_public_prefixes(module)
+    result = oci_utils.create_and_wait(
+        resource_type="virtual_circuit",
+        create_fn=virtual_network_client.create_virtual_circuit,
+        kwargs_create={
+            "create_virtual_circuit_details": create_virtual_circuit_details
+        },
+        client=virtual_network_client,
+        get_fn=virtual_network_client.get_virtual_circuit,
+        get_param="virtual_circuit_id",
+        module=module,
+    )
+    return result
+
+
+def get_cross_connect_mappings(module):
+    input_cross_connect_mappings = module.params.get("cross_connect_mappings")
+    if input_cross_connect_mappings is None:
+        return None
+    result_cross_connect_mappings = []
+    for input_cross_connect_mapping_dict in input_cross_connect_mappings:
+        cross_connect_mapping = oci_utils.create_hashed_instance(CrossConnectMapping)
+        if module.params.get("type") == "PUBLIC" and (
+            input_cross_connect_mapping_dict.get("oracle_bgp_peering_ip")
+            or input_cross_connect_mapping_dict.get("customer_bgp_peering_ip")
+        ):
+            module.fail_json(
+                msg="oracle_bgp_peering_ip or customer_bgp_peering_ip is not allowed for public virual circuit"
+            )
+        if module.params.get("type") == "PRIVATE" and (
+            input_cross_connect_mapping_dict.get("oracle_bgp_peering_ip") is None
+            or input_cross_connect_mapping_dict.get("customer_bgp_peering_ip") is None
+        ):
+            module.fail_json(
+                msg="oracle_bgp_peering_ip and customer_bgp_peering_ip are mandatory for private virual circuit"
+            )
+        for attribute in cross_connect_mapping.attribute_map:
+            cross_connect_mapping.__setattr__(
+                attribute, input_cross_connect_mapping_dict.get(attribute)
+            )
+        result_cross_connect_mappings.append(cross_connect_mapping)
+    return result_cross_connect_mappings
+
+
+def get_public_prefixes(module):
+    input_public_prefixes = module.params.get("public_prefixes")
+    if input_public_prefixes is None:
+        return None
+    result_public_prefixes = []
+    virtual_circuit_public_prefixes_details = None
+    for input_public_prefix in input_public_prefixes:
+        if module.params.get("delete_public_prefixes"):
+            virtual_circuit_public_prefixes_details = (
+                DeleteVirtualCircuitPublicPrefixDetails()
+            )
+        else:
+            virtual_circuit_public_prefixes_details = (
+                CreateVirtualCircuitPublicPrefixDetails()
+            )
+        virtual_circuit_public_prefixes_details.cidr_block = input_public_prefix
+        result_public_prefixes.append(virtual_circuit_public_prefixes_details)
+
+    return result_public_prefixes
+
+
+def update_virtual_circuit(virtual_network_client, existing_virtual_circuit, module):
+    result = dict(virtual_circuit=to_dict(existing_virtual_circuit), changed=False)
+    attributes_changed = False
+    cross_connect_mappings_changed = False
+    update_virtual_circuit_details = UpdateVirtualCircuitDetails()
+    for attribute in update_virtual_circuit_details.attribute_map:
+        if attribute != "cross_connect_mappings":
+            attributes_changed = oci_utils.check_and_update_attributes(
+                update_virtual_circuit_details,
+                attribute,
+                module.params.get(attribute),
+                getattr(existing_virtual_circuit, attribute),
+                attributes_changed,
+            )
+    purge_cross_connect_mappings = module.params.get(
+        "purge_cross_connect_mappings", True
+    )
+    delete_cross_connect_mappings = module.params.get("delete_cross_connect_mappings")
+    input_cross_connect_mappings = get_cross_connect_mappings(module)
+    existing_cross_connect_mappings = oci_utils.get_hashed_object_list(
+        CrossConnectMapping, existing_virtual_circuit.cross_connect_mappings
+    )
+    if existing_virtual_circuit.type == "PUBLIC":
+        remove_assigned_bgp_peering_ips(existing_cross_connect_mappings)
+    if input_cross_connect_mappings is not None:
+        cross_connect_mappings, cross_connect_mappings_changed = oci_utils.check_and_return_component_list_difference(
+            input_cross_connect_mappings,
+            existing_cross_connect_mappings,
+            purge_cross_connect_mappings,
+            delete_cross_connect_mappings,
+        )
+    if cross_connect_mappings_changed:
+        update_virtual_circuit_details.cross_connect_mappings = cross_connect_mappings
+    else:
+        update_virtual_circuit_details.cross_connect_mappings = (
+            existing_cross_connect_mappings
+        )
+    if attributes_changed or cross_connect_mappings_changed:
+        result = oci_utils.update_and_wait(
+            resource_type="virtual_circuit",
+            update_fn=virtual_network_client.update_virtual_circuit,
+            kwargs_update={
+                "update_virtual_circuit_details": update_virtual_circuit_details,
+                "virtual_circuit_id": existing_virtual_circuit.id,
+            },
+            client=virtual_network_client,
+            get_fn=virtual_network_client.get_virtual_circuit,
+            get_param="virtual_circuit_id",
+            module=module,
+        )
+
+    if module.params.get("public_prefixes") is not None:
+        result = bulk_add_or_delete_public_prefixes(
+            get_public_prefixes(module),
+            virtual_network_client,
+            existing_virtual_circuit.id,
+            module,
+        )
+
+    return result
+
+
+def bulk_add_or_delete_public_prefixes(
+    input_public_prefixes, virtual_network_client, virtual_circuit_id, module
+):
+    update_fn = None
+    kwargs_update = None
+    virtual_circuit_public_prefixes_details = None
+    if module.params.get("delete_public_prefixes"):
+        virtual_circuit_public_prefixes_details = (
+            BulkDeleteVirtualCircuitPublicPrefixesDetails()
+        )
+        update_fn = virtual_network_client.bulk_delete_virtual_circuit_public_prefixes
+        kwargs_update = {
+            "bulk_delete_virtual_circuit_public_prefixes_details": virtual_circuit_public_prefixes_details,
+            "virtual_circuit_id": virtual_circuit_id,
+        }
+    else:
+        virtual_circuit_public_prefixes_details = (
+            BulkAddVirtualCircuitPublicPrefixesDetails()
+        )
+        update_fn = virtual_network_client.bulk_add_virtual_circuit_public_prefixes
+        kwargs_update = {
+            "bulk_add_virtual_circuit_public_prefixes_details": virtual_circuit_public_prefixes_details,
+            "virtual_circuit_id": virtual_circuit_id,
+        }
+    virtual_circuit_public_prefixes_details.public_prefixes = input_public_prefixes
+    result = oci_utils.update_and_wait(
+        resource_type="virtual_circuit",
+        update_fn=update_fn,
+        kwargs_update=kwargs_update,
+        client=virtual_network_client,
+        get_fn=virtual_network_client.get_virtual_circuit,
+        kwargs_get={"virtual_circuit_id": virtual_circuit_id},
+        get_param=None,
+        module=module,
+    )
+    return result
+
+
+def remove_assigned_bgp_peering_ips(existing_cross_connect_mappings):
+    for existing_cross_connect_mapping in existing_cross_connect_mappings:
+        existing_cross_connect_mapping.oracle_bgp_peering_ip = None
+        existing_cross_connect_mapping.customer_bgp_peering_ip = None
+
+
+def delete_virtual_circuit(virtual_network_client, module):
+    return oci_utils.delete_and_wait(
+        resource_type="virtual_circuit",
+        client=virtual_network_client,
+        get_fn=virtual_network_client.get_virtual_circuit,
+        kwargs_get={"virtual_circuit_id": module.params["virtual_circuit_id"]},
+        delete_fn=virtual_network_client.delete_virtual_circuit,
+        kwargs_delete={"virtual_circuit_id": module.params["virtual_circuit_id"]},
+        module=module,
+    )
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec(
+        supports_create=True, supports_wait=True
+    )
+    module_args.update(
+        compartment_id=dict(type="str", required=False),
+        display_name=dict(type="str", required=False, aliases=["name"]),
+        virtual_circuit_id=dict(type="str", required=False, aliases=["id"]),
+        bandwidth_shape_name=dict(type="str", required=False),
+        cross_connect_mappings=dict(type=list, required=False),
+        customer_bgp_asn=dict(type=int, required=False),
+        state=dict(
+            type="str", required=False, default="present", choices=["present", "absent"]
+        ),
+        gateway_id=dict(type="str", required=False),
+        provider_name=dict(type="str", required=False),
+        provider_service_id=dict(type="str", required=False),
+        provider_service_name=dict(type="str", required=False),
+        public_prefixes=dict(type=list, required=False),
+        reference_comment=dict(type="str", required=False),
+        region=dict(type="str", required=False),
+        provider_state=dict(type="str", required=False, choices=["ACTIVE", "INACTIVE"]),
+        type=dict(type="str", required=False, choices=["PUBLIC", "PRIVATE"]),
+        purge_cross_connect_mappings=dict(type="bool", required=False, default=True),
+        delete_cross_connect_mappings=dict(type="bool", required=False, default=False),
+        delete_public_prefixes=dict(type=bool, required=False, default=False),
+    )
+    module = AnsibleModule(
+        argument_spec=module_args,
+        mutually_exclusive=[
+            ["purge_cross_connect_mappings", "delete_cross_connect_mappings"]
+        ],
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    state = module.params["state"]
+
+    if state == "present":
+        result = create_or_update_virtual_circuit(virtual_network_client, module)
+    elif state == "absent":
+        result = delete_virtual_circuit(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_virtual_circuit_bandwidth_shape_facts.py
+++ b/library/oci_virtual_circuit_bandwidth_shape_facts.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_virtual_circuit_bandwidth_shape_facts
+short_description: Fetches details of one or more OCI virtual circuit bandwidth shapes
+description:
+     - Fetches details of the OCI virtual circuit bandwidth shapes
+version_added: "2.5"
+options:
+    compartment_id:
+        description: Identifier of the compartment under which virtual circuit bandwidth shapes exists
+        required: true
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch All virtual circuit bandwidth shapes under a specific compartment
+- name: FFetch All virtual circuit bandwidth shapes under a specific compartment
+  oci_virtual_circuit_bandwidth_shape_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+"""
+
+RETURN = """
+    oci_virtual_circuit_bandwidth_shapes:
+        description: Attributes of the virtual circuit bandwidth shapes.
+        returned: success
+        type: complex
+        contains:
+            name:
+                description: The name of the bandwidth shape.
+                returned: always
+                type: string
+                sample: 10 Gbps
+            bandwidth_in_mbps:
+                description: The bandwidth in Mbps.
+                returned: always
+                type: int
+                sample: 10
+        sample: [{
+                    "name": "1 Gbps",
+                    "bandwidth_in_mbps": 1000
+                }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+logger = None
+
+
+def list_virtual_circuit_bandwidth_shapes(virtual_network_client, module):
+    result = dict(virtual_circuit_bandwidth_shapes="")
+    compartment_id = module.params.get("compartment_id")
+    get_logger().info(
+        "Retrieving all virtual circuit Bandwidth Shapes in Compartment %s",
+        compartment_id,
+    )
+    try:
+        result["virtual_circuit_bandwidth_shapes"] = to_dict(
+            oci_utils.list_all_resources(
+                virtual_network_client.list_virtual_circuit_bandwidth_shapes,
+                compartment_id=compartment_id,
+            )
+        )
+    except ServiceError as ex:
+        get_logger().error(
+            "Unable to list all virtual circuit Bandwidth Shapes due to: %s", ex.message
+        )
+        module.fail_json(msg=ex.message)
+
+    return result
+
+
+def set_logger(input_logger):
+    global logger
+    logger = input_logger
+
+
+def get_logger():
+    return logger
+
+
+def main():
+    logger = oci_utils.get_logger("oci_virtual_circuit_bandwidth_shape_facts")
+    set_logger(logger)
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(dict(compartment_id=dict(type="str", required=True)))
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_virtual_circuit_bandwidth_shapes(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_virtual_circuit_facts.py
+++ b/library/oci_virtual_circuit_facts.py
@@ -1,0 +1,314 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_virtual_circuit_facts
+short_description: Fetches details of one or more OCI Virtual Circuits
+description:
+     - Fetches details of a specified OCI Virtual Circuit or all Virtual Circuit in a specified compartment.
+version_added: "2.5"
+options:
+    compartment_id:
+        description: Identifier of the compartment under which the specified Virtual Circuit exists
+        required: false
+    virtual_circuit_id:
+        description: Identifier of the Virtual Circuit whose details needs to be fetched.
+        required: false
+        aliases: [ 'id' ]
+    lifecycle_state:
+        description: A filter to return only resources that match the given lifecycle state.
+        required: false
+        choices: ["PENDING_PROVIDER", "VERIFYING", "PROVISIONING", "PROVISIONED", "FAILED", "INACTIVE", "TERMINATING", "TERMINATED"]
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle, oracle_display_name_option  ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch All Virtual Circuits under a specific compartment
+- name: Fetch All Virtual Circuits under a specific compartment
+  oci_virtual_circuit_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+# Fetch All Virtual Circuits under a specific compartment, filtered by
+# display name and lifecycle state
+- name: Fetch All Virtual Circuits under a specific compartment, filtered by display name and lifecycle state
+  oci_virtual_circuit_facts:
+      compartment_id: 'ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx'
+      display_name: 'ansible-virtual-circuit'
+      lifecycle_state: 'PROVISIONED'
+
+# Fetch a specific Virtual Circuit
+- name: Fetch a specific Virtual Circuit
+  oci_virtual_circuit_facts:
+      virtual_circuit_id: 'ocid1.virtualcircuit.oc1.iad.xxxxxEXAMPLExxxxx'
+"""
+
+RETURN = """
+    oci_virtual_circuits:
+        description: Attributes of the Fetched Virtual Circuit.
+        returned: success
+        type: complex
+        contains:
+            compartment_id:
+                description: The OCID of the compartment containing the Virtual Circuit.
+                returned: always
+                type: string
+                sample: ocid1.compartment.oc1.iad.xxxxxEXAMPLExxxxx
+            display_name:
+                description: A user-friendly name. Does not have to be unique, and it's changeable.
+                             Avoid entering confidential information.
+                returned: always
+                type: string
+                sample: ansible-virtual-circuit
+            id:
+                description: Identifier of the Virtual Circuit.
+                returned: always
+                type: string
+                sample: ocid1.virtualcircuit.oc1.iad.xxxxxEXAMPLExxxxx
+            time_created:
+                description: Date and time when the Virtual Circuit was created, in
+                             the format defined by RFC3339
+                returned: always
+                type: datetime
+                sample: 2016-08-25T21:10:29.600Z
+            lifecycle_state:
+                description: The current state of the Virtual Circuit.
+                returned: always
+                type: string
+                sample: PROVISIONED
+            bgp_management:
+                description: BGP management option.
+                returned: always
+                type: string
+                sample: CUSTOMER_MANAGED
+            bgp_session_state:
+                description: The state of the BGP session associated with the virtual circuit.
+                returned: always
+                type: string
+                sample: UP
+            cross_connect_mappings:
+                description: An array of mappings, each containing properties for a cross-connect or
+                             cross-connect group that is associated with this virtual circuit.
+                returned: always
+                type: list
+                sample: [
+                          {
+                            "bgp_md5_auth_key":null,
+                            "cross_connect_or_cross_connect_group_id":null,
+                            "customer_bgp_peering_ip":"10.0.0.18/31",
+                            "oracle_bgp_peering_ip":"10.0.0.19/31",
+                            "vlan":null
+                          }
+                       ]
+            customer_bgp_asn:
+                description: The BGP ASN of the network at the other end of the BGP session from Oracle.
+                             If the session is between the customer's edge router and Oracle, the value is
+                             the customer's ASN. If the BGP session is between the provider's edge router
+                             and Oracle, the value is the provider's ASN.
+                returned: always
+                type: int
+                sample: 10
+            gateway_id:
+                description: The OCID of the customer's dynamic routing gateway (DRG) that this virtual
+                             circuit uses. Applicable only to private virtual circuits.
+                returned: always
+                type: string
+                sample: 'ocid1.drg..xxxxxEXAMPLExxxxx'
+            oracle_bgp_asn:
+                description: The Oracle BGP ASN.
+                returned: always
+                type: int
+                sample: 31898
+            provider_name:
+                description: Name of the Provider.
+                returned: always
+                type: string
+                sample: 'Megaport'
+            provider_service_id:
+                description: The OCID of the service offered by the provider (if the customer is
+                             connecting via a provider).
+                returned: always
+                type: string
+                sample: 'ocid1.providerservice.oc1..xxxxxEXAMPLExxxxx'
+            provider_service_name:
+                description: Name of the Provider Service.
+                returned: always
+                type: string
+                sample: 'Service'
+            provider_state:
+                description: The provider's state in relation to this virtual circuit (if the customer
+                             is connecting via a provider). ACTIVE means the provider has provisioned
+                             the virtual circuit from their end. INACTIVE means the provider has not
+                             yet provisioned the virtual circuit, or has de-provisioned it.
+                returned: always
+                type: string
+                sample: 'INACTIVE'
+            public_prefixes:
+                description: For a public virtual circuit. The public IP prefixes (CIDRs) the customer
+                             wants to advertise across the connection. Each prefix must be /31 or less
+                             specific.
+                returned: always
+                type: list
+                sample: [{
+                           'cidr_block': '10.0.0.10/31'
+
+                        }]
+            reference_comment:
+                description: Provider-supplied reference information about this virtual circuit
+                             (if the customer is connecting via a provider).
+                returned: always
+                type: string
+                sample: 'SAMPLE'
+            region:
+                description: The Oracle Cloud Infrastructure region where this virtual circuit is located.
+                returned: always
+                type: string
+                sample: 'phx'
+            service_type:
+                description: Provider service type.
+                returned: always
+                type: string
+                sample: 'COLOCATED'
+            type:
+                description: Whether the virtual circuit supports private or public peering.
+                returned: always
+                type: string
+                sample: 'PUBLIC'
+            port_speed_shape_name:
+                description: The port speed for this cross-connect.
+                returned: always
+                type: string
+                sample: 10 Gbps
+        sample: [{
+                    "bandwidth_shape_name":"10 Gbps",
+                    "bgp_management":"CUSTOMER_MANAGED",
+                    "bgp_session_state":"DOWN",
+                    "compartment_id":"ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
+                    "cross_connect_mappings":[
+                                              {
+                                                "bgp_md5_auth_key":null,
+                                                "cross_connect_or_cross_connect_group_id":"ocid1.crossconnectgroup.xxxxxEXAMPLExxxxx",
+                                                "customer_bgp_peering_ip":"169.254.203.202/30",
+                                                "oracle_bgp_peering_ip":"169.254.203.201/30",
+                                                "vlan":105
+                                              }
+                                             ],
+                    "customer_bgp_asn":5,
+                    "display_name":"sample-virtual-circuit",
+                    "gateway_id":null,
+                    "id":"ocid1.virtualcircuit.oc1..xxxxxEXAMPLExxxxx",
+                    "lifecycle_state":"PROVISIONED",
+                    "oracle_bgp_asn":31898,
+                    "provider_name":null,
+                    "provider_service_id":null,
+                    "provider_service_name":null,
+                    "provider_state":null,
+                    "public_prefixes":null,
+                    "reference_comment":null,
+                    "region":null,
+                    "service_type":"COLOCATED",
+                    "time_created":"2018-12-15T12:09:34.999000+00:00",
+                    "type":"PUBLIC"
+                }]
+"""
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def list_virtual_circuits(virtual_network_client, module):
+    result = dict(virtual_circuits="")
+    compartment_id = module.params.get("compartment_id")
+    virtual_circuit_id = module.params.get("virtual_circuit_id")
+    try:
+        if compartment_id:
+            optional_list_method_params = ["display_name", "lifecycle_state"]
+            optional_kwargs = {
+                param: module.params[param]
+                for param in optional_list_method_params
+                if module.params.get(param) is not None
+            }
+            existing_virtual_circuits = oci_utils.list_all_resources(
+                virtual_network_client.list_virtual_circuits,
+                compartment_id=compartment_id,
+                **optional_kwargs
+            )
+        elif virtual_circuit_id:
+            response = oci_utils.call_with_backoff(
+                virtual_network_client.get_virtual_circuit,
+                virtual_circuit_id=virtual_circuit_id,
+            )
+            existing_virtual_circuits = [response.data]
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    result["virtual_circuits"] = to_dict(existing_virtual_circuits)
+    return result
+
+
+def main():
+    module_args = oci_utils.get_facts_module_arg_spec()
+    module_args.update(
+        dict(
+            compartment_id=dict(type="str", required=False),
+            virtual_circuit_id=dict(type="str", required=False, aliases=["id"]),
+            lifecycle_state=dict(
+                type="str",
+                required=False,
+                choices=[
+                    "PENDING_PROVIDER",
+                    "VERIFYING",
+                    "PROVISIONING",
+                    "PROVISIONED",
+                    "FAILED",
+                    "INACTIVE",
+                    "TERMINATING",
+                    "TERMINATED",
+                ],
+            ),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=module_args, mutually_exclusive=[["compartment_id", "id"]]
+    )
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_virtual_circuits(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_virtual_circuit_public_prefix_facts.py
+++ b/library/oci_virtual_circuit_public_prefix_facts.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_virtual_circuit_public_prefix_facts
+short_description: Fetches details of one or more OCI Virtual Circuit Public Prefixes
+description:
+     - Fetches details of all Virtual Circuit Public Prefixes of a specified Virtual Circuit.
+version_added: "2.5"
+options:
+    virtual_circuit_id:
+        description: Identifier of the Virtual Circuit whose Public Prefixes needs to be fetched.
+        required: false
+        aliases: [ 'id' ]
+    verification_state:
+        description: A filter to return only resources that match the given verification state.
+        required: false
+        choices: ["IN_PROGRESS", "COMPLETED", "FAILED"]
+author:
+    - "Debayan Gupta(@debayan_gupta)"
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+# Note: These examples do not set authentication details.
+# Fetch All Virtual Circuit Public Prefixes of a specific Virtual Circuit
+- name: Fetch All Virtual Circuit Public Prefixes of a specific Virtual Circuit
+  oci_virtual_circuit_public_prefix_facts:
+      virtual_circuit_id: 'ocid1.virtualcircuit.oc1.iad.xxxxxEXAMPLExxxxx'
+
+
+# Fetch All Virtual Circuit Public Prefixes of a specific Virtual Circuit, filtered by
+# verification state
+- name: Fetch All Virtual Circuits under a specific compartment, filtered by display name and lifecycle state
+  oci_virtual_circuit_public_prefix_facts:
+      virtual_circuit_id: 'ocid1.virtualcircuit.oc1.iad.xxxxxEXAMPLExxxxx'
+      verification_state: 'COMPLETED'
+"""
+
+RETURN = """
+    oci_virtual_circuit_public_prefixes:
+        description: Attributes of the Fetched Virtual Circuit Public Prefixes.
+        returned: success
+        type: complex
+        contains:
+            cidr_block:
+                description: Publix IP prefix (CIDR) that the customer specified.
+                returned: always
+                type: string
+                sample: 10.0.0.21/31
+            verification_state:
+                description: Oracle must verify that the customer owns the public
+                             IP prefix before traffic for that prefix can flow across the
+                             virtual circuit. Verification can take a few business days.
+                             IN_PROGRESS means Oracle is verifying the prefix. COMPLETED
+                             means verification succeeded. FAILED means verification failed
+                             and traffic for this prefix will not flow across the connection.
+                returned: always
+                type: string
+                sample: COMPLETED
+        sample: [{
+                    "cidr_block":"10.0.0.20/31",
+                    "verification_state":"COMPLETED"
+                }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.exceptions import ServiceError
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+def list_virtual_circuit_public_prefixes(virtual_network_client, module):
+    result = dict(virtual_circuit_public_prefixes="")
+    virtual_circuit_id = module.params.get("virtual_circuit_id")
+    try:
+        optional_list_method_params = ["verification_state"]
+        optional_kwargs = {
+            param: module.params[param]
+            for param in optional_list_method_params
+            if module.params.get(param) is not None
+        }
+        existing_virtual_circuit_public_prefixes = oci_utils.list_all_resources(
+            virtual_network_client.list_virtual_circuit_public_prefixes,
+            virtual_circuit_id=virtual_circuit_id,
+            **optional_kwargs
+        )
+        result["virtual_circuit_public_prefixes"] = to_dict(
+            existing_virtual_circuit_public_prefixes
+        )
+    except ServiceError as ex:
+        module.fail_json(msg=ex.message)
+    return result
+
+
+def main():
+    module_args = oci_utils.get_common_arg_spec()
+    module_args.update(
+        dict(
+            virtual_circuit_id=dict(type="str", required=False, aliases=["id"]),
+            verification_state=dict(
+                type="str",
+                required=False,
+                choices=["IN_PROGRESS", "COMPLETED", "FAILED"],
+            ),
+        )
+    )
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module")
+
+    virtual_network_client = oci_utils.create_service_client(
+        module, VirtualNetworkClient
+    )
+
+    result = list_virtual_circuit_public_prefixes(virtual_network_client, module)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/block_volume/attach_connect_block_volume/README.md
+++ b/samples/block_volume/attach_connect_block_volume/README.md
@@ -29,4 +29,4 @@ ansible cloud modules, please provide values (that are specific to your tenancy)
 for the following variables in the `vars` section of `sample.yaml`:
 - instance_ad
 - instance_compartment
-- instance_image  # provide an OEL image
+- instance_image  # provide an OL image

--- a/samples/block_volume/attach_connect_block_volume/sample.yaml
+++ b/samples/block_volume/attach_connect_block_volume/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -40,11 +40,11 @@
     #########################################
     # Tenancy specific configuration
     # *Note* - Override the following variables based on your tenancy
-    # or set a valid value for the corresponding environment variable     
+    # or set a valid value for the corresponding environment variable
     #########################################
     instance_ad: "{{ lookup('env', 'SAMPLE_AD_NAME') }}"
     instance_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # provide an OEL image
+    # provide an OL image
     instance_image: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
 
   tasks:

--- a/samples/block_volume/attach_connect_block_volume/setup.yaml
+++ b/samples/block_volume/attach_connect_block_volume/setup.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -162,12 +162,12 @@
     ansible_connection: local
 
 - set_fact:
-    # Use "opc" user as this is an OEL image
+    # Use "opc" user as this is an OL image
     # Disable SSH's strict host key checking just for this one command invocation
     common_ssh_args: '-o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i {{ temp_certificates_path }}/private_key.pem opc@{{ instance_public_ip }}'
 
 - name: Attempt a ssh connection to the newly launced instance
-  # Use "opc" user as this is an OEL image
+  # Use "opc" user as this is an OL image
   # Disable SSH's strict host key checking just for this one command invocation
   command: "ssh {{ common_ssh_args }} uname -a"
   retries: 3

--- a/samples/compute/create_instance_pool/README.md
+++ b/samples/compute/create_instance_pool/README.md
@@ -14,4 +14,4 @@ The sample
 To run the sample, after ensuring that you have the pre-requisites for OCI ansible cloud modules, please provide values (that are specific to your tenancy) for the following variables in the `vars` section of `sample.yaml`:
 - instance_ad
 - instance_compartment
-- instance_image  # provide an OEL image
+- instance_image  # provide an OL image

--- a/samples/compute/create_instance_pool/sample.yaml
+++ b/samples/compute/create_instance_pool/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -38,11 +38,11 @@
     #########################################
     # Tenancy specific configuration
     # *Note* - Override the following variables based on your tenancy
-    # or set a valid value for the corresponding environment variable 
+    # or set a valid value for the corresponding environment variable
     #########################################
     instance_ad: "{{ lookup('env', 'SAMPLE_AD_NAME') }}"
     instance_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # provide an "OEL" image
+    # provide an "OL" image
     instance_image: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
 
   tasks:
@@ -74,7 +74,7 @@
 
     - set_fact:
         instance_configuration_id: "{{result.instance_configuration.id }}"
-        
+
 
     - name: Create a new instance pool from this instance configuration
       oci_instance_pool:
@@ -103,11 +103,11 @@
     - name: Print details of instances in the new instance pool
       debug:
         msg: "Instances in instance pool {{instance_pool_id}} are {{ result.instance_pool_instances }}"
-      
+
     - name: Get the first instance from the pool
       set_fact:
         instance_id: "{{result.instance_pool_instances[0].id}}"
-    
+
     - name: Get the VNIC attachment details of that instance
       oci_vnic_attachment_facts:
         compartment_id: "{{ instance_compartment }}"
@@ -135,7 +135,7 @@
         ansible_connection: local
 
     - name: Attempt a ssh connection to the newly launced instance
-      # Use "opc" user as this is an OEL image
+      # Use "opc" user as this is an OL image
       # Disable SSH's strict host key checking just for this one command invocation
       command: ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i {{ temp_certificates_path }}/private_key.pem opc@{{ instance_public_ip }} uname -a
       retries: 3

--- a/samples/compute/instance-console-connections-and-capture-console-history/README.md
+++ b/samples/compute/instance-console-connections-and-capture-console-history/README.md
@@ -12,4 +12,4 @@ The sample
 To run the sample, after ensuring that you have the pre-requisites for OCI ansible cloud modules, please provide values (that are specific to your tenancy) for the following variables in the `vars` section of `sample.yaml`:
 - instance_ad
 - instance_compartment
-- instance_image  # provide an OEL image
+- instance_image  # provide an OL image

--- a/samples/compute/instance-console-connections-and-capture-console-history/sample.yaml
+++ b/samples/compute/instance-console-connections-and-capture-console-history/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -42,7 +42,7 @@
     #########################################
     instance_ad: "{{ lookup('env', 'SAMPLE_AD_NAME') }}"
     instance_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # provide an "OEL" image
+    # provide an "OL" image
     instance_image: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
 
   tasks:

--- a/samples/compute/launch_compute_instance/README.md
+++ b/samples/compute/launch_compute_instance/README.md
@@ -12,4 +12,4 @@ The sample
 To run the sample, after ensuring that you have the pre-requisites for OCI ansible cloud modules, please provide values (that are specific to your tenancy) for the following variables in the `vars` section of `sample.yaml`:
 - instance_ad
 - instance_compartment
-- instance_image  # provide an OEL image
+- instance_image  # provide an OL image

--- a/samples/compute/launch_compute_instance/sample.yaml
+++ b/samples/compute/launch_compute_instance/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -38,11 +38,11 @@
     #########################################
     # Tenancy specific configuration
     # *Note* - Override the following variables based on your tenancy
-    # or set a valid value for the corresponding environment variable 
+    # or set a valid value for the corresponding environment variable
     #########################################
     instance_ad: "{{ lookup('env', 'SAMPLE_AD_NAME') }}"
     instance_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # provide an "OEL" image
+    # provide an "OL" image
     instance_image: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
 
   tasks:
@@ -96,7 +96,7 @@
         ansible_connection: local
 
     - name: Attempt a ssh connection to the newly launced instance
-      # Use "opc" user as this is an OEL image
+      # Use "opc" user as this is an OL image
       # Disable SSH's strict host key checking just for this one command invocation
       command: ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i {{ temp_certificates_path }}/private_key.pem opc@{{ instance_public_ip }} uname -a
       retries: 3

--- a/samples/compute/nat_gateway_configuration/sample.yaml
+++ b/samples/compute/nat_gateway_configuration/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -47,7 +47,7 @@
     public_subnet_instance_hostname: "mypublicinstance"
     private_subnet_instance_hostname: "myprivateinstance"
 
-    # Use "opc" as the user, as this is an OEL image
+    # Use "opc" as the user, as this is an OL image
     ssh_user: "opc"
     ssh_disable_strict_host_key_checking_args: '-o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no"'
     ssh_credentials_arg: "-i {{ temp_certificates_path }}/private_key.pem"
@@ -55,12 +55,12 @@
     #########################################
     # Tenancy specific configuration
     # *Note* - Override the following variables based on your tenancy
-    # or set a valid value for the corresponding environment variable     
+    # or set a valid value for the corresponding environment variable
     #########################################
     instance_ad: "{{ lookup('env', 'SAMPLE_AD_NAME') }}"
     instance_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # provide an OEL image
-    instance_image: "{{ lookup('env', 'SAMPLE_OEL_IMAGE_OCID') }}"
+    # provide an OL image
+    instance_image: "{{ lookup('env', 'SAMPLE_OL_IMAGE_OCID') }}"
 
   tasks:
     - import_tasks: setup.yaml

--- a/samples/compute/nat_gateway_configuration/setup.yaml
+++ b/samples/compute/nat_gateway_configuration/setup.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -11,7 +11,7 @@
   when: item not in ansible_env
   with_items:
     - "SAMPLE_COMPARTMENT_OCID"
-    - "SAMPLE_OEL_IMAGE_OCID"
+    - "SAMPLE_OL_IMAGE_OCID"
     - "SAMPLE_AD_NAME"
 
 - name: Create a temporary directory to house a temporary SSH keypair we will later use to connect to instance
@@ -255,4 +255,4 @@
 - name: Print the private ip of the newly launched instance
   debug:
     msg: "Private IP of the instance launched in the private subnet {{ private_instance_private_ip }}"
-    
+

--- a/samples/compute/nat_instance_configuration/sample.yaml
+++ b/samples/compute/nat_instance_configuration/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -46,7 +46,7 @@
     public_subnet_instance_hostname: "mypublicinstance"
     private_subnet_instance_hostname: "myprivateinstance"
 
-    # Use "opc" as the user, as this is an OEL image
+    # Use "opc" as the user, as this is an OL image
     ssh_user: "opc"
     ssh_disable_strict_host_key_checking_args: '-o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no"'
     ssh_credentials_arg: "-i {{ temp_certificates_path }}/private_key.pem"
@@ -58,7 +58,7 @@
     #########################################
     instance_ad: "{{ lookup('env', 'SAMPLE_AD_NAME') }}"
     instance_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # provide an OEL image
+    # provide an OL image
     instance_image: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
 
   tasks:

--- a/samples/compute/service_gateway/sample.yaml
+++ b/samples/compute/service_gateway/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -7,7 +7,7 @@
 
 - name: Launch a private compute instance and connect to object storage via storage gateway
   hosts: localhost
-  
+
   vars:
     # common networking definitions
     quad_zero_route: "0.0.0.0/0"
@@ -17,13 +17,13 @@
     #########################################
     # Tenancy specific configuration
     # *Note* - Override the following variables based on your tenancy
-    # or set a valid value for the corresponding environment variable     
+    # or set a valid value for the corresponding environment variable
     #########################################
     tenancy_ocid: "{{ lookup('env', 'SAMPLE_TENANCY_OCID') }}"
     instance_ad: "{{ lookup('env', 'SAMPLE_AD_NAME') }}"
     instance_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # provide an OEL image
-    instance_image: "{{ lookup('env', 'SAMPLE_OEL_IMAGE_OCID') }}"
+    # provide an OL image
+    instance_image: "{{ lookup('env', 'SAMPLE_OL_IMAGE_OCID') }}"
     namespace_name: "{{ lookup('env', 'SAMPLE_OBJECT_NS_NAME') }}"
     region: "{{ lookup('env', 'SAMPLE_REGION') }}"
 
@@ -42,13 +42,13 @@
 
     public_subnet_securitylist_name: "mysecuritylist_for_{{public_subnet_name}}"
     private_subnet_securitylist_name: "mysecuritylist_for_{{private_subnet_name}}"
-    
+
     public_subnet_route_table_name: "myroutetable_for_{{public_subnet_name}}"
     # route all internet access from the public subnet to the Internet Gateway
     public_subnet_route_table_rules:
         - cidr_block: "{{ quad_zero_route }}"
           network_entity_id: "{{ ig_id }}"
-    
+
     public_instance_egress_security_rules:
       # Allow all connections outside
       - destination: "{{ quad_zero_route }}"
@@ -64,7 +64,7 @@
             max: "{{ SSH_port }}"
 
     private_subnet_route_table_name: "myroutetable_for_{{private_subnet_name}}"
-    
+
     # temporary rule which allows private instance to install oci cli
     quad_zero_nat_gateway_route_rule:
       destination: "{{ quad_zero_route }}"
@@ -72,17 +72,17 @@
 
     private_subnet_route_table_rules_temp:
       - "{{ quad_zero_nat_gateway_route_rule }}"
-    
+
     object_storage_destination_type: "SERVICE_CIDR_BLOCK"
     object_service_route_rule:
       destination: "{{ object_storage_destination }}"
       destination_type: "{{ object_storage_destination_type }}"
       network_entity_id: "{{ sg_id }}"
-    
+
     # route rule to allow private object storage access via Service Gateway
     private_subnet_route_table_rules:
       - "{{ object_service_route_rule }}"
-    
+
     private_instance_egress_security_rules:
       # Allow all connections outside
       - destination: "{{ quad_zero_route }}"
@@ -104,7 +104,7 @@
     public_subnet_instance_hostname: "mybastioninstance"
     private_subnet_instance_hostname: "myprivateinstance"
 
-    # Use "opc" as the user, as this is an OEL image
+    # Use "opc" as the user, as this is an OL image
     ssh_user: "opc"
     ssh_disable_strict_host_key_checking_args: '-o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no"'
     ssh_credentials_arg: "-i {{ temp_certificates_path }}/private_key.pem"
@@ -141,16 +141,16 @@
     - name: Print bucket create response
       debug:
         msg: "Create bucket reponse -> {{ result.stdout }}"
-    
+
     - name: get the bucket details
       oci_bucket_facts:
         namespace_name: "{{ namespace_name }}"
         name: "{{ test_bucket_name }}"
       register: result
-    
+
     - debug:
         msg: "{{ result.buckets }}"
-      
+
     - name: verify that the bucket is created
       assert:
         that:

--- a/samples/compute/service_gateway/setup.yaml
+++ b/samples/compute/service_gateway/setup.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -12,7 +12,7 @@
   with_items:
     - "SAMPLE_TENANCY_OCID"
     - "SAMPLE_COMPARTMENT_OCID"
-    - "SAMPLE_OEL_IMAGE_OCID"
+    - "SAMPLE_OL_IMAGE_OCID"
     - "SAMPLE_AD_NAME"
     - "SAMPLE_OBJECT_NS_NAME"
     - "SAMPLE_REGION"

--- a/samples/file_storage/create_and_mount_file_system/README.md
+++ b/samples/file_storage/create_and_mount_file_system/README.md
@@ -2,7 +2,7 @@
 
 This sample shows how a File System can be created and accessed through compute instances, through OCI ansible cloud modules.
 
-The sample 
+The sample
 - Generates all network related dependencies (e.g. VCN, subnets) and security list with configuration required by File System Service
 - Generates required certificates required by instances
 - Demonstrates the procedure to create File System Service components e.g. Mount Target, File System, Export and Snapshot
@@ -12,4 +12,4 @@ The sample
 
 To run the sample, after ensuring that you have the pre-requisites for OCI ansible cloud modules, please provide values (that are specific to your tenancy) for the following variables in the `vars` section of `sample.yaml`:
 - compartment_id
-- instance_image # provide an OEL image
+- instance_image # provide an OL image

--- a/samples/file_storage/create_and_mount_file_system/sample.yaml
+++ b/samples/file_storage/create_and_mount_file_system/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -44,7 +44,7 @@
     # or set a valid value for the corresponding environment variable
     #########################################
     compartment_id: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # This image must be of type Oracle Linux in order for this example to work
+    # This image must be of type Oracle Linux(OL) in order for this example to work
     instance_image: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
 
   tasks:
@@ -149,7 +149,7 @@
         ansible_connection: local
 #==========================================================================================
     - name: Mount the filesystem in the first instance and create a directory
-      # Use "opc" user as this is an OEL image
+      # Use "opc" user as this is an OL image
       # Disable SSH's strict host key checking just for this one command invocation
       # Installs nfs-utils to mount the File System and create a directory in the File System
       command: ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i {{ temp_certificates_path }}/private_key.pem opc@{{ first_instance_public_ip }} "sudo yum -y install nfs-utils > nfs-utils-install.log;sudo mkdir -p /mnt{{ export_path }};sudo mount {{ mount_target_ip_address }}:{{ export_path }} /mnt{{ export_path }};cd /mnt{{ export_path }};sudo mkdir filesystem_test"
@@ -214,7 +214,7 @@
 # first instance. Here listing the files in the folder shared through the export path lists same file created
 # through first instance.
     - name: Mount the filesystem in the second instance and list all content
-      # Use "opc" user as this is an OEL image
+      # Use "opc" user as this is an OL image
       # Disable SSH's strict host key checking just for this one command invocation
       # Access the File System and list it's content. The directory created bu the first
       # instance should be listed

--- a/samples/file_storage/multiple_file_systems_with_mount_targets/README.md
+++ b/samples/file_storage/multiple_file_systems_with_mount_targets/README.md
@@ -14,4 +14,4 @@ The sample
 
 To run the sample, after ensuring that you have the pre-requisites for OCI ansible cloud modules, please provide values (that are specific to your tenancy) for the following variables in the `vars` section of `sample.yaml`:
 - compartment_id
-- instance_image # provide an OEL image
+- instance_image # provide an OL image

--- a/samples/file_storage/multiple_file_systems_with_mount_targets/sample.yaml
+++ b/samples/file_storage/multiple_file_systems_with_mount_targets/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -46,7 +46,7 @@
     # or set a valid value for the corresponding environment variable
     #########################################
     compartment_id: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # This image must be of type Oracle Linux in order for this example to work
+    # This image must be of type Oracle Linux(OL) in order for this example to work
     instance_image: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
 
   tasks:
@@ -219,7 +219,7 @@
         ansible_connection: local
 #==========================================================================================
     - name: Mount the filesystem in the instance and create a directory
-      # Use "opc" user as this is an OEL image
+      # Use "opc" user as this is an OL image
       # Disable SSH's strict host key checking just for this one command invocation
       # Installs nfs-utils to mount the File System and create a directory in the File System
       command: ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i {{ temp_certificates_path }}/private_key.pem opc@{{ instance_public_ip }} "sudo yum -y install nfs-utils > nfs-utils-install.log;sudo mkdir -p /mnt{{ mt1_fs1_export_path }};sudo mount {{ mt1_ip_address }}:{{ mt1_fs1_export_path }} /mnt{{ mt1_fs1_export_path }};cd /mnt{{ mt1_fs1_export_path }};sudo mkdir filesystem_test"

--- a/samples/iam/iam-use-instance-principal-auth/README.md
+++ b/samples/iam/iam-use-instance-principal-auth/README.md
@@ -18,5 +18,5 @@ If you want to author a playbook that is tied to, and only needs to use, instanc
 To run the sample, after ensuring that you have the pre-requisites for OCI ansible cloud modules, please provide values (that are specific to your tenancy) for the following variables in the `vars` section of `sample.yaml`:
 - `sample_tenancy_ocid`
 - `sample_compartment_ocid`
-- `sample_image_ocid` (Provide an Oracle Linux image ocid)
+- `sample_image_ocid` (Provide an Oracle Linux(OL) image ocid)
 - `sample_ad_name`

--- a/samples/iam/iam-use-instance-principal-auth/instance-principal-test.sh
+++ b/samples/iam/iam-use-instance-principal-auth/instance-principal-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -11,7 +11,7 @@
 # all compute instances in the current compartment. It employs the instance
 # principal for authentication
 
-# This script assumes an Centos/RHEL/Oracle Linux instance
+# This script assumes an Centos/RHEL/Oracle Linux(OL) instance
 
 # install pre-reqs (python, git, oci SDK, oci ansible modules)
 sudo yum install -y python-pip

--- a/samples/iam/iam-use-instance-principal-auth/setup.yaml
+++ b/samples/iam/iam-use-instance-principal-auth/setup.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -192,7 +192,7 @@
     ansible_connection: local
 
 - name: Test a ssh connection to the newly launced instance
-  # Use "opc" user as this is an OEL image
+  # Use "opc" user as this is an OL image
   # Disable SSH's strict host key checking just for this one command invocation
   command: ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i {{ temp_certificates_path }}/private_key.pem opc@{{ instance_public_ip }} uname -a
   retries: 3

--- a/samples/load_balancing/create_load_balancer/sample.yaml
+++ b/samples/load_balancing/create_load_balancer/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -51,7 +51,7 @@
     # or set a valid value for the corresponding environment variable
     #########################################
     compartment_id: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # This image must be of type Oracle Linux in order for this example to work
+    # This image must be of type Oracle Linux(OL) in order for this example to work
     sample_app_server_image_id: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
 
 # Create a public load balancer with the variables initialized in the beginning

--- a/samples/networking/private_subnets_with_vpn/sample.yaml
+++ b/samples/networking/private_subnets_with_vpn/sample.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -56,7 +56,7 @@
     ad1: "{{ lookup('env', 'SAMPLE_AD1_NAME') }}"
     ad2: "{{ lookup('env', 'SAMPLE_AD2_NAME') }}"
     sample_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
-    # provide an OEL image OCID if you want to launch instances
+    # provide an OL image OCID if you want to launch instances
     instance_image: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
     cpe_ip_address: "{{ lookup('env', 'SAMPLE_CPE_IP_ADDRESS') }}"
     static_route: "{{ lookup('env', 'SAMPLE_STATIC_ROUTE') }}"

--- a/samples/solutions/secure-mongodb-deployment/README.md
+++ b/samples/solutions/secure-mongodb-deployment/README.md
@@ -29,7 +29,7 @@ various OCI Services and resources used in this sample is shown below
 - Ensure that you have a valid OCI SDK configuration at the default config path ~/.oci/config
 - Export the following environment variables specific to your tenancy:
   SAMPLE_COMPARTMENT_OCID
-  SAMPLE_OEL_IMAGE_OCID
+  SAMPLE_OL_IMAGE_OCID
   SAMPLE_AD1_NAME
   SAMPLE_AD2_NAME
 - Run the demo playbook to create the Secure MongoDB topology in OCI

--- a/samples/solutions/secure-mongodb-deployment/roles/appserver/vars/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/appserver/vars/main.yml
@@ -1,11 +1,11 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
 
-demo_appserver_image_ocid: "{{ lookup('env', 'SAMPLE_OEL_IMAGE_OCID') }}"
+demo_appserver_image_ocid: "{{ lookup('env', 'SAMPLE_OL_IMAGE_OCID') }}"
 demo_appserver_availability_domain_ad1: "{{ lookup('env', 'SAMPLE_AD1_NAME') }}"
 demo_appserver_1_name: "{{ demo_var_prefix }}_appserver_1"
 demo_appserver_2_name: "{{ demo_var_prefix }}_appserver_2"

--- a/samples/solutions/secure-mongodb-deployment/roles/bastion/vars/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/bastion/vars/main.yml
@@ -1,11 +1,11 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
 
-bastion_image_ocid: "{{ lookup('env', 'SAMPLE_OEL_IMAGE_OCID') }}"
+bastion_image_ocid: "{{ lookup('env', 'SAMPLE_OL_IMAGE_OCID') }}"
 bastion_shape: "VM.Standard1.1"
 bastion_availability_domain: "{{ lookup('env', 'SAMPLE_AD2_NAME') }}"
 

--- a/samples/solutions/secure-mongodb-deployment/roles/common/tasks/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/common/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -16,7 +16,7 @@
     - "SAMPLE_COMPARTMENT_OCID"
     - "SAMPLE_AD1_NAME"
     - "SAMPLE_AD2_NAME"
-    - "SAMPLE_OEL_IMAGE_OCID"
+    - "SAMPLE_OL_IMAGE_OCID"
 
 - name: Create a temporary directory to house a temporary SSH keypair to connect to bastion instance
   tempfile:

--- a/samples/solutions/secure-mongodb-deployment/roles/mongo/vars/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/mongo/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -7,7 +7,7 @@
 
 compartment_id: "{{ demo_compartment_ocid }}"
 
-mongodb_image_id: "{{ lookup('env', 'SAMPLE_OEL_IMAGE_OCID') }}"
+mongodb_image_id: "{{ lookup('env', 'SAMPLE_OL_IMAGE_OCID') }}"
 
 availability_domain_1: "{{ lookup('env', 'SAMPLE_AD1_NAME') }}"
 availability_domain_2: "{{ lookup('env', 'SAMPLE_AD2_NAME') }}"

--- a/samples/solutions/secure-mongodb-deployment/roles/nat_instance/vars/main.yml
+++ b/samples/solutions/secure-mongodb-deployment/roles/nat_instance/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -13,5 +13,5 @@ demo_public_subnet_dns_label: "demo{{ random_suffix }}subnet"
 demo_public_subnet_security_list_name: "{{ demo_var_prefix }}_public_subnet"
 
 nat_instance_name: "{{ demo_var_prefix }}_nat_instance_for_mongodb_setup"
-nat_instance_image_ocid: "{{ lookup('env', 'SAMPLE_OEL_IMAGE_OCID') }}"
+nat_instance_image_ocid: "{{ lookup('env', 'SAMPLE_OL_IMAGE_OCID') }}"
 nat_instance_shape: "VM.Standard1.1"

--- a/test/units/test_oci_backup_facts.py
+++ b/test/units/test_oci_backup_facts.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+import logging
+from ansible.modules.cloud.oracle import oci_backup_facts
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    import oci
+    from oci.database.models import Backup
+    from oci.exceptions import ServiceError
+except ImportError:
+    raise SkipTest("test_oci_backup_facts.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def db_client(mocker):
+    mock_db_client = mocker.patch("oci.database.database_client.DatabaseClient")
+    return mock_db_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def setUpModule():
+    logging.basicConfig(
+        filename="/tmp/oci_ansible_module.log", filemode="a", level=logging.INFO
+    )
+    oci_backup_facts.set_logger(logging)
+
+
+def test_list_backups_list_by_compartment_id(db_client, list_all_resources_patch):
+    module = get_module(dict({"compartment_id": "ocid1.compartment.aaaa"}))
+    list_all_resources_patch.return_value = get_backups()
+    result = oci_backup_facts.list_backups(db_client, module)
+    assert len(result["backups"]) is 2
+
+
+def test_list_backups_list_by_database_id(db_client, list_all_resources_patch):
+    module = get_module(dict({"database_id": "ocid1.database.aaaa"}))
+    list_all_resources_patch.return_value = get_backups()
+    result = oci_backup_facts.list_backups(db_client, module)
+    assert len(result["backups"]) is 2
+
+
+def test_list_backups_list_specific(db_client):
+    module = get_module(dict({"backup_id": "ocid1.backup.aaaa"}))
+    backup = get_backup()
+    db_client.get_backup.return_value = get_response(200, None, backup, None)
+    result = oci_backup_facts.list_backups(db_client, module)
+    assert result["backups"][0]["display_name"] is backup.display_name
+
+
+def test_list_db_systems_service_error(db_client):
+    error_message = "Internal Server Error"
+    module = get_module(dict({"backup_id": "ocid1.backup.aaaa"}))
+    db_client.get_db_system.side_effect = ServiceError(
+        499, "InternalServerError", dict(), error_message
+    )
+    try:
+        oci_backup_facts.list_backups(db_client, module)
+    except Exception as ex:
+        assert error_message in ex.args[0]
+
+
+def get_backups():
+    backups = []
+    backup1 = Backup()
+    backup1.display_name = "ansible-backup1"
+    backup2 = Backup()
+    backup2.display_name = "ansible-backup2"
+    backups.append(backup1)
+    backups.append(backup2)
+    return backups
+
+
+def get_backup():
+    backup = Backup()
+    backup.display_name = "ansible-backup"
+    return backup
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties):
+    params = dict()
+    params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_bucket.py
+++ b/test/units/test_oci_bucket.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2018, 2019, Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -12,7 +12,12 @@ from ansible.module_utils.oracle import oci_utils
 
 try:
     import oci
-    from oci.object_storage.models import Bucket, ListObjects, ObjectSummary
+    from oci.object_storage.models import (
+        Bucket,
+        ListObjects,
+        ObjectSummary,
+        PreauthenticatedRequestSummary,
+    )
     from oci.exceptions import ServiceError
 except ImportError:
     raise SkipTest("test_oci_bucket.py requires `oci` module")
@@ -48,6 +53,11 @@ def get_existing_bucket_patch(mocker):
 @pytest.fixture()
 def delete_all_objects_in_bucket_patch(mocker):
     return mocker.patch.object(oci_bucket, "delete_all_objects_in_bucket")
+
+
+@pytest.fixture()
+def delete_all_pars_of_bucket_patch(mocker):
+    return mocker.patch.object(oci_bucket, "delete_all_pars_of_bucket")
 
 
 @pytest.fixture()
@@ -117,7 +127,7 @@ def test_get_exisiting_bucket_failure_service_error(object_storage_client):
         assert error_message in ex.args[0]
 
 
-def test__create_or_update_bucket_create_bucket_service_error(
+def test_create_or_update_bucket_create_bucket_service_error(
     object_storage_client, get_existing_bucket_patch
 ):
     get_existing_bucket_patch.return_value = None
@@ -132,7 +142,7 @@ def test__create_or_update_bucket_create_bucket_service_error(
         assert error_message in ex.args[0]
 
 
-def test__create_or_update_bucket_update_bucket_service_error(
+def test_create_or_update_bucket_update_bucket_service_error(
     object_storage_client, get_existing_bucket_patch
 ):
     get_existing_bucket_patch.return_value = oci.object_storage.models.Bucket()
@@ -183,7 +193,10 @@ def test_delete_bucket_success(object_storage_client, get_existing_bucket_patch)
 
 
 def test_delete_bucket_success_with_force(
-    object_storage_client, get_existing_bucket_patch, delete_all_objects_in_bucket_patch
+    object_storage_client,
+    get_existing_bucket_patch,
+    delete_all_objects_in_bucket_patch,
+    delete_all_pars_of_bucket_patch,
 ):
     module = get_module()
     module.params.update({"force": True})
@@ -227,6 +240,16 @@ def test_delete_all_objects_in_bucket(object_storage_client, list_all_resources_
         object_storage_client, "test_namespace", "test_bucket"
     )
     assert object_storage_client.delete_object.called
+
+
+def test_delete_all_pars_of_bucket(object_storage_client, list_all_resources_patch):
+    preauthenticated_request_summary = PreauthenticatedRequestSummary()
+    preauthenticated_request_summary.name = "test_par"
+    list_all_resources_patch.return_value = [preauthenticated_request_summary]
+    oci_bucket.delete_all_pars_of_bucket(
+        object_storage_client, "test_namespace", "test_bucket"
+    )
+    assert object_storage_client.delete_preauthenticated_request.called
 
 
 def get_response(status, header, data, request):

--- a/test/units/test_oci_cross_connect.py
+++ b/test/units/test_oci_cross_connect.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_cross_connect
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import CrossConnect
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest("test_oci_cross_connect.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def get_existing_resource_patch(mocker):
+    return mocker.patch.object(oci_utils, "get_existing_resource")
+
+
+@pytest.fixture()
+def create_cross_connect_patch(mocker):
+    return mocker.patch.object(oci_cross_connect, "create_cross_connect")
+
+
+@pytest.fixture()
+def update_cross_connect_patch(mocker):
+    return mocker.patch.object(oci_cross_connect, "update_cross_connect")
+
+
+@pytest.fixture()
+def check_and_create_resource_patch(mocker):
+    return mocker.patch.object(oci_utils, "check_and_create_resource")
+
+
+@pytest.fixture()
+def create_and_wait_patch(mocker):
+    return mocker.patch.object(oci_utils, "create_and_wait")
+
+
+@pytest.fixture()
+def check_and_update_resource_patch(mocker):
+    return mocker.patch.object(oci_utils, "check_and_update_resource")
+
+
+@pytest.fixture()
+def delete_and_wait_patch(mocker):
+    return mocker.patch.object(oci_utils, "delete_and_wait")
+
+
+def test_create_or_update_cross_connect_create_success(
+    virtual_network_client, check_and_create_resource_patch
+):
+    cross_connect = get_cross_connect()
+    module = get_module(dict())
+    check_and_create_resource_patch.return_value = dict(
+        {"cross_connect": cross_connect, "changed": True}
+    )
+    result = oci_cross_connect.create_or_update_cross_connect(
+        virtual_network_client, module
+    )
+    assert result["cross_connect"].display_name == cross_connect.display_name
+    assert result["changed"] is True
+
+
+def test_create_or_update_cross_connect_update_success(
+    virtual_network_client, update_cross_connect_patch
+):
+    cross_connect = get_cross_connect()
+    module = get_module(dict({"cross_connect_id": "test_cross_connect_id"}))
+    get_existing_resource_patch.return_value = cross_connect
+    update_cross_connect_patch.return_value = dict(
+        changed=True, cross_connect=to_dict(cross_connect)
+    )
+    result = oci_cross_connect.create_or_update_cross_connect(
+        virtual_network_client, module
+    )
+    assert result["cross_connect"]["display_name"] == cross_connect.display_name
+    assert result["changed"] is True
+
+
+def test_create_or_update_cross_connect_service_error(
+    virtual_network_client, update_cross_connect_patch
+):
+    error_message = "Internal Server Error"
+    module = get_module(dict({"cross_connect_id": "test_cross_connect_id"}))
+    update_cross_connect_patch.side_effect = ServiceError(
+        500, "InternalServerError", dict(), error_message
+    )
+    try:
+        oci_cross_connect.create_or_update_cross_connect(virtual_network_client, module)
+    except Exception as ex:
+        assert error_message in ex.args[0]
+
+
+def test_create_or_update_cross_connect_timeout_error(
+    virtual_network_client, update_cross_connect_patch
+):
+    error_message = "Maximum Timeout Reached"
+    module = get_module(dict({"cross_connect_id": "test_cross_connect_id"}))
+    update_cross_connect_patch.side_effect = MaximumWaitTimeExceeded(
+        500, "TimeOutError", dict(), error_message
+    )
+    try:
+        oci_cross_connect.create_or_update_cross_connect(virtual_network_client, module)
+    except Exception as ex:
+        assert error_message in ex.args[0].__repr__()
+
+
+def test_create_cross_connect(virtual_network_client, create_and_wait_patch):
+    module = get_module(dict({"display_name": "ansible_ig", "is_enabled": True}))
+    cross_connect = get_cross_connect()
+    create_and_wait_patch.return_value = dict(
+        {"cross_connect": to_dict(cross_connect), "changed": True}
+    )
+    result = oci_cross_connect.create_cross_connect(virtual_network_client, module)
+    assert result["cross_connect"]["display_name"] == cross_connect.display_name
+
+
+def test_update_cross_connect_success(
+    virtual_network_client, check_and_update_resource_patch
+):
+    module = get_module(
+        dict(
+            display_name="ansible_ig_updated",
+            cross_connect_id="ocid1.crossconnect..xvzf",
+        )
+    )
+    cross_connect = get_cross_connect()
+    check_and_update_resource_patch.return_value = dict(
+        {"cross_connect": cross_connect, "changed": True}
+    )
+    oci_cross_connect.update_cross_connect(
+        virtual_network_client, cross_connect, module
+    )
+    assert check_and_update_resource_patch.called
+
+
+def test_delete_cross_connect(virtual_network_client, delete_and_wait_patch):
+    cross_connect = get_cross_connect()
+    module = get_module(dict({"cross_connect_id": "ocid1.crossconnect..xvzf"}))
+    get_existing_resource_patch.return_value = cross_connect
+    oci_cross_connect.delete_cross_connect(virtual_network_client, module)
+    assert delete_and_wait_patch.called
+
+
+def get_cross_connect():
+    cross_connect = CrossConnect()
+    cross_connect.compartment_id = "ocid1.compartment..axsd"
+    cross_connect.cross_connect_group_id = "ocid1.crossconectgroup..fxdv"
+    cross_connect.id = "ocid1.crossconnect..vfgc"
+    cross_connect.display_name = "ansible_cross_connect"
+    cross_connect.location_name = "Equinix DC6, Ashburn, VA"
+    cross_connect.port_name = "sample_port"
+    cross_connect.port_speed_shape_name = "10 Gbps"
+    cross_connect.lifecycle_state = "AVAILABLE"
+    cross_connect.time_created = "2018-08-25T21:10:29.600Z"
+
+    return cross_connect
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties):
+    params = {"compartment_id": "ocid1.comp..axsd"}
+    params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_cross_connect_facts.py
+++ b/test/units/test_oci_cross_connect_facts.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_cross_connect_facts
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import CrossConnect
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest("test_oci_cross_connect_facts.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def test_list_cross_connects_all(virtual_network_client, list_all_resources_patch):
+    module = get_module()
+    cross_connects = get_cross_connects()
+    list_all_resources_patch.return_value = cross_connects
+    result = oci_cross_connect_facts.list_cross_connects(virtual_network_client, module)
+    assert result["cross_connects"][0]["display_name"] == cross_connects[0].display_name
+
+
+def test_list_cross_connects_specific(virtual_network_client, list_all_resources_patch):
+    module = get_module(dict(cross_connect_id="ocid1.crossconnect..vgfc"))
+    cross_connects = get_cross_connects()
+    list_all_resources_patch.return_value = cross_connects
+    result = oci_cross_connect_facts.list_cross_connects(virtual_network_client, module)
+    assert result["cross_connects"][0]["display_name"] == cross_connects[0].display_name
+
+
+def get_cross_connects():
+    cross_connects = []
+    cross_connect = CrossConnect()
+    cross_connect.compartment_id = "ocid1.compartment..axsd"
+    cross_connect.cross_connect_group_id = "ocid1.crossconectgroup..fxdv"
+    cross_connect.id = "ocid1.crossconnect..vfgc"
+    cross_connect.display_name = "ansible_cross_connect"
+    cross_connect.location_name = "Equinix DC6, Ashburn, VA"
+    cross_connect.port_name = "sample_port"
+    cross_connect.port_speed_shape_name = "10 Gbps"
+    cross_connect.lifecycle_state = "AVAILABLE"
+    cross_connect.time_created = "2018-08-25T21:10:29.600Z"
+    cross_connects.append(cross_connect)
+    return cross_connects
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"compartment_id": "ocid1.compartment..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_cross_connect_group.py
+++ b/test/units/test_oci_cross_connect_group.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_cross_connect_group
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import CrossConnectGroup
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest("test_oci_cross_connect_group.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def get_existing_resource_patch(mocker):
+    return mocker.patch.object(oci_utils, "get_existing_resource")
+
+
+@pytest.fixture()
+def create_cross_connect_group_patch(mocker):
+    return mocker.patch.object(oci_cross_connect_group, "create_cross_connect_group")
+
+
+@pytest.fixture()
+def update_cross_connect_group_patch(mocker):
+    return mocker.patch.object(oci_cross_connect_group, "update_cross_connect_group")
+
+
+@pytest.fixture()
+def check_and_create_resource_patch(mocker):
+    return mocker.patch.object(oci_utils, "check_and_create_resource")
+
+
+@pytest.fixture()
+def create_and_wait_patch(mocker):
+    return mocker.patch.object(oci_utils, "create_and_wait")
+
+
+@pytest.fixture()
+def check_and_update_resource_patch(mocker):
+    return mocker.patch.object(oci_utils, "check_and_update_resource")
+
+
+@pytest.fixture()
+def delete_and_wait_patch(mocker):
+    return mocker.patch.object(oci_utils, "delete_and_wait")
+
+
+def test_create_or_update_cross_connect_group_create_success(
+    virtual_network_client, check_and_create_resource_patch
+):
+    cross_connect_group = get_cross_connect_group()
+    module = get_module(dict())
+    check_and_create_resource_patch.return_value = dict(
+        {"cross_connect_group": cross_connect_group, "changed": True}
+    )
+    result = oci_cross_connect_group.create_or_update_cross_connect_group(
+        virtual_network_client, module
+    )
+    assert (
+        result["cross_connect_group"].display_name == cross_connect_group.display_name
+    )
+    assert result["changed"] is True
+
+
+def test_create_or_update_cross_connect_group_update_success(
+    virtual_network_client, update_cross_connect_group_patch
+):
+    cross_connect_group = get_cross_connect_group()
+    module = get_module(
+        dict({"cross_connect_group_id": "ocid1.crossconnectgroup..xvfd"})
+    )
+    get_existing_resource_patch.return_value = cross_connect_group
+    update_cross_connect_group_patch.return_value = dict(
+        changed=True, cross_connect_group=to_dict(cross_connect_group)
+    )
+    result = oci_cross_connect_group.create_or_update_cross_connect_group(
+        virtual_network_client, module
+    )
+    assert (
+        result["cross_connect_group"]["display_name"]
+        == cross_connect_group.display_name
+    )
+    assert result["changed"] is True
+
+
+def test_create_or_update_cross_connect_group_service_error(
+    virtual_network_client, update_cross_connect_group_patch
+):
+    error_message = "Internal Server Error"
+    module = get_module(
+        dict({"cross_connect_group_id": "ocid1.crossconnectgroup..xvfd"})
+    )
+    update_cross_connect_group_patch.side_effect = ServiceError(
+        500, "InternalServerError", dict(), error_message
+    )
+    try:
+        oci_cross_connect_group.create_or_update_cross_connect_group(
+            virtual_network_client, module
+        )
+    except Exception as ex:
+        assert error_message in ex.args[0]
+
+
+def test_create_or_update_cross_connect_group_timeout_error(
+    virtual_network_client, update_cross_connect_group_patch
+):
+    error_message = "Maximum Timeout Reached"
+    module = get_module(
+        dict({"cross_connect_group_id": "ocid1.crossconnectgroup..xvfd"})
+    )
+    update_cross_connect_group_patch.side_effect = MaximumWaitTimeExceeded(
+        500, "TimeOutError", dict(), error_message
+    )
+    try:
+        oci_cross_connect_group.create_or_update_cross_connect_group(
+            virtual_network_client, module
+        )
+    except Exception as ex:
+        assert error_message in ex.args[0].__repr__()
+
+
+def test_create_cross_connect_group(virtual_network_client, create_and_wait_patch):
+    module = get_module(dict({"display_name": "ansible_cross_connect_group"}))
+    cross_connect_group = get_cross_connect_group()
+    create_and_wait_patch.return_value = dict(
+        {"cross_connect_group": to_dict(cross_connect_group), "changed": True}
+    )
+    result = oci_cross_connect_group.create_cross_connect_group(
+        virtual_network_client, module
+    )
+    assert (
+        result["cross_connect_group"]["display_name"]
+        == cross_connect_group.display_name
+    )
+
+
+def test_update_cross_connect_group_success(
+    virtual_network_client, check_and_update_resource_patch
+):
+    module = get_module(
+        dict(
+            display_name="ansible_cross_connect_group_updated",
+            cross_connect_group_id="ocid1.crossconnectgroup..xvzf",
+        )
+    )
+    cross_connect_group = get_cross_connect_group()
+    check_and_update_resource_patch.return_value = dict(
+        {"cross_connect_group": cross_connect_group, "changed": True}
+    )
+    oci_cross_connect_group.update_cross_connect_group(
+        virtual_network_client, cross_connect_group, module
+    )
+    assert check_and_update_resource_patch.called
+
+
+def test_delete_cross_connect_group(virtual_network_client, delete_and_wait_patch):
+    cross_connect_group = get_cross_connect_group()
+    module = get_module(
+        dict({"cross_connect_group_id": "ocid1.crossconnectgroup..xvzf"})
+    )
+    get_existing_resource_patch.return_value = cross_connect_group
+    oci_cross_connect_group.delete_cross_connect_group(virtual_network_client, module)
+    assert delete_and_wait_patch.called
+
+
+def get_cross_connect_group():
+    cross_connect_group = CrossConnectGroup()
+    cross_connect_group.compartment_id = "ocid1.compartment..axsd"
+    cross_connect_group.cross_connect_group_id = "ocid1.crossconectgroup..fxdv"
+    cross_connect_group.display_name = "ansible_cross_connect_group"
+    cross_connect_group.lifecycle_state = "AVAILABLE"
+    cross_connect_group.time_created = "2018-08-25T21:10:29.600Z"
+
+    return cross_connect_group
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties):
+    params = {"compartment_id": "ocid1.comp..axsd"}
+    params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_cross_connect_group_facts.py
+++ b/test/units/test_oci_cross_connect_group_facts.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_cross_connect_group_facts
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import CrossConnectGroup
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest("test_oci_cross_connect_group_facts.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def test_list_cross_connect_groups_all(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module()
+    cross_connects = get_cross_connects()
+    list_all_resources_patch.return_value = cross_connects
+    result = oci_cross_connect_group_facts.list_cross_connect_groups(
+        virtual_network_client, module
+    )
+    assert (
+        result["cross_connect_groups"][0]["display_name"]
+        == cross_connects[0].display_name
+    )
+
+
+def test_list_cross_connect_groups_specific(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module(dict(cross_connect_group_id="ocid1.crossconnectgroup..vgfc"))
+    cross_connects = get_cross_connects()
+    list_all_resources_patch.return_value = cross_connects
+    result = oci_cross_connect_group_facts.list_cross_connect_groups(
+        virtual_network_client, module
+    )
+    assert (
+        result["cross_connect_groups"][0]["display_name"]
+        == cross_connects[0].display_name
+    )
+
+
+def get_cross_connects():
+    cross_connect_groups = []
+    cross_connect_group = CrossConnectGroup()
+    cross_connect_group.compartment_id = "ocid1.compartment..axsd"
+    cross_connect_group.id = "ocid1.crossconectgroup..fxdv"
+    cross_connect_group.display_name = "ansible_cross_connect_group"
+    cross_connect_group.lifecycle_state = "AVAILABLE"
+    cross_connect_group.time_created = "2018-08-25T21:10:29.600Z"
+    cross_connect_groups.append(cross_connect_group)
+    return cross_connect_groups
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"compartment_id": "ocid1.compartment..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_cross_connect_letter_of_authority_facts.py
+++ b/test/units/test_oci_cross_connect_letter_of_authority_facts.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_letter_of_authority_facts
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import LetterOfAuthority
+except ImportError:
+    raise SkipTest("test_oci_letter_of_authority_facts.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+def test_list_cross_connect_letter_of_authorities_all(virtual_network_client):
+    module = get_module()
+    letter_of_authority = get_letter_of_authority()
+    virtual_network_client.get_cross_connect_letter_of_authority.return_value = get_response(
+        200, None, letter_of_authority, None
+    )
+    result = oci_letter_of_authority_facts.list_letter_of_authorities(
+        virtual_network_client, module
+    )
+    assert (
+        result["letter_of_authorities"][0]["circuit_type"]
+        == letter_of_authority.circuit_type
+    )
+
+
+def get_letter_of_authority():
+    letter_of_authority = LetterOfAuthority()
+    letter_of_authority.authorized_entity_name = "Example Authorized Entity Name"
+    letter_of_authority.circuit_type = "Single_mode_LC"
+    letter_of_authority.cross_connect_id = "ocid1.crossconnect..vfgc"
+    letter_of_authority.facility_location = "Example Location"
+    letter_of_authority.time_expires = "2018-03-03T06:55:49.463000+00:00"
+    letter_of_authority.time_issued = "2018-02-03T06:55:49.463000+00:00"
+    return letter_of_authority
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"cross_connect_id": "ocid1.crossconnect..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_cross_connect_location_facts.py
+++ b/test/units/test_oci_cross_connect_location_facts.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+import logging
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_cross_connect_location_facts
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import CrossConnectLocation
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest("test_oci_cross_connect_location_facts.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def setUpModule():
+    logging.basicConfig(
+        filename="/tmp/oci_ansible_module.log", filemode="a", level=logging.INFO
+    )
+    oci_cross_connect_location_facts.set_logger(logging)
+
+
+def test_list_cross_connect_locations_all(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module()
+    cross_connect_locations = get_cross_connect_locations()
+    list_all_resources_patch.return_value = cross_connect_locations
+    result = oci_cross_connect_location_facts.list_cross_connect_locations(
+        virtual_network_client, module
+    )
+    assert (
+        result["cross_connect_locations"][0]["name"] == cross_connect_locations[0].name
+    )
+
+
+def get_cross_connect_locations():
+    cross_connect_locations = []
+    cross_connect_location = CrossConnectLocation()
+    cross_connect_location.description = "Equinox"
+    cross_connect_location.name = "Equinox"
+    cross_connect_locations.append(cross_connect_location)
+    return cross_connect_locations
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"compartment_id": "ocid1.compartment..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_cross_connect_port_speed_shape_facts.py
+++ b/test/units/test_oci_cross_connect_port_speed_shape_facts.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+import logging
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_cross_connect_port_speed_shape_facts
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import CrossConnectPortSpeedShape
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest(
+        "test_oci_cross_connect_port_speed_shape_facts.py requires `oci` module"
+    )
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def setUpModule():
+    logging.basicConfig(
+        filename="/tmp/oci_ansible_module.log", filemode="a", level=logging.INFO
+    )
+    oci_cross_connect_port_speed_shape_facts.set_logger(logging)
+
+
+def test_list_cross_connect_port_speed_shapes_all(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module()
+    cross_connect_port_speed_shapes = get_cross_connect_port_speed_shapes()
+    list_all_resources_patch.return_value = cross_connect_port_speed_shapes
+    result = oci_cross_connect_port_speed_shape_facts.list_cross_connect_port_speed_shapes(
+        virtual_network_client, module
+    )
+    assert (
+        result["cross_connect_port_speed_shapes"][0]["name"]
+        == cross_connect_port_speed_shapes[0].name
+    )
+
+
+def get_cross_connect_port_speed_shapes():
+    cross_connect_port_speed_shapes = []
+    cross_connect_port_speed_shape = CrossConnectPortSpeedShape()
+    cross_connect_port_speed_shape.name = "10 Gbps"
+    cross_connect_port_speed_shape.port_speed_in_gbps = 10
+    cross_connect_port_speed_shapes.append(cross_connect_port_speed_shape)
+    return cross_connect_port_speed_shapes
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"compartment_id": "ocid1.compartment..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_cross_connect_status_facts.py
+++ b/test/units/test_oci_cross_connect_status_facts.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+import logging
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_cross_connect_status_facts
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import CrossConnectStatus
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest("test_oci_cross_connect_status_facts.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def setUpModule():
+    logging.basicConfig(
+        filename="/tmp/oci_ansible_module.log", filemode="a", level=logging.INFO
+    )
+    oci_cross_connect_status_facts.set_logger(logging)
+
+
+def test_list_cross_connect_statuses_all(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module()
+    cross_connect_statuses = get_cross_connect_statuses()
+    virtual_network_client.get_cross_connect_status.return_value = (
+        cross_connect_statuses
+    )
+    result = oci_cross_connect_status_facts.list_cross_connect_statuses(
+        virtual_network_client, module
+    )
+    assert (
+        result["cross_connect_statuses"][0]["light_level_indicator"]
+        == cross_connect_statuses[0].light_level_indicator
+    )
+
+
+def get_cross_connect_statuses():
+    cross_connect_statuses = []
+    cross_connect_status = CrossConnectStatus()
+    cross_connect_status.cross_connect_id = "ocid1.crossconnect..axsd"
+    cross_connect_status.interface_state = "UP"
+    cross_connect_status.light_level_ind_bm = 14.0
+    cross_connect_status.light_level_indicator = "GOOD"
+    cross_connect_statuses.append(cross_connect_status)
+    return cross_connect_statuses
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"compartment_id": "ocid1.compartment..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_fast_connect_provider_service_facts.py
+++ b/test/units/test_oci_fast_connect_provider_service_facts.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_fast_connect_provider_service_facts
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import FastConnectProviderService
+except ImportError:
+    raise SkipTest(
+        "test_oci_fast_connect_provider_service_facts.py requires `oci` module"
+    )
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def test_list_fast_connect_provider_services_all(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module()
+    fast_connect_provider_services = get_fast_connect_provider_services()
+    list_all_resources_patch.return_value = fast_connect_provider_services
+    result = oci_fast_connect_provider_service_facts.list_fast_connect_provider_services(
+        virtual_network_client, module
+    )
+    assert (
+        result["fast_connect_provider_services"][0]["description"]
+        == fast_connect_provider_services[0].description
+    )
+
+
+def test_list_fast_connect_provider_services_specific(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module(dict(provider_service_id="ocid1.providerservice..vgfc"))
+    fast_connect_provider_services = get_fast_connect_provider_services()
+    list_all_resources_patch.return_value = fast_connect_provider_services
+    result = oci_fast_connect_provider_service_facts.list_fast_connect_provider_services(
+        virtual_network_client, module
+    )
+    assert (
+        result["fast_connect_provider_services"][0]["description"]
+        == fast_connect_provider_services[0].description
+    )
+
+
+def get_fast_connect_provider_services():
+    fast_connect_provider_services = []
+    fast_connect_provider_service = FastConnectProviderService()
+    fast_connect_provider_service.description = "https://testexample.com"
+    fast_connect_provider_service.id = "ocid1.providerservice..fxdv"
+    fast_connect_provider_service.private_peering_bgp_management = "CUSTOMER_MANAGED"
+    fast_connect_provider_service.provider_name = "Example Provider"
+    fast_connect_provider_service.provider_service_name = "Example Provider Service"
+    fast_connect_provider_service.public_peering_bgp_management = "ORACLE_MANAGED"
+    fast_connect_provider_service.supported_virtual_circuit_types = [
+        "PRIVATE",
+        "PUBLIC",
+    ]
+    fast_connect_provider_service.type = "LAYER2"
+    fast_connect_provider_services.append(fast_connect_provider_service)
+    return fast_connect_provider_services
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"compartment_id": "ocid1.compartment..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts.py
+++ b/test/units/test_oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import (
+    oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts,
+)
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import VirtualCircuitBandwidthShape
+except ImportError:
+    raise SkipTest(
+        "test_oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts.py requires `oci` module"
+    )
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def test_list_fast_connect_provider_virtual_circuit_bandwidth_shapes_all(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module()
+    fast_connect_provider_virtual_circuit_bandwidth_shapes = (
+        get_fast_connect_provider_virtual_circuit_bandwidth_shapes()
+    )
+    list_all_resources_patch.return_value = (
+        fast_connect_provider_virtual_circuit_bandwidth_shapes
+    )
+    result = oci_fast_connect_provider_virtual_circuit_bandwidth_shape_facts.list_fast_connect_provider_virtual_circuit_bandwidth_shapes(
+        virtual_network_client, module
+    )
+    assert (
+        result["fast_connect_provider_virtual_circuit_bandwidth_shapes"][0]["name"]
+        == fast_connect_provider_virtual_circuit_bandwidth_shapes[0].name
+    )
+
+
+def get_fast_connect_provider_virtual_circuit_bandwidth_shapes():
+    fast_connect_provider_virtual_circuit_bandwidth_shapes = []
+    virtual_circuit_bandwidth_shape = VirtualCircuitBandwidthShape()
+    virtual_circuit_bandwidth_shape.bandwidth_in_mbps = 1000
+    virtual_circuit_bandwidth_shape.name = "1 Mbps"
+    fast_connect_provider_virtual_circuit_bandwidth_shapes.append(
+        virtual_circuit_bandwidth_shape
+    )
+    return fast_connect_provider_virtual_circuit_bandwidth_shapes
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"provider_service_id": "ocid1.serviceprovider..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_group.py
+++ b/test/units/test_oci_group.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -547,7 +547,11 @@ def get_response(status, header, data, request):
 
 
 def get_module(additional_properties):
-    params = {"name": "test_group", "description": "Test Group"}
+    params = {
+        "name": "test_group",
+        "description": "Test Group",
+        "delete_user_memberships": False,
+    }
     # if additional_properties:
     params.update(additional_properties)
     module = FakeModule(**params)

--- a/test/units/test_oci_preauthenticated_request.py
+++ b/test/units/test_oci_preauthenticated_request.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+import logging
+from ansible.modules.cloud.oracle import oci_preauthenticated_request
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.object_storage.models import PreauthenticatedRequest
+    from oci.exceptions import ServiceError, ClientError
+except ImportError:
+    raise SkipTest("test_oci_preauthenicated_request.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def identity_client(mocker):
+    mock_identity_client = mocker.patch("oci.identity.identity_client.IdentityClient")
+    return mock_identity_client.return_value
+
+
+@pytest.fixture()
+def create_resource_patch(mocker):
+    return mocker.patch.object(oci_utils, "create_resource")
+
+
+@pytest.fixture()
+def delete_and_wait_patch(mocker):
+    return mocker.patch.object(oci_utils, "delete_and_wait")
+
+
+def setUpModule():
+    logging.basicConfig(
+        filename="/tmp/oci_ansible_module.log", filemode="a", level=logging.INFO
+    )
+    oci_preauthenticated_request.set_logger(logging)
+
+
+def test_create__preauthenicate_request(identity_client, create_resource_patch):
+    module = get_module()
+    preauthenticated_request = get_preauthenticated_request()
+    create_resource_patch.return_value = {
+        "preauthenticated_request": to_dict(preauthenticated_request),
+        "changed": True,
+    }
+    result = oci_preauthenticated_request.create_preauthenticated_request(
+        identity_client, module
+    )
+    assert result["preauthenticated_request"]["name"] is preauthenticated_request.name
+
+
+def test_delete_suppression(identity_client, delete_and_wait_patch):
+    module = get_module(dict({"par_id": "rE=:test.html"}))
+    preauthenticated_request = get_preauthenticated_request()
+    delete_and_wait_patch.return_value = dict(
+        {"preauthenticated_request": to_dict(preauthenticated_request), "changed": True}
+    )
+    result = oci_preauthenticated_request.delete_preauthenticated_request(
+        identity_client, module
+    )
+    assert result["changed"] is True
+
+
+def get_preauthenticated_request():
+    preauthenticated_request = PreauthenticatedRequest()
+    preauthenticated_request.name = "test_preauthenticated_request"
+    return preauthenticated_request
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {
+        "namespace_name": "example_namespace",
+        "bucket_name": "test_bucket",
+        "time_expires": "2018-12-22T00:00:00+00:00",
+    }
+    if additional_properties:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_preauthenticated_request_facts.py
+++ b/test/units/test_oci_preauthenticated_request_facts.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+import logging
+from ansible.modules.cloud.oracle import oci_preauthenticated_request_facts
+from ansible.module_utils.oracle import oci_utils
+
+
+try:
+    import oci
+    from oci.object_storage.models import PreauthenticatedRequestSummary
+    from oci.exceptions import ServiceError
+except ImportError:
+    raise SkipTest("test_oci_preauthenticated_request_facts.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def identity_client(mocker):
+    mock_identity_client = mocker.patch("oci.identity.identity_client.IdentityClient")
+    return mock_identity_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def setUpModule():
+    logging.basicConfig(
+        filename="/tmp/oci_ansible_module.log", filemode="a", level=logging.INFO
+    )
+    oci_preauthenticated_request_facts.set_logger(logging)
+
+
+def test_list_suppressions_list_all(identity_client, list_all_resources_patch):
+    module = get_module()
+    list_all_resources_patch.return_value = get_preauthenticated_request_summaries()
+    result = oci_preauthenticated_request_facts.list_preauthenticated_requests(
+        identity_client, module
+    )
+    assert len(result["preauthenticated_requests"]) is 2
+
+
+def test_list_suppressions_list_specific(identity_client):
+    module = get_module(dict({"par_id": "xvdz:=test.html"}))
+    preauthenticated_request_summary = get_preauthenticated_request_summary()
+    identity_client.get_preauthenticated_request.return_value = get_response(
+        200, None, preauthenticated_request_summary, None
+    )
+    result = oci_preauthenticated_request_facts.list_preauthenticated_requests(
+        identity_client, module
+    )
+    assert (
+        result["preauthenticated_requests"][0]["name"]
+        is preauthenticated_request_summary.name
+    )
+
+
+def test_list_suppression_service_error(identity_client):
+    error_message = "Internal Server Error"
+    module = get_module(dict({"par_id": "xvdz:=test.html"}))
+    identity_client.get_preauthenticated_request.side_effect = ServiceError(
+        499, "InternalServerError", dict(), error_message
+    )
+    try:
+        oci_preauthenticated_request_facts.list_preauthenticated_requests(
+            identity_client, module
+        )
+    except Exception as ex:
+        assert error_message in ex.args[0]
+
+
+def get_preauthenticated_request_summaries():
+    preauthenticated_request_summaries = []
+    preauthenticated_request_summary1 = PreauthenticatedRequestSummary()
+    preauthenticated_request_summary1.name = "test_par1"
+    preauthenticated_request_summary2 = PreauthenticatedRequestSummary()
+    preauthenticated_request_summary2.name = "test_par2"
+    preauthenticated_request_summaries.append(preauthenticated_request_summary1)
+    preauthenticated_request_summaries.append(preauthenticated_request_summary2)
+    return preauthenticated_request_summaries
+
+
+def get_preauthenticated_request_summary():
+    preauthenticated_request_summary = PreauthenticatedRequestSummary()
+    preauthenticated_request_summary.name = "test_par"
+    return preauthenticated_request_summary
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"namespace_name": "example_namespace", "bucket_name": "test_bucket"}
+    if additional_properties:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_route_table.py
+++ b/test/units/test_oci_route_table.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -396,6 +396,7 @@ def get_module(additional_properties):
             }
         ],
         "purge_route_rules": False,
+        "delete_route_rules": False,
     }
     if additional_properties:
         params.update(additional_properties)

--- a/test/units/test_oci_virtual_circuit.py
+++ b/test/units/test_oci_virtual_circuit.py
@@ -1,0 +1,307 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_virtual_circuit
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import VirtualCircuit, CrossConnectMapping
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest("test_oci_virtual_circuit.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def get_existing_resource_patch(mocker):
+    return mocker.patch.object(oci_utils, "get_existing_resource")
+
+
+@pytest.fixture()
+def create_virtual_circuit_patch(mocker):
+    return mocker.patch.object(oci_virtual_circuit, "create_virtual_circuit")
+
+
+@pytest.fixture()
+def update_virtual_circuit_patch(mocker):
+    return mocker.patch.object(oci_virtual_circuit, "update_virtual_circuit")
+
+
+@pytest.fixture()
+def check_and_create_resource_patch(mocker):
+    return mocker.patch.object(oci_utils, "check_and_create_resource")
+
+
+@pytest.fixture()
+def create_and_wait_patch(mocker):
+    return mocker.patch.object(oci_utils, "create_and_wait")
+
+
+@pytest.fixture()
+def check_and_update_resource_patch(mocker):
+    return mocker.patch.object(oci_utils, "check_and_update_resource")
+
+
+@pytest.fixture()
+def update_and_wait_patch(mocker):
+    return mocker.patch.object(oci_utils, "update_and_wait")
+
+
+@pytest.fixture()
+def delete_and_wait_patch(mocker):
+    return mocker.patch.object(oci_utils, "delete_and_wait")
+
+
+def test_create_or_update_cross_connect_create_success(
+    virtual_network_client, check_and_create_resource_patch
+):
+    virtual_circuit = get_virtual_circuit()
+    module = get_module(dict())
+    check_and_create_resource_patch.return_value = dict(
+        {"virtual_circuit": virtual_circuit, "changed": True}
+    )
+    result = oci_virtual_circuit.create_or_update_virtual_circuit(
+        virtual_network_client, module
+    )
+    assert result["virtual_circuit"].display_name == virtual_circuit.display_name
+    assert result["changed"] is True
+
+
+def test_create_or_update_cross_connect_update_success(
+    virtual_network_client, update_virtual_circuit_patch
+):
+    virtual_circuit = get_virtual_circuit()
+    module = get_module(dict({"virtual_circuit_id": "ocid1.virtualcircuit..xvdf"}))
+    get_existing_resource_patch.return_value = virtual_circuit
+    update_virtual_circuit_patch.return_value = dict(
+        changed=True, virtual_circuit=to_dict(virtual_circuit)
+    )
+    result = oci_virtual_circuit.create_or_update_virtual_circuit(
+        virtual_network_client, module
+    )
+    assert result["virtual_circuit"]["display_name"] == virtual_circuit.display_name
+    assert result["changed"] is True
+
+
+def test_create_or_update_virtual_circuit_service_error(
+    virtual_network_client, update_virtual_circuit_patch
+):
+    error_message = "Internal Server Error"
+    module = get_module(dict({"virtual_circuit_id": "ocid1.virtualcircuit.xvdf"}))
+    update_virtual_circuit_patch.side_effect = ServiceError(
+        500, "InternalServerError", dict(), error_message
+    )
+    try:
+        oci_virtual_circuit.create_or_update_virtual_circuit(
+            virtual_network_client, module
+        )
+    except Exception as ex:
+        assert error_message in ex.args[0]
+
+
+def test_create_or_update_virtual_circuit_timeout_error(
+    virtual_network_client, update_virtual_circuit_patch
+):
+    error_message = "Maximum Timeout Reached"
+    module = get_module(dict({"virtual_circuit_id": "ocid1.virtualcircuit.xvdf"}))
+    update_virtual_circuit_patch.side_effect = MaximumWaitTimeExceeded(
+        500, "TimeOutError", dict(), error_message
+    )
+    try:
+        oci_virtual_circuit.create_or_update_virtual_circuit(
+            virtual_network_client, module
+        )
+    except Exception as ex:
+        assert error_message in ex.args[0].__repr__()
+
+
+def test_create_virtual_circuit(virtual_network_client, create_and_wait_patch):
+    module = get_module(dict({"type": "PUBLIC"}))
+    virtual_circuit = get_virtual_circuit()
+    create_and_wait_patch.return_value = dict(
+        {"virtual_circuit": to_dict(virtual_circuit), "changed": True}
+    )
+    result = oci_virtual_circuit.create_virtual_circuit(virtual_network_client, module)
+    assert result["virtual_circuit"]["display_name"] == virtual_circuit.display_name
+
+
+def test_create_virtual_circuit_fail_no_bgp_peering_ip_for_public(
+    virtual_network_client, create_and_wait_patch
+):
+    error_message = "oracle_bgp_peering_ip or customer_bgp_peering_ip is not allowed for public virual circuit"
+    module = get_module(
+        dict(
+            {
+                "type": "PUBLIC",
+                "cross_connect_mappings": [
+                    dict({"customer_bgp_peering_ip": "10.0.0.21/31"})
+                ],
+            }
+        )
+    )
+    try:
+        oci_virtual_circuit.create_virtual_circuit(virtual_network_client, module)
+    except Exception as ex:
+        assert error_message in ex.args[0]
+
+
+def test_create_virtual_circuit_fail_mandatory_bgp_peering_ips_for_private(
+    virtual_network_client, create_and_wait_patch
+):
+    error_message = "oracle_bgp_peering_ip and customer_bgp_peering_ip are mandatory for private virual circuit"
+    module = get_module(
+        dict(
+            {
+                "type": "PRIVATE",
+                "cross_connect_mappings": [
+                    dict({"customer_bgp_peering_ip": "10.0.0.21/31"})
+                ],
+            }
+        )
+    )
+    try:
+        oci_virtual_circuit.create_virtual_circuit(virtual_network_client, module)
+    except Exception as ex:
+        assert error_message in ex.args[0]
+
+
+def test_update_virtual_circuit_success_display_name_changed(
+    virtual_network_client, update_and_wait_patch
+):
+    module = get_module(
+        dict(
+            display_name="ansible_virtual_circuit_updated",
+            cross_connect_id="ocid1.crossconnect..xvzf",
+            cross_connect_mappings=[dict({"vlan": 101})],
+        )
+    )
+    virtual_circuit = get_virtual_circuit()
+    update_and_wait_patch.return_value = dict(
+        {"virtual_circuit": virtual_circuit, "changed": True}
+    )
+    oci_virtual_circuit.update_virtual_circuit(
+        virtual_network_client, virtual_circuit, module
+    )
+    assert update_and_wait_patch.called
+
+
+def test_update_virtual_circuit_success_cross_connect_mappings_changed(
+    virtual_network_client, update_and_wait_patch
+):
+    module = get_module(
+        dict(
+            virtual_circuit_id_id="ocid1.virtualcircuit..xvzf",
+            cross_connect_mappings=[dict({"vlan": 105})],
+        )
+    )
+    virtual_circuit = get_virtual_circuit()
+    update_and_wait_patch.return_value = dict(
+        {"virtual_circuit": virtual_circuit, "changed": True}
+    )
+    oci_virtual_circuit.update_virtual_circuit(
+        virtual_network_client, virtual_circuit, module
+    )
+    assert update_and_wait_patch.called
+
+
+def test_update_virtual_circuit_success_bulk_add_public_prefixes(
+    virtual_network_client, update_and_wait_patch
+):
+    module = get_module(
+        dict(
+            virtual_circuit_id="ocid1.virtualcircuit..xvzf",
+            public_prefixes=["0.0.0.18/31"],
+        )
+    )
+    virtual_circuit = get_virtual_circuit()
+    update_and_wait_patch.return_value = dict(
+        {"virtual_circuit": virtual_circuit, "changed": True}
+    )
+    oci_virtual_circuit.update_virtual_circuit(
+        virtual_network_client, virtual_circuit, module
+    )
+    assert update_and_wait_patch.called
+
+
+def test_update_virtual_circuit_success_bulk_delete_public_prefixes(
+    virtual_network_client, update_and_wait_patch
+):
+    module = get_module(
+        dict(
+            virtual_circuit_id="ocid1.virtualcircuit..xvzf",
+            public_prefixes=["0.0.0.18/31"],
+            delete_public_prefixes=True,
+        )
+    )
+    virtual_circuit = get_virtual_circuit()
+    update_and_wait_patch.return_value = dict(
+        {"virtual_circuit": virtual_circuit, "changed": True}
+    )
+    oci_virtual_circuit.update_virtual_circuit(
+        virtual_network_client, virtual_circuit, module
+    )
+    assert update_and_wait_patch.called
+
+
+def test_delete_virtual_circuit(virtual_network_client, delete_and_wait_patch):
+    virtual_circuit = get_virtual_circuit()
+    module = get_module(dict({"virtual_circuit_id": "ocid1.virtualcircuit..xvzf"}))
+    get_existing_resource_patch.return_value = virtual_circuit
+    oci_virtual_circuit.delete_virtual_circuit(virtual_network_client, module)
+    assert delete_and_wait_patch.called
+
+
+def get_virtual_circuit():
+    virtual_circuit = VirtualCircuit()
+    virtual_circuit.compartment_id = "ocid1.compartment..axsd"
+    virtual_circuit.display_name = "ansible_virtual_circuit"
+    cross_connect_mapping = CrossConnectMapping()
+    cross_connect_mapping.customer_bgp_peering_ip = "10.0.0.18/30"
+    cross_connect_mapping.oracle_bgp_peering_ip = "10.0.0.19/30"
+    cross_connect_mapping.vlan = 101
+    cross_connect_mapping.cross_connect_or_cross_connect_group_id = (
+        "ocid1.crossconnect..xvdf"
+    )
+    virtual_circuit.cross_connect_mappings = [cross_connect_mapping]
+    virtual_circuit.customer_bgp_asn = 5
+    virtual_circuit.display_name = "ansible_cross_connect"
+    virtual_circuit.type = "PUBLIC"
+
+    return virtual_circuit
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties):
+    params = {"compartment_id": "ocid1.comp..axsd"}
+    params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_virtual_circuit_bandwidth_shape_facts.py
+++ b/test/units/test_oci_virtual_circuit_bandwidth_shape_facts.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+import logging
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_virtual_circuit_bandwidth_shape_facts
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import VirtualCircuitBandwidthShape
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest(
+        "test_oci_virtual_circuit_bandwidth_shape_facts.py requires `oci` module"
+    )
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def setUpModule():
+    logging.basicConfig(
+        filename="/tmp/oci_ansible_module.log", filemode="a", level=logging.INFO
+    )
+    oci_virtual_circuit_bandwidth_shape_facts.set_logger(logging)
+
+
+def test_list_virtual_circuit_bandwidth_shapes_all(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module()
+    virtual_circuit_bandwidth_shapes = get_virtual_circuit_bandwidth_shapes()
+    list_all_resources_patch.return_value = virtual_circuit_bandwidth_shapes
+    result = oci_virtual_circuit_bandwidth_shape_facts.list_virtual_circuit_bandwidth_shapes(
+        virtual_network_client, module
+    )
+    assert (
+        result["virtual_circuit_bandwidth_shapes"][0]["name"]
+        == virtual_circuit_bandwidth_shapes[0].name
+    )
+
+
+def get_virtual_circuit_bandwidth_shapes():
+    virtual_circuit_bandwidth_shapes = []
+    virtual_circuit_bandwidth_shape = VirtualCircuitBandwidthShape()
+    virtual_circuit_bandwidth_shape.name = "1 Gbps"
+    virtual_circuit_bandwidth_shape.bandwidth_in_mbps = 10
+    virtual_circuit_bandwidth_shapes.append(virtual_circuit_bandwidth_shape)
+    return virtual_circuit_bandwidth_shapes
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"compartment_id": "ocid1.compartment..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_virtual_circuit_facts.py
+++ b/test/units/test_oci_virtual_circuit_facts.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_virtual_circuit_facts
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import VirtualCircuit
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest("test_oci_virtual_circuit_facts.py requires `oci` module")
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def test_list_cross_virtual_circuits_all(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module()
+    virtual_circuits = get_virtual_circuits()
+    list_all_resources_patch.return_value = virtual_circuits
+    result = oci_virtual_circuit_facts.list_virtual_circuits(
+        virtual_network_client, module
+    )
+    assert (
+        result["virtual_circuits"][0]["display_name"]
+        == virtual_circuits[0].display_name
+    )
+
+
+def test_list_virtual_circuits_specific(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module(dict(virtual_circuit_id="ocid1.virtualcircuit..vgfc"))
+    virtual_circuits = get_virtual_circuits()
+    list_all_resources_patch.return_value = virtual_circuits
+    result = oci_virtual_circuit_facts.list_virtual_circuits(
+        virtual_network_client, module
+    )
+    assert (
+        result["virtual_circuits"][0]["display_name"]
+        == virtual_circuits[0].display_name
+    )
+
+
+def get_virtual_circuits():
+    virtual_circuits = []
+    virtual_circuit = VirtualCircuit()
+    virtual_circuit.display_name = "ansible_virtual_circuit"
+    virtual_circuits.append(virtual_circuit)
+    return virtual_circuits
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"compartment_id": "ocid1.compartment..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/test/units/test_oci_virtual_circuit_public_prefixes_facts.py
+++ b/test/units/test_oci_virtual_circuit_public_prefixes_facts.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2019, Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+import pytest
+from nose.plugins.skip import SkipTest
+from ansible.modules.cloud.oracle import oci_virtual_circuit_public_prefix_facts
+from ansible.module_utils.oracle import oci_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+    from oci.core.models import VirtualCircuitPublicPrefix
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+except ImportError:
+    raise SkipTest(
+        "test_oci_virtual_circuit_public_prefix_facts.py requires `oci` module"
+    )
+
+
+class FakeModule(object):
+    def __init__(self, **kwargs):
+        self.params = kwargs
+
+    def fail_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+        raise Exception(kwargs["msg"])
+
+    def exit_json(self, *args, **kwargs):
+        self.exit_args = args
+        self.exit_kwargs = kwargs
+
+
+@pytest.fixture()
+def virtual_network_client(mocker):
+    mock_virtual_network_client = mocker.patch("oci.core.VirtualNetworkClient")
+    return mock_virtual_network_client.return_value
+
+
+@pytest.fixture()
+def list_all_resources_patch(mocker):
+    return mocker.patch.object(oci_utils, "list_all_resources")
+
+
+def test_list_cross_virtual_circuit_public_prefixes_all(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module()
+    virtual_circuit_public_prefixes = get_virtual_circuit_public_prefixes()
+    list_all_resources_patch.return_value = virtual_circuit_public_prefixes
+    result = oci_virtual_circuit_public_prefix_facts.list_virtual_circuit_public_prefixes(
+        virtual_network_client, module
+    )
+    assert (
+        result["virtual_circuit_public_prefixes"][0]["cidr_block"]
+        == virtual_circuit_public_prefixes[0].cidr_block
+    )
+
+
+def test_list_virtual_circuit_public_prefixes_specific(
+    virtual_network_client, list_all_resources_patch
+):
+    module = get_module(
+        dict(virtual_circuit_public_prefix_id="ocid1.virtualcircuitpublicprefix..vgfc")
+    )
+    virtual_circuit_public_prefixes = get_virtual_circuit_public_prefixes()
+    list_all_resources_patch.return_value = virtual_circuit_public_prefixes
+    result = oci_virtual_circuit_public_prefix_facts.list_virtual_circuit_public_prefixes(
+        virtual_network_client, module
+    )
+    assert (
+        result["virtual_circuit_public_prefixes"][0]["cidr_block"]
+        == virtual_circuit_public_prefixes[0].cidr_block
+    )
+
+
+def get_virtual_circuit_public_prefixes():
+    virtual_circuit_public_prefixes = []
+    virtual_circuit_public_prefix = VirtualCircuitPublicPrefix()
+    virtual_circuit_public_prefix.cidr_block = "10.0.0.18/31"
+    virtual_circuit_public_prefixes.append(virtual_circuit_public_prefix)
+    return virtual_circuit_public_prefixes
+
+
+def get_response(status, header, data, request):
+    return oci.Response(status, header, data, request)
+
+
+def get_module(additional_properties=None):
+    params = {"compartment_id": "ocid1.compartment..axsd"}
+    if additional_properties is not None:
+        params.update(additional_properties)
+    module = FakeModule(**params)
+    return module

--- a/uninstall.py
+++ b/uninstall.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
 
-'''
-Oracle Cloud Infrastructure(OCI) Ansible Role Uninstaller Script
+"""
+Oracle Cloud Infrastructure(OCI) Ansible Modules Uninstaller Script
 ===================================================================
 This script deletes OCI Ansible modules, Oracle docs fragments and Oracle Ansible utility file from the ansible path.
 
-To uninstall the OCI Ansible role, execute:
+To uninstall OCI Ansible modules, execute:
 $ ./uninstall.py
 To execute the script with debug messages, execute:
 $ ./uninstall.py --debug
 
 author: "Rohit Chaware (@rohitChaware)"
-'''
+"""
 
 from __future__ import print_function
 import argparse
@@ -26,6 +26,7 @@ import sys
 
 try:
     import ansible
+
     ANSIBLE_IS_INSTALLED = True
 except ImportError:
     ANSIBLE_IS_INSTALLED = False
@@ -34,11 +35,13 @@ debug = False
 
 
 def parse_cli_args():
-    parser = argparse.ArgumentParser(description='Script to uninstall oci-ansible-role')
-    parser.add_argument('--debug',
-                        action='store_true',
-                        default=False,
-                        help='Send debug messages to STDERR')
+    parser = argparse.ArgumentParser(description="Script to uninstall oci-ansible-role")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Send debug messages to STDERR",
+    )
     return parser.parse_args()
 
 
@@ -59,22 +62,24 @@ def main():
     ansible_path = os.path.dirname(os.path.abspath(os.path.realpath(ansible.__file__)))
     log("Ansible path: {}".format(ansible_path))
 
-    module_utils_path = os.path.join(ansible_path, 'module_utils', 'oracle')
+    module_utils_path = os.path.join(ansible_path, "module_utils", "oracle")
     log("Module utilities path: {}".format(module_utils_path))
 
-    document_fragments_path = os.path.join(ansible_path, 'utils', 'module_docs_fragments')
+    document_fragments_path = os.path.join(
+        ansible_path, "utils", "module_docs_fragments"
+    )
     log("Documentation fragments path: {}".format(document_fragments_path))
 
     delete(module_utils_path)
 
     oci_docs_fragments = []
     for filename in os.listdir(document_fragments_path):
-        if filename.startswith('oracle'):
+        if filename.startswith("oracle"):
             oci_docs_fragments.append(os.path.join(document_fragments_path, filename))
 
     delete(oci_docs_fragments)
 
-    oracle_module_dir_path = os.path.join(ansible_path, 'modules', 'cloud', 'oracle')
+    oracle_module_dir_path = os.path.join(ansible_path, "modules", "cloud", "oracle")
     delete(oracle_module_dir_path)
 
     print("Uninstalled OCI Ansible modules successfully.")
@@ -93,5 +98,5 @@ def delete(paths):
             os.remove(path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Added
- Modules to manage
    - [FastConnect](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnectoverview.htm) resources
- Added the following features in existing modules:
    - [Pre-Authenticated Requests](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/usingpreauthenticatedrequests.htm) in Object Storage Service.
    - `force` option in `oci_bucket` now also supports automatic deletion of bucket-level PARs
    - Support for listing multi-part uploads and multi-part upload parts, aborting a multi-part upload in `oci_object_facts` and `oci_object` modules
    - In modules having a module option that supports a list of items, a `delete_*` option is now supported to delete specified list items. See `delete_security_rules` in `oci_security_list` for an example
    - Options in `oci_tag` module to apply tags
    - Option to filter by `display_name` in `oci_instance_configuration_facts` module
- Added the following features in OCI dynamic inventory script:
    - Option to build inventory from multiple regions

Changed
- Minimum supported OCI Python SDK to `2.1.3`

Co-authored-by: Sivakumar Thyagarajan <sivakumar.thyagarajan@oracle.com>
Co-authored-by: Rohit Chaware <rohit.chaware@oracle.com>
Co-authored-by: Debayan Gupta <debayan.gupta@oracle.com>