### PR TITLE
Fix boolean conditional for fqdn generation.

### DIFF
--- a/inventory-script/oci_inventory.py
+++ b/inventory-script/oci_inventory.py
@@ -971,17 +971,9 @@ class OCIInventory:
                 virtual_nw_client.get_vcn, vcn_id=subnet.vcn_id
             ).data
 
-            oraclevcn_domain_name = ".oraclevcn.com"
-            if not (vnic.hostname_label or subnet.dns_label or vcn.dns_label):
-                return None
-            fqdn = (
-                vnic.hostname_label
-                + "."
-                + subnet.dns_label
-                + "."
-                + vcn.dns_label
-                + oraclevcn_domain_name
-            )
+            values = [vnic.hostname_label, subnet.dns_label,
+                      vcn.dns_label, 'oraclevcn.com']
+            fqdn = None if None in values else '.'.join(values)
             self.log("FQDN for VNIC: {0} is {1}.".format(vnic.id, fqdn))
             return fqdn
 


### PR DESCRIPTION
Hello,
While using the inventory generation script, I had faced an issue with exceptions on concatenating string with None objects:

```
Traceback (most recent call last):
  File "oci_inventory.py", line 408, in __init__
    self.build_inventory()
  File "oci_inventory.py", line 1217, in build_inventory
    instances,
  File "/usr/local/Cellar/python@2/2.7.16/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/pool.py", line 253, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/local/Cellar/python@2/2.7.16/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/pool.py", line 572, in get
    raise self._value
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

unsupported operand type(s) for +: 'NoneType' and 'str'
```

I traced this to the following [code](https://github.com/oracle/oci-ansible-modules/blob/master/inventory-script/oci_inventory.py#L977):
```
            oraclevcn_domain_name = ".oraclevcn.com"
            if not (vnic.hostname_label or subnet.dns_label or vcn.dns_label):
                return None
            fqdn = (
                vnic.hostname_label
                + "."
                + subnet.dns_label
                + "."
                + vcn.dns_label
                + oraclevcn_domain_name
            )
            self.log("FQDN for VNIC: {0} is {1}.".format(vnic.id, fqdn))
            return fqdn
```

If I understand correctly, here you try to implement the logic of a three way or gate to detect any False values, whereas you should use an "and" gate logic.  This can be checked out by the following code snippet:
```
vals = ["a_value", None]
for s1 in vals:
    for s2 in vals:
        for s3 in vals:
            print "%s\t%s\t%s\t\t%s\t%s" % (s1, s2, s3, bool(s1 and s2 and s3), bool(s1 or s2 or s3))
```
with output:
```
Value 1    Value 2    Value 3     AND     OR
--------------------------------------------------
a_value    a_value    a_value     True    True
a_value    a_value    None        False   True
a_value    None       a_value     False   True
a_value    None       None        False   True
None       a_value    a_value     False   True
None       a_value    None        False   True
None       None       a_value     False   True
None       None       None        False   False
```

This PR solves this issue, in a more pythonic way.