### PR TITLE
Fix "No such file or directory" on install

### DIFF
--- a/install.py
+++ b/install.py
@@ -145,7 +145,7 @@ def main():
     oracle_module_dir_path = os.path.join(ansible_path, "modules", "cloud", "oracle")
     if not os.path.exists(oracle_module_dir_path):
         print("Creating directory {}".format(oracle_module_dir_path))
-        os.mkdir(oracle_module_dir_path)
+        os.makedirs(oracle_module_dir_path)
 
     # Modules in oci-ansible-modules are stored in library directory.
     roles_library_path = os.path.join(current_path, "library")


### PR DESCRIPTION
Creating directory /usr/lib/python2.7/dist-packages/ansible/modules/cloud/oracle
Traceback (most recent call last):
  File "./install.py", line 181, in <module>
    main()
  File "./install.py", line 148, in main
    os.mkdir(oracle_module_dir_path)
OSError: [Errno 2] No such file or directory: '/usr/lib/python2.7/dist-packages/ansible/modules/cloud/oracle'

Use os.makedirs to create parent "modules" directories on clean ansible installations

Signed-off-by: Stephan Wolf <stephan@letzte-bankreihe.de>