### PR TITLE
Fix invalid options error for assert

### DIFF
--- a/samples/block_volume/attach_connect_block_volume/sample.yaml
+++ b/samples/block_volume/attach_connect_block_volume/sample.yaml
@@ -91,6 +91,6 @@
     - assert:
         that:
           - "'Disk /dev/sdb' in result.stdout"
-        message: "'Disk /dev/sdb' not returned in fdisk output. The block storage volume was not attached."
+        fail_msg: "'Disk /dev/sdb' not returned in fdisk output. The block storage volume was not attached."
 
     - import_tasks: teardown.yaml


### PR DESCRIPTION
Currently this sample fails with the following error:
TASK [assert] *****************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Invalid options for assert: message"}
        to retry, use: --limit @/home/opc/oci-ansible-modules/samples/block_volume/attach_connect_block_volume/sample.retry

According https://docs.ansible.com/ansible/latest/modules/assert_module.html there is no such option.
With "fail_msg" this sample works correctly.