### PR TITLE
New release of v1.13.0 of OCI Ansible Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2019-12-12
+
+### Added
+- Support for [Free Tier](https://www.oracle.com/cloud/free/) resources
+  - Compute [sample](https://github.com/oracle/oci-ansible-modules/tree/master/samples/compute/always_free_launch_compute_instance)
+  - Autonomous Database [sample](https://github.com/oracle/oci-ansible-modules/tree/master/samples/database/always_free_autonomous_database)
+- Support for associating [Network Security Groups](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/networksecuritygroups.htm) with vnics
+  - `oci_instance`
+  - `oci_vnic`
+  - `oci_vnic_attachment`
+- Support for associating [Security Rules](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/securityrules.htm) with [Network Security Groups](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/networksecuritygroups.htm)
+  - `oci_security_rule_actions`
+  - `oci_security_rule_facts`
+- Support for specifying device path for volume attachments
+  - `oci_volume_attachment`
+
+### Changed
+   - Minimum supported OCI Python SDK to 2.5.0
+
 ## [1.12.0] - 2019-10-16
 
 ### Added

--- a/docs/dynamic-inventory-script.md
+++ b/docs/dynamic-inventory-script.md
@@ -237,7 +237,7 @@ The script would then return the following variables for the specified host:
       "foo": "bar"
     },
     "region": "iad",
-    "shape": "VM.Standard1.1",
+    "shape": "VM.Standard2.1",
     "source_details": {
       "image_id": "ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx",
       "source_type": "image"

--- a/docs/modules/list_of_cloud_modules.rst
+++ b/docs/modules/list_of_cloud_modules.rst
@@ -207,6 +207,8 @@ Oracle
   * :ref:`oci_search_resources_facts_module` 
   * :ref:`oci_security_list_module` 
   * :ref:`oci_security_list_facts_module` 
+  * :ref:`oci_security_rule_actions_module` 
+  * :ref:`oci_security_rule_facts_module` 
   * :ref:`oci_sender_module` 
   * :ref:`oci_sender_facts_module` 
   * :ref:`oci_service_facts_module` 

--- a/docs/modules/oci_audit_event_facts_module.rst
+++ b/docs/modules/oci_audit_event_facts_module.rst
@@ -221,9 +221,9 @@ Examples
     
     - name: List audit_events
       oci_audit_event_facts:
-          compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
-          start_time: 2013-10-20T19:20:30+01:00
-          end_time: 2013-10-20T19:20:30+01:00
+        compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
+        start_time: 2013-10-20T19:20:30+01:00
+        end_time: 2013-10-20T19:20:30+01:00
 
 
 

--- a/docs/modules/oci_auth_token_facts_module.rst
+++ b/docs/modules/oci_auth_token_facts_module.rst
@@ -5,8 +5,8 @@
 .. _oci_auth_token_facts_module:
 
 
-oci_auth_token_facts -- Retrieve facts of auth tokens in OCI Identity and Access Management Service
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+oci_auth_token_facts -- Fetches details about one or multiple AuthToken resources in Oracle Cloud Infrastructure
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. versionadded:: 2.5
 
@@ -17,7 +17,8 @@ oci_auth_token_facts -- Retrieve facts of auth tokens in OCI Identity and Access
 
 Synopsis
 --------
-- This module retrieves information of all the auth tokens for a specified user.
+- Fetches details about one or multiple AuthToken resources in Oracle Cloud Infrastructure
+- Lists the auth tokens for the specified user. The returned object contains the token's OCID, but not the token itself. The actual token is returned only upon creation.
 
 
 
@@ -192,9 +193,10 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Get information of all the auth tokens for a specific user
+    - name: List auth_tokens
       oci_auth_token_facts:
-        user_id: ocid1.user.oc1..xxxxxEXAMPLExxxxx...h5hq
+        user_id: ocid1.user.oc1..xxxxxxEXAMPLExxxxxx
+
 
 
 
@@ -213,15 +215,15 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
         </tr>
                     <tr>
                                 <td colspan="2">
-                    <b>auth_groups</b>
+                    <b>auth_tokens</b>
                     <div style="font-size: small; color: purple">complex</div>
                                     </td>
-                <td>On success</td>
+                <td>on success</td>
                 <td>
-                                            <div>List of auth token information</div>
-                                        <br/>
+                                                                        <div>List of AuthToken resources</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;time-created&#x27;: &#x27;2018-11-08T02:40:25.118000+00:00&#x27;, &#x27;lifecycle-state&#x27;: &#x27;ACTIVE&#x27;, &#x27;time-expires&#x27;: None, &#x27;description&#x27;: &#x27;test auth token 1&#x27;, &#x27;token&#x27;: None, &#x27;inactive-status&#x27;: None, &#x27;user-id&#x27;: &#x27;ocid1.user.oc1..xxxxxEXAMPLExxxxx...h5hq&#x27;, &#x27;id&#x27;: &#x27;ocid1.credential.oc1..xxxxxEXAMPLExxxxx...l5aq&#x27;}]</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;lifecycle_state&#x27;: &#x27;CREATING&#x27;, &#x27;inactive_status&#x27;: 56, &#x27;user_id&#x27;: &#x27;ocid1.user.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;description&#x27;: &#x27;description_example&#x27;, &#x27;time_created&#x27;: &#x27;2016-08-25T21:10:29.600Z&#x27;, &#x27;token&#x27;: &#x27;token_example&#x27;, &#x27;time_expires&#x27;: &#x27;2016-08-25T21:10:29.600Z&#x27;, &#x27;id&#x27;: &#x27;ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx&#x27;}]</div>
                                     </td>
             </tr>
                                                             <tr>
@@ -230,12 +232,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>description</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The description you assign to the auth token. Does not have to be unique, and it&#x27;s changeable.</div>
-                                        <br/>
+                                                                        <div>The description you assign to the auth token. Does not have to be unique, and it&#x27;s changeable.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My test auth token</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">description_example</div>
                                     </td>
             </tr>
                                 <tr>
@@ -244,12 +246,40 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>id</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The OCID of the auth token.</div>
-                                        <br/>
+                                                                        <div>The OCID of the auth token.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.credential.oc1..xxxxxEXAMPLExxxxx...l5aq</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The detailed status of INACTIVE lifecycleState.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The token&#x27;s current state. After creating an auth token, make sure its `lifecycleState` changes from CREATING to ACTIVE before using it.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CREATING</div>
                                     </td>
             </tr>
                                 <tr>
@@ -258,12 +288,13 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>time_created</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>Date and time the AuthToken object was created, in the format defined by RFC3339.</div>
-                                        <br/>
+                                                                        <div>Date and time the `AuthToken` object was created, in the format defined by RFC3339.</div>
+                                                    <div>Example: `2016-08-25T21:10:29.600Z`</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-11-08T02:40:25.118000+00:00</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
                                     </td>
             </tr>
                                 <tr>
@@ -272,10 +303,13 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>time_expires</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>Date and time when this auth token will expire, in the format defined by RFC3339. Null if it never expires.</div>
-                                        <br/>
+                                                                        <div>Date and time when this auth token will expire, in the format defined by RFC3339. Null if it never expires.</div>
+                                                    <div>Example: `2016-08-25T21:10:29.600Z`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
                                     </td>
             </tr>
                                 <tr>
@@ -284,10 +318,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>token</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The Auth token. The value is available only in the response for CreateAuthToken, and not for ListAuthTokens or UpdateAuthToken. So the value returned by this fact module would always be null.</div>
-                                        <br/>
+                                                                        <div>The auth token. The value is available only in the response for `CreateAuthToken`, and not for `ListAuthTokens` or `UpdateAuthToken`.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">token_example</div>
                                     </td>
             </tr>
                                 <tr>
@@ -296,12 +332,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>user_id</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The OCID of the user the auth token belongs to.</div>
-                                        <br/>
+                                                                        <div>The OCID of the user the auth token belongs to.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.user.oc1..xxxxxEXAMPLExxxxx...h5hq</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.user.oc1..xxxxxxEXAMPLExxxxxx</div>
                                     </td>
             </tr>
                     
@@ -327,7 +363,9 @@ Status
 Authors
 ~~~~~~~
 
-- Sivakumar Thyagarajan (@sivakumart)
+- Manoj Meda (@manojmeda)
+- Mike Ross (@mross22)
+- Nabeel Al-Saber (@nalsaber)
 
 
 .. hint::

--- a/docs/modules/oci_autonomous_database_facts_module.rst
+++ b/docs/modules/oci_autonomous_database_facts_module.rst
@@ -177,6 +177,19 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>is_free_tier</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Filter on the value of the resource&#x27;s &#x27;is_free_tier&#x27; property. A value of true returns only Always Free resources. A value of false excludes Always Free resources from the returned results. Omitting this parameter returns both Always Free and paid resources.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>region</b>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
@@ -260,7 +273,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                             <div>Attributes of the Fetched Autonomous Database.</div>
                                         <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;lifecycle_state&#x27;: &#x27;AVAILABLE&#x27;, &#x27;display_name&#x27;: &#x27;ansible-autonomous-database-prod&#x27;, &#x27;cpu_core_count&#x27;: 1, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;defined_tags&#x27;: {&#x27;ansible_tag_namespace_integration_test_1&#x27;: {&#x27;ansible_tag_1&#x27;: &#x27;initial&#x27;}}, &#x27;freeform_tags&#x27;: {&#x27;system_license&#x27;: &#x27;trial&#x27;}, &#x27;time_created&#x27;: &#x27;2018-09-22T15:06:55.426000+00:00&#x27;, &#x27;db_name&#x27;: &#x27;autodbbackup&#x27;, &#x27;license_model&#x27;: &#x27;LICENSE_INCLUDED&#x27;, &#x27;connection_strings&#x27;: {&#x27;high&#x27;: &#x27;adwc.EXAMPLE1.oraclecloud.com:1522/EXAMPLE1_autodb_high.atp.oraclecloud.com&#x27;, &#x27;medium&#x27;: &#x27;adwc.EXAMPLE3.oraclecloud.com:1522/EXAMPLE3_autodb_medium.atp.oraclecloud.com&#x27;, &#x27;low&#x27;: &#x27;adwc.EXAMPLE2.oraclecloud.com:1522/EXAMPLE2_autodb_low.atp.oraclecloud.com&#x27;}, &#x27;lifecycle_details&#x27;: None, &#x27;data_storage_size_in_tbs&#x27;: 1, &#x27;id&#x27;: &#x27;ocid1.autonomousdatabase.oc1.iad.xxxxxEXAMPLExxxxx&#x27;, &#x27;service_console_url&#x27;: &#x27;https://example1.oraclecloud.com/console/index.html? tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx &amp;database_name=ANSIBLEAUTODB&amp;service_type=ATP&#x27;}, {&#x27;lifecycle_state&#x27;: &#x27;AVAILABLE&#x27;, &#x27;display_name&#x27;: &#x27;ansible-autonomous-database-test&#x27;, &#x27;cpu_core_count&#x27;: 1, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;defined_tags&#x27;: {&#x27;ansible_tag_namespace_integration_test_1&#x27;: {&#x27;ansible_tag_1&#x27;: &#x27;initial&#x27;}}, &#x27;freeform_tags&#x27;: {&#x27;system_license&#x27;: &#x27;trial&#x27;}, &#x27;time_created&#x27;: &#x27;2018-09-22T15:06:55.426000+00:00&#x27;, &#x27;db_name&#x27;: &#x27;autodbbackup2&#x27;, &#x27;license_model&#x27;: &#x27;LICENSE_INCLUDED&#x27;, &#x27;connection_strings&#x27;: {&#x27;high&#x27;: &#x27;adwc.EXAMPLE1.oraclecloud.com:1522/EXAMPLE1_autodb_high.atp.oraclecloud.com&#x27;, &#x27;medium&#x27;: &#x27;adwc.EXAMPLE3.oraclecloud.com:1522/EXAMPLE3_autodb_medium.atp.oraclecloud.com&#x27;, &#x27;low&#x27;: &#x27;adwc.EXAMPLE2.oraclecloud.com:1522/EXAMPLE2_autodb_low.atp.oraclecloud.com&#x27;}, &#x27;lifecycle_details&#x27;: None, &#x27;data_storage_size_in_tbs&#x27;: 1, &#x27;id&#x27;: &#x27;ocid1.autonomousdatabase.oc1.iad.xxxxxEXAMPLExxxxx&#x27;, &#x27;service_console_url&#x27;: &#x27;https://example1.oraclecloud.com/console/index.html? tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx &amp;database_name=ANSIBLEAUTODB&amp;service_type=ATP&#x27;}]</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;lifecycle_state&#x27;: &#x27;AVAILABLE&#x27;, &#x27;display_name&#x27;: &#x27;ansible-autonomous-database-prod&#x27;, &#x27;cpu_core_count&#x27;: 1, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;defined_tags&#x27;: {&#x27;ansible_tag_namespace_integration_test_1&#x27;: {&#x27;ansible_tag_1&#x27;: &#x27;initial&#x27;}}, &#x27;is_free_tier&#x27;: False, &#x27;freeform_tags&#x27;: {&#x27;system_license&#x27;: &#x27;trial&#x27;}, &#x27;time_created&#x27;: &#x27;2018-09-22T15:06:55.426000+00:00&#x27;, &#x27;db_name&#x27;: &#x27;autodbbackup&#x27;, &#x27;license_model&#x27;: &#x27;LICENSE_INCLUDED&#x27;, &#x27;connection_strings&#x27;: {&#x27;high&#x27;: &#x27;adwc.EXAMPLE1.oraclecloud.com:1522/EXAMPLE1_autodb_high.atp.oraclecloud.com&#x27;, &#x27;medium&#x27;: &#x27;adwc.EXAMPLE3.oraclecloud.com:1522/EXAMPLE3_autodb_medium.atp.oraclecloud.com&#x27;, &#x27;low&#x27;: &#x27;adwc.EXAMPLE2.oraclecloud.com:1522/EXAMPLE2_autodb_low.atp.oraclecloud.com&#x27;}, &#x27;lifecycle_details&#x27;: None, &#x27;data_storage_size_in_tbs&#x27;: 1, &#x27;id&#x27;: &#x27;ocid1.autonomousdatabase.oc1.iad.xxxxxEXAMPLExxxxx&#x27;, &#x27;service_console_url&#x27;: &#x27;https://example1.oraclecloud.com/console/index.html? tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx &amp;database_name=ANSIBLEAUTODB&amp;service_type=ATP&#x27;}, {&#x27;lifecycle_state&#x27;: &#x27;AVAILABLE&#x27;, &#x27;display_name&#x27;: &#x27;ansible-autonomous-database-test&#x27;, &#x27;cpu_core_count&#x27;: 1, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;defined_tags&#x27;: {&#x27;ansible_tag_namespace_integration_test_1&#x27;: {&#x27;ansible_tag_1&#x27;: &#x27;initial&#x27;}}, &#x27;is_free_tier&#x27;: False, &#x27;freeform_tags&#x27;: {&#x27;system_license&#x27;: &#x27;trial&#x27;}, &#x27;time_created&#x27;: &#x27;2018-09-22T15:06:55.426000+00:00&#x27;, &#x27;db_name&#x27;: &#x27;autodbbackup2&#x27;, &#x27;license_model&#x27;: &#x27;LICENSE_INCLUDED&#x27;, &#x27;connection_strings&#x27;: {&#x27;high&#x27;: &#x27;adwc.EXAMPLE1.oraclecloud.com:1522/EXAMPLE1_autodb_high.atp.oraclecloud.com&#x27;, &#x27;medium&#x27;: &#x27;adwc.EXAMPLE3.oraclecloud.com:1522/EXAMPLE3_autodb_medium.atp.oraclecloud.com&#x27;, &#x27;low&#x27;: &#x27;adwc.EXAMPLE2.oraclecloud.com:1522/EXAMPLE2_autodb_low.atp.oraclecloud.com&#x27;}, &#x27;lifecycle_details&#x27;: None, &#x27;data_storage_size_in_tbs&#x27;: 1, &#x27;id&#x27;: &#x27;ocid1.autonomousdatabase.oc1.iad.xxxxxEXAMPLExxxxx&#x27;, &#x27;service_console_url&#x27;: &#x27;https://example1.oraclecloud.com/console/index.html? tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx &amp;database_name=ANSIBLEAUTODB&amp;service_type=ATP&#x27;}]</div>
                                     </td>
             </tr>
                                                             <tr>
@@ -359,6 +372,18 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                         <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.autonomousdatabase.oc1.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_free_tier</b>
+                    <div style="font-size: small; color: purple">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.</div>
+                                        <br/>
                                     </td>
             </tr>
                                 <tr>

--- a/docs/modules/oci_autonomous_database_module.rst
+++ b/docs/modules/oci_autonomous_database_module.rst
@@ -295,6 +295,19 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>is_free_tier</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>key_by</b>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
@@ -557,7 +570,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                             <div>Attributes of the launched/updated Autonomous Database. For delete, deleted Autonomous Database description will be returned.</div>
                                         <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;lifecycle_state&#x27;: &#x27;AVAILABLE&#x27;, &#x27;display_name&#x27;: &#x27;ansible-autonomous-database-955&#x27;, &#x27;cpu_core_count&#x27;: 1, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;defined_tags&#x27;: {&#x27;ansible_tag_namespace_integration_test_1&#x27;: {&#x27;ansible_tag_1&#x27;: &#x27;initial&#x27;}}, &#x27;freeform_tags&#x27;: {&#x27;system_license&#x27;: &#x27;trial&#x27;}, &#x27;time_created&#x27;: &#x27;2018-09-22T15:06:55.426000+00:00&#x27;, &#x27;db_name&#x27;: &#x27;autodbbackup&#x27;, &#x27;license_model&#x27;: &#x27;LICENSE_INCLUDED&#x27;, &#x27;connection_strings&#x27;: {&#x27;high&#x27;: &#x27;adwc.EXAMPLE1.oraclecloud.com:1522/EXAMPLE1_autodb_high.atp.oraclecloud.com&#x27;, &#x27;medium&#x27;: &#x27;adwc.EXAMPLE3.oraclecloud.com:1522/EXAMPLE3_autodb_medium.atp.oraclecloud.com&#x27;, &#x27;low&#x27;: &#x27;adwc.EXAMPLE2.oraclecloud.com:1522/EXAMPLE2_autodb_low.atp.oraclecloud.com&#x27;}, &#x27;lifecycle_details&#x27;: None, &#x27;data_storage_size_in_tbs&#x27;: 1, &#x27;id&#x27;: &#x27;ocid1.autonomousdatabase.oc1.iad.xxxxxEXAMPLExxxxx&#x27;, &#x27;service_console_url&#x27;: &#x27;https://example1.oraclecloud.com/console/index.html? tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx &amp;database_name=ANSIBLEAUTODB&amp;service_type=ATP&#x27;}</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;lifecycle_state&#x27;: &#x27;AVAILABLE&#x27;, &#x27;display_name&#x27;: &#x27;ansible-autonomous-database-955&#x27;, &#x27;cpu_core_count&#x27;: 1, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;defined_tags&#x27;: {&#x27;ansible_tag_namespace_integration_test_1&#x27;: {&#x27;ansible_tag_1&#x27;: &#x27;initial&#x27;}}, &#x27;is_free_tier&#x27;: False, &#x27;freeform_tags&#x27;: {&#x27;system_license&#x27;: &#x27;trial&#x27;}, &#x27;time_created&#x27;: &#x27;2018-09-22T15:06:55.426000+00:00&#x27;, &#x27;db_name&#x27;: &#x27;autodbbackup&#x27;, &#x27;license_model&#x27;: &#x27;LICENSE_INCLUDED&#x27;, &#x27;connection_strings&#x27;: {&#x27;high&#x27;: &#x27;adwc.EXAMPLE1.oraclecloud.com:1522/EXAMPLE1_autodb_high.atp.oraclecloud.com&#x27;, &#x27;medium&#x27;: &#x27;adwc.EXAMPLE3.oraclecloud.com:1522/EXAMPLE3_autodb_medium.atp.oraclecloud.com&#x27;, &#x27;low&#x27;: &#x27;adwc.EXAMPLE2.oraclecloud.com:1522/EXAMPLE2_autodb_low.atp.oraclecloud.com&#x27;}, &#x27;lifecycle_details&#x27;: None, &#x27;data_storage_size_in_tbs&#x27;: 1, &#x27;id&#x27;: &#x27;ocid1.autonomousdatabase.oc1.iad.xxxxxEXAMPLExxxxx&#x27;, &#x27;service_console_url&#x27;: &#x27;https://example1.oraclecloud.com/console/index.html? tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx &amp;database_name=ANSIBLEAUTODB&amp;service_type=ATP&#x27;}</div>
                                     </td>
             </tr>
                                                             <tr>
@@ -656,6 +669,18 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                         <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.autonomousdatabase.oc1.xzvf.xxxxxEXAMPLExxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_free_tier</b>
+                    <div style="font-size: small; color: purple">boolean</div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                            <div>Indicates if this is an Always Free resource. The default value is false. Note that Always Free Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU cannot be scaled.</div>
+                                        <br/>
                                     </td>
             </tr>
                                 <tr>

--- a/docs/modules/oci_autonomous_exadata_infrastructure_facts_module.rst
+++ b/docs/modules/oci_autonomous_exadata_infrastructure_facts_module.rst
@@ -295,11 +295,11 @@ Examples
     
     - name: List autonomous_exadata_infrastructures
       oci_autonomous_exadata_infrastructure_facts:
-          compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
+        compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
 
     - name: Get a specific autonomous_exadata_infrastructure
       oci_autonomous_exadata_infrastructure_facts:
-          autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
+        autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
 
 
 

--- a/docs/modules/oci_autonomous_exadata_infrastructure_module.rst
+++ b/docs/modules/oci_autonomous_exadata_infrastructure_module.rst
@@ -488,23 +488,23 @@ Examples
     
     - name: Create autonomous_exadata_infrastructure
       oci_autonomous_exadata_infrastructure:
-          compartment_id: ocid1.tenancy.oc1.<var>&lt;unique_ID&gt;</var>
-          display_name: tst3dbsys
-          availability_domain: Uocm:PHX-AD-1
-          subnet_id: ocid1.subnet.oc1.<var>&lt;unique_ID&gt;</var>
-          shape: Exadata.Half1.168
-          hostname: athena
-          domain: my.company.com
+        availability_domain: Uocm:PHX-AD-1
+        compartment_id: ocid1.tenancy.oc1.unique_ID
+        display_name: tst3dbsys
+        domain: my.company.com
+        hostname: athena
+        shape: Exadata.Half1.168
+        subnet_id: ocid1.subnet.oc1.unique_ID
 
     - name: Update autonomous_exadata_infrastructure
       oci_autonomous_exadata_infrastructure:
-          display_name: new displayname
-          autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
+        display_name: new displayname
+        autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
 
     - name: Delete autonomous_exadata_infrastructure
       oci_autonomous_exadata_infrastructure:
-          autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
-          state: absent
+        autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
+        state: absent
 
 
 

--- a/docs/modules/oci_autonomous_exadata_infrastructure_shape_facts_module.rst
+++ b/docs/modules/oci_autonomous_exadata_infrastructure_shape_facts_module.rst
@@ -164,6 +164,19 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>name</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>name</em> along with the other options to return only resources that match the given name exactly.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>region</b>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
@@ -208,8 +221,8 @@ Examples
     
     - name: List autonomous_exadata_infrastructure_shapes
       oci_autonomous_exadata_infrastructure_shape_facts:
-          availability_domain: Uocm:PHX-AD-1
-          compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
+        availability_domain: Uocm:PHX-AD-1
+        compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
 
 
 

--- a/docs/modules/oci_autoscaling_auto_scaling_configuration_module.rst
+++ b/docs/modules/oci_autoscaling_auto_scaling_configuration_module.rst
@@ -660,7 +660,7 @@ Examples
     
     - name: Create auto_scaling_configuration
       oci_autoscaling_auto_scaling_configuration:
-        compartment_id: ocid1.compartment.oc1..<var>&lt;unique_ID&gt;</var>
+        compartment_id: ocid1.compartment.oc1..unique_ID
         display_name: example_autoscaling_configuration
         cool_down_in_seconds: 300
         is_enabled: true
@@ -692,7 +692,7 @@ Examples
                 value: 25
         resource:
           type: instancePool
-          id: ocid1.instancepool.oc1..<var>&lt;unique_ID&gt;</var>
+          id: ocid1.instancepool.oc1..unique_ID
 
     - name: Update auto_scaling_configuration
       oci_autoscaling_auto_scaling_configuration:

--- a/docs/modules/oci_cpe_module.rst
+++ b/docs/modules/oci_cpe_module.rst
@@ -326,7 +326,7 @@ Examples
 
     - name: Update cpe
       oci_cpe:
-        defined_tags: {Operations: {CostCenter: US}}
+        defined_tags: {'Operations': {'CostCenter': 'US'}}
         display_name: MyCpe
         cpe_id: ocid1.cpe.oc1..xxxxxxEXAMPLExxxxxx
 

--- a/docs/modules/oci_drg_attachment_facts_module.rst
+++ b/docs/modules/oci_drg_attachment_facts_module.rst
@@ -121,7 +121,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The OCID of the compartment.</div>
+                                                                        <div>The <a href='https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm'>OCID</a> of the compartment.</div>
                                                     <div>Required to list multiple drg_attachments.</div>
                                                                                 </td>
             </tr>
@@ -149,6 +149,19 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                                                         <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>display_name</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Use <em>display_name</em> along with the other options to return only resources that match the given display name exactly.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -215,7 +228,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The OCID of the VCN.</div>
+                                                                        <div>The <a href='https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm'>OCID</a> of the VCN.</div>
                                                                                 </td>
             </tr>
                         </table>
@@ -351,7 +364,8 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                                                        <div>The OCID of the route table the DRG attachment is using. For information about why you would associate a route table with a DRG attachment, see <a href='https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm'>Advanced Scenario: Transit Routing</a>.</div>
+                                                                        <div>The OCID of the route table the DRG attachment is using.</div>
+                                                    <div>For information about why you would associate a route table with a DRG attachment, see <a href='https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm'>Advanced Scenario: Transit Routing</a>.</div>
                                                                 <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.routetable.oc1..xxxxxxEXAMPLExxxxxx</div>

--- a/docs/modules/oci_drg_attachment_module.rst
+++ b/docs/modules/oci_drg_attachment_module.rst
@@ -470,7 +470,8 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                                                        <div>The OCID of the route table the DRG attachment is using. For information about why you would associate a route table with a DRG attachment, see <a href='https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm'>Advanced Scenario: Transit Routing</a>.</div>
+                                                                        <div>The OCID of the route table the DRG attachment is using.</div>
+                                                    <div>For information about why you would associate a route table with a DRG attachment, see <a href='https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm'>Advanced Scenario: Transit Routing</a>.</div>
                                                                 <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.routetable.oc1..xxxxxxEXAMPLExxxxxx</div>

--- a/docs/modules/oci_drg_module.rst
+++ b/docs/modules/oci_drg_module.rst
@@ -353,7 +353,7 @@ Examples
 
     - name: Update drg
       oci_drg:
-        defined_tags: {Operations: {CostCenter: US}}
+        defined_tags: {'Operations': {'CostCenter': 'US'}}
         display_name: MyDrg
         drg_id: ocid1.drg.oc1..xxxxxxEXAMPLExxxxxx
 

--- a/docs/modules/oci_dynamic_group_facts_module.rst
+++ b/docs/modules/oci_dynamic_group_facts_module.rst
@@ -5,8 +5,8 @@
 .. _oci_dynamic_group_facts_module:
 
 
-oci_dynamic_group_facts -- Retrieve facts of dynamic groups
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+oci_dynamic_group_facts -- Fetches details about one or multiple DynamicGroup resources in Oracle Cloud Infrastructure
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. versionadded:: 2.5
 
@@ -17,7 +17,9 @@ oci_dynamic_group_facts -- Retrieve facts of dynamic groups
 
 Synopsis
 --------
-- This module retrieves information of the specified dynamic group or lists all the dynamic groups in a tenancy.
+- Fetches details about one or multiple DynamicGroup resources in Oracle Cloud Infrastructure
+- Lists the dynamic groups in your tenancy. You must specify your tenancy's OCID as the value for the compartment ID (remember that the tenancy is simply the root compartment). See `Where to Get the Tenancy's OCID and User's OCID <https://docs.cloud.oracle.com/Content/API/Concepts/apisigningkey.htm#five>`_.
+- If *dynamic_group_id* is specified, the details of a single DynamicGroup will be returned.
 
 
 
@@ -119,7 +121,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The OCID of the compartment (remember that the tenancy is simply the root compartment). Required to list all the dynamic groups in a tenancy.</div>
+                                                                        <div>The OCID of the compartment (remember that the tenancy is simply the root compartment).</div>
+                                                    <div>Required to list multiple dynamic_groups.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -158,7 +161,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The OCID of the dynamic group. <em>dynamic_group_id</em> is required to get a specific dynamic group&#x27;s information.</div>
+                                                                        <div>The OCID of the dynamic group.</div>
+                                                    <div>Required to get a specific dynamic_group.</div>
                                                                                         <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
                                     </td>
             </tr>
@@ -219,13 +223,14 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Get all the dynamic groups in a tenancy
+    - name: List dynamic_groups
       oci_dynamic_group_facts:
-        compartment_id: ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx
+        compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
 
-    - name: Get information of a specific dynamic group
+    - name: Get a specific dynamic_group
       oci_dynamic_group_facts:
-        dynamic_group_id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+        dynamic_group_id: ocid1.dynamicgroup.oc1..xxxxxxEXAMPLExxxxxx
+
 
 
 
@@ -247,12 +252,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>dynamic_groups</b>
                     <div style="font-size: small; color: purple">complex</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>List of dynamic group details</div>
-                                        <br/>
+                                                                        <div>List of DynamicGroup resources</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;lifecycle_state&#x27;: &#x27;ACTIVE&#x27;, &#x27;inactive_status&#x27;: None, &#x27;description&#x27;: &#x27;Group for all instances with the tag namespace and tag key operations.department&#x27;, &#x27;compartment_id&#x27;: &#x27;ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;matching_rule&#x27;: &#x27;tag.operations.department.value&#x27;, &#x27;time_created&#x27;: &#x27;2018-07-05T09:38:27.176000+00:00&#x27;, &#x27;id&#x27;: &#x27;ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;name&#x27;: &#x27;Sample dynamic group&#x27;}]</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;lifecycle_state&#x27;: &#x27;CREATING&#x27;, &#x27;inactive_status&#x27;: 56, &#x27;description&#x27;: &#x27;description_example&#x27;, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;matching_rule&#x27;: &#x27;matching_rule_example&#x27;, &#x27;defined_tags&#x27;: {&#x27;Operations&#x27;: {&#x27;CostCenter&#x27;: &#x27;US&#x27;}}, &#x27;freeform_tags&#x27;: {&#x27;Department&#x27;: &#x27;Finance&#x27;}, &#x27;time_created&#x27;: &#x27;2016-08-25T21:10:29.600Z&#x27;, &#x27;id&#x27;: &#x27;ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;name&#x27;: &#x27;name_example&#x27;}]</div>
                                     </td>
             </tr>
                                                             <tr>
@@ -261,12 +266,26 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>compartment_id</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The OCID of the tenancy containing the group.</div>
-                                        <br/>
+                                                                        <div>The OCID of the tenancy containing the group.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxEXAMPLExxxxx</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>defined_tags</b>
+                    <div style="font-size: small; color: purple">dictionary</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm'>Resource Tags</a>. Example: `{&quot;Operations&quot;: {&quot;CostCenter&quot;: &quot;42&quot;}}`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;Operations&#x27;: {&#x27;CostCenter&#x27;: &#x27;US&#x27;}}</div>
                                     </td>
             </tr>
                                 <tr>
@@ -275,12 +294,26 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>description</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The description you assign to the group. Does not have to be unique, and it&#x27;s changeable.</div>
-                                        <br/>
+                                                                        <div>The description you assign to the group. Does not have to be unique, and it&#x27;s changeable.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Group for all instances with the tag namespace and tag key operations.department</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">description_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>freeform_tags</b>
+                    <div style="font-size: small; color: purple">dictionary</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm'>Resource Tags</a>. Example: `{&quot;Department&quot;: &quot;Finance&quot;}`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;Department&#x27;: &#x27;Finance&#x27;}</div>
                                     </td>
             </tr>
                                 <tr>
@@ -289,12 +322,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>id</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The OCID of the group.</div>
-                                        <br/>
+                                                                        <div>The OCID of the group.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx</div>
                                     </td>
             </tr>
                                 <tr>
@@ -303,12 +336,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>inactive_status</b>
                     <div style="font-size: small; color: purple">integer</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The detailed status of INACTIVE lifecycleState.</div>
-                                        <br/>
+                                                                        <div>The detailed status of INACTIVE lifecycleState.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
                                     </td>
             </tr>
                                 <tr>
@@ -317,12 +350,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>lifecycle_state</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The group&#x27;s current state. After creating a group, make sure its lifecycleState changes from CREATING to ACTIVE before using it.</div>
-                                        <br/>
+                                                                        <div>The group&#x27;s current state. After creating a group, make sure its `lifecycleState` changes from CREATING to ACTIVE before using it.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ACTIVE</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CREATING</div>
                                     </td>
             </tr>
                                 <tr>
@@ -331,12 +364,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>matching_rule</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>A rule string that defines which instance certificates will be matched. For syntax, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm</a>.</div>
-                                        <br/>
+                                                                        <div>A rule string that defines which instance certificates will be matched. For syntax, see <a href='https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm'>Managing Dynamic Groups</a>.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">tag.operations.department.value</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">matching_rule_example</div>
                                     </td>
             </tr>
                                 <tr>
@@ -345,26 +378,27 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>name</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The name you assign to the group during creation. The name must be unique across all groups in the tenancy and cannot be changed.</div>
-                                        <br/>
+                                                                        <div>The name you assign to the group during creation. The name must be unique across all groups in the tenancy and cannot be changed.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Sample dynamic group</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">name_example</div>
                                     </td>
             </tr>
                                 <tr>
                                     <td class="elbow-placeholder">&nbsp;</td>
                                 <td colspan="1">
                     <b>time_created</b>
-                    <div style="font-size: small; color: purple">datetime</div>
+                    <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>Date and time the group was created, in the format defined by RFC3339.</div>
-                                        <br/>
+                                                                        <div>Date and time the group was created, in the format defined by RFC3339.</div>
+                                                    <div>Example: `2016-08-25T21:10:29.600Z`</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2018-03-28 18:37:56.190000</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
                                     </td>
             </tr>
                     
@@ -390,7 +424,9 @@ Status
 Authors
 ~~~~~~~
 
-- Rohit Chaware (@rohitChaware)
+- Manoj Meda (@manojmeda)
+- Mike Ross (@mross22)
+- Nabeel Al-Saber (@nalsaber)
 
 
 .. hint::

--- a/docs/modules/oci_dynamic_group_module.rst
+++ b/docs/modules/oci_dynamic_group_module.rst
@@ -5,8 +5,8 @@
 .. _oci_dynamic_group_module:
 
 
-oci_dynamic_group -- Manage dynamic groups in OCI
-+++++++++++++++++++++++++++++++++++++++++++++++++
+oci_dynamic_group -- Manage a DynamicGroup resource in Oracle Cloud Infrastructure
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. versionadded:: 2.5
 
@@ -17,7 +17,12 @@ oci_dynamic_group -- Manage dynamic groups in OCI
 
 Synopsis
 --------
-- This module allows the user to create, delete and update dynamic groups in Oracle Cloud Infrastructure.
+- This module allows the user to create, update and delete a DynamicGroup resource in Oracle Cloud Infrastructure
+- For *state=present*, creates a new dynamic group in your tenancy.
+- You must specify your tenancy's OCID as the compartment ID in the request object (remember that the tenancy is simply the root compartment). Notice that IAM resources (users, groups, compartments, and some policies) reside within the tenancy itself, unlike cloud resources such as compute instances, which typically reside within compartments inside the tenancy. For information about OCIDs, see `Resource Identifiers <https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm>`_.
+- You must also specify a *name* for the dynamic group, which must be unique across all dynamic groups in your tenancy, and cannot be changed. Note that this name has to be also unique accross all groups in your tenancy. You can use this name or the OCID when writing policies that apply to the dynamic group. For more information about policies, see `How Policies Work <https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm>`_.
+- You must also specify a *description* for the dynamic group (although it can be an empty string). It does not have to be unique, and you can change it anytime with `UpdateDynamicGroup <https://docs.cloud.oracle.com/#/en/identity/20160918/DynamicGroup/UpdateDynamicGroup>`_.
+- After you send your request, the new object's `lifecycleState` will temporarily be CREATING. Before using the object, first make sure its `lifecycleState` has changed to ACTIVE.
 
 
 
@@ -119,7 +124,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The OCID of the tenancy containing the group. Required to create a dynamic group.</div>
+                                                                        <div>The OCID of the tenancy containing the group.</div>
+                                                    <div>Required for create using <em>state=present</em>.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -158,7 +164,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm'>Resource Tags</a>. Example: `{&quot;Operations&quot;: {&quot;CostCenter&quot;: &quot;42&quot;}}`</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -171,7 +177,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The description you assign to the group during creation. Does not have to be unique, and it&#x27;s changeable. Required to create a dynamic group.</div>
+                                                                        <div>The description you assign to the group during creation. Does not have to be unique, and it&#x27;s changeable.</div>
+                                                    <div>Required for create using <em>state=present</em>.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -184,9 +191,27 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The OCID of the dynamic group. Required to delete or update a dynamic group.</div>
+                                                                        <div>The OCID of the dynamic group.</div>
+                                                    <div>Required for update using <em>state=present</em>, <em>state=absent</em>.</div>
                                                                                         <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
                                     </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>force_create</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Whether to attempt non-idempotent creation of a resource. By default, create resource is an idempotent operation, and doesn&#x27;t create the resource if it already exists. Setting this option to true, forcefully creates a copy of the resource, even if it already exists.This option is mutually exclusive with <em>key_by</em>.</div>
+                                                                                </td>
             </tr>
                                 <tr>
                                                                 <td colspan="1">
@@ -198,7 +223,20 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/resourcetags.htm</a>.</div>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm'>Resource Tags</a>. Example: `{&quot;Department&quot;: &quot;Finance&quot;}`</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>key_by</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The list of comma-separated attributes of this resource which should be used to uniquely identify an instance of the resource. By default, all the attributes of a resource except <em>freeform_tags</em> are used to uniquely identify a resource.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -211,7 +249,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The matching rule to dynamically match an instance certificate to this dynamic group. For rule syntax, see <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm</a>. Required to create a dynamic group.</div>
+                                                                        <div>The matching rule to dynamically match an instance certificate to this dynamic group. For rule syntax, see <a href='https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm'>Managing Dynamic Groups</a>.</div>
+                                                    <div>Required for create using <em>state=present</em>.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -224,7 +263,8 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The name you assign to the group during creation. The name must be unique across all groups in the tenancy and cannot be changed. Required to create a dynamic group.</div>
+                                                                        <div>The name you assign to the group during creation. The name must be unique across all groups in the tenancy and cannot be changed.</div>
+                                                    <div>Required for create using <em>state=present</em>.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -254,7 +294,9 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                                                        <div>Create or update a dynamic group with <em>state=present</em>. Use <em>state=absent</em> to delete a dynamic group.</div>
+                                                                        <div>The state of the DynamicGroup.</div>
+                                                    <div>Use <em>state=present</em> to create or update a DynamicGroup.</div>
+                                                    <div>Use <em>state=absent</em> to delete a DynamicGroup.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -332,23 +374,24 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Create a dynamic group
+    - name: Create dynamic_group
       oci_dynamic_group:
-        compartment_id: ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx
-        description: Group for all instances that are in a specific compartment
-        matching_rule: "instance.compartment.id = 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx'"
-        name: Sample dynamic group
+        compartment_id: ocid1.tenancy.oc1..aaaaaaaaba3pv6wkcr4jqae5f44n2b2cmdt2j6rx32uzr4h25vqstifsfdsq
+        description: Instance group for dev compartment
+        name: DevCompartmentDynamicGroup
+        matching_rule: instance.compartment.id=ocid1.compartment.oc1..aaaaaaaayd6inozhadasiiaqmttsgqanpxd6ads5tvo6g27ujaygksvivrnq
 
-    - name: Update matching rule and description of a dynamic group
+    - name: Update dynamic_group
       oci_dynamic_group:
-        id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
-        description: Group for all instances with the tag namespace and tag key operations.department
-        matching_rule: "tag.operations.department.value"
+        matching_rule: instance.compartment.id=ocid1.compartment.oc1..aaaaaaaayd6inozhadasiiaqmttsgqanpxd6ads5tvo6g27ujaygksvivrnq
+        description: Instance group for dev compartment
+        dynamic_group_id: ocid1.dynamicgroup.oc1..xxxxxxEXAMPLExxxxxx
 
-    - name: Delete a dynamic group
+    - name: Delete dynamic_group
       oci_dynamic_group:
-        id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+        dynamic_group_id: ocid1.dynamicgroup.oc1..xxxxxxEXAMPLExxxxxx
         state: absent
+
 
 
 
@@ -361,24 +404,166 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
     <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-            <th colspan="1">Key</th>
+            <th colspan="2">Key</th>
             <th>Returned</th>
             <th width="100%">Description</th>
         </tr>
                     <tr>
-                                <td colspan="1">
+                                <td colspan="2">
                     <b>dynamic_group</b>
-                    <div style="font-size: small; color: purple">dictionary</div>
+                    <div style="font-size: small; color: purple">complex</div>
                                     </td>
-                <td>On successful create, delete &amp; update operation</td>
+                <td>on success</td>
                 <td>
-                                            <div>Information about the dynamic group</div>
-                                        <br/>
+                                                                        <div>Details of the DynamicGroup resource acted upon by the current operation</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;lifecycle_state&#x27;: &#x27;ACTIVE&#x27;, &#x27;inactive_status&#x27;: None, &#x27;description&#x27;: &#x27;Group for all instances with the tag namespace and tag key operations.department&#x27;, &#x27;compartment_id&#x27;: &#x27;ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;matching_rule&#x27;: &#x27;tag.operations.department.value&#x27;, &#x27;time_created&#x27;: &#x27;2018-07-05T09:38:27.176000+00:00&#x27;, &#x27;id&#x27;: &#x27;ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;name&#x27;: &#x27;Sample dynamic group&#x27;}</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;lifecycle_state&#x27;: &#x27;CREATING&#x27;, &#x27;inactive_status&#x27;: 56, &#x27;description&#x27;: &#x27;description_example&#x27;, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;matching_rule&#x27;: &#x27;matching_rule_example&#x27;, &#x27;defined_tags&#x27;: {&#x27;Operations&#x27;: {&#x27;CostCenter&#x27;: &#x27;US&#x27;}}, &#x27;freeform_tags&#x27;: {&#x27;Department&#x27;: &#x27;Finance&#x27;}, &#x27;time_created&#x27;: &#x27;2016-08-25T21:10:29.600Z&#x27;, &#x27;id&#x27;: &#x27;ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;name&#x27;: &#x27;name_example&#x27;}</div>
                                     </td>
             </tr>
-                        </table>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The OCID of the tenancy containing the group.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>defined_tags</b>
+                    <div style="font-size: small; color: purple">dictionary</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see <a href='https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm'>Resource Tags</a>. Example: `{&quot;Operations&quot;: {&quot;CostCenter&quot;: &quot;42&quot;}}`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;Operations&#x27;: {&#x27;CostCenter&#x27;: &#x27;US&#x27;}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>description</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The description you assign to the group. Does not have to be unique, and it&#x27;s changeable.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">description_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>freeform_tags</b>
+                    <div style="font-size: small; color: purple">dictionary</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see <a href='https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm'>Resource Tags</a>. Example: `{&quot;Department&quot;: &quot;Finance&quot;}`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;Department&#x27;: &#x27;Finance&#x27;}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The OCID of the group.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>inactive_status</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The detailed status of INACTIVE lifecycleState.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The group&#x27;s current state. After creating a group, make sure its `lifecycleState` changes from CREATING to ACTIVE before using it.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CREATING</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>matching_rule</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>A rule string that defines which instance certificates will be matched. For syntax, see <a href='https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm'>Managing Dynamic Groups</a>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">matching_rule_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>name</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The name you assign to the group during creation. The name must be unique across all groups in the tenancy and cannot be changed.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">name_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Date and time the group was created, in the format defined by RFC3339.</div>
+                                                    <div>Example: `2016-08-25T21:10:29.600Z`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
     <br/><br/>
 
 
@@ -400,7 +585,9 @@ Status
 Authors
 ~~~~~~~
 
-- Rohit Chaware (@rohitChaware)
+- Manoj Meda (@manojmeda)
+- Mike Ross (@mross22)
+- Nabeel Al-Saber (@nalsaber)
 
 
 .. hint::

--- a/docs/modules/oci_image_actions_module.rst
+++ b/docs/modules/oci_image_actions_module.rst
@@ -207,7 +207,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The OCID of the image.</div>
+                                                                        <div>The <a href='https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm'>OCID</a> of the image.</div>
                                                                                         <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
                                     </td>
             </tr>
@@ -329,19 +329,19 @@ Examples
     
     - name: Perform action export on image
       oci_image_actions:
-          image_id: ocid1.image.oc1..xxxxxxEXAMPLExxxxxx
-          destination_type: objectStorageTuple
-          bucket_name: MyBucket
-          namespace_name: MyNamespace
-          object_name: exported-image.oci
-          action: export
+        object_name: exported-image.oci
+        bucket_name: MyBucket
+        namespace_name: MyNamespace
+        destination_type: objectStorageTuple
+        image_id: ocid1.image.oc1..xxxxxxEXAMPLExxxxxx
+        action: export
 
     - name: Perform action export on image
       oci_image_actions:
-          image_id: ocid1.image.oc1..xxxxxxEXAMPLExxxxxx
-          destination_type: objectStorageUri
-          destination_uri: https://objectstorage.us-phoenix-1.oraclecloud.com/n/MyNamespace/b/MyBucket/o/exported-image.oci
-          action: export
+        destination_uri: https://objectstorage.us-phoenix-1.oraclecloud.com/n/MyNamespace/b/MyBucket/o/exported-image.oci
+        destination_type: objectStorageUri
+        image_id: ocid1.image.oc1..xxxxxxEXAMPLExxxxxx
+        action: export
 
 
 
@@ -436,7 +436,8 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                                                        <div>Whether instances launched with this image can be used to create new images. For example, you cannot create an image of an Oracle Database instance. Example: `true`</div>
+                                                                        <div>Whether instances launched with this image can be used to create new images. For example, you cannot create an image of an Oracle Database instance.</div>
+                                                    <div>Example: `true`</div>
                                                                 <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
@@ -465,7 +466,8 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                                                        <div>A user-friendly name for the image. It does not have to be unique, and it&#x27;s changeable. Avoid entering confidential information. You cannot use an Oracle-provided image name as a custom image name.</div>
+                                                                        <div>A user-friendly name for the image. It does not have to be unique, and it&#x27;s changeable. Avoid entering confidential information.</div>
+                                                    <div>You cannot use an Oracle-provided image name as a custom image name.</div>
                                                     <div>Example: `My custom Oracle Linux image`</div>
                                                                 <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
@@ -596,7 +598,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                                                        <div>Emulation type for NIC. * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver. * `VFIO` - Direct attached Virtual Function network controller.  Default for Oracle provided images. * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.</div>
+                                                                        <div>Emulation type for the physical network interface card (NIC). * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver. * `VFIO` - Direct attached Virtual Function network controller. This is the networking type when you launch an instance using hardware-assisted (SR-IOV) networking. * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.</div>
                                                                 <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">E1000</div>
@@ -670,7 +672,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                                                        <div>Image size (1 MB = 1048576 bytes)</div>
+                                                                        <div>The boot volume size for an instance launched from this image, (1 MB = 1048576 bytes). Note this is not the same as the size of the image when it was exported or the actual size of the image.</div>
                                                     <div>Example: `47694`</div>
                                                                 <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>

--- a/docs/modules/oci_image_facts_module.rst
+++ b/docs/modules/oci_image_facts_module.rst
@@ -122,7 +122,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The OCID of the compartment.</div>
+                                                                        <div>The <a href='https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm'>OCID</a> of the compartment.</div>
                                                     <div>Required to list multiple images.</div>
                                                                                 </td>
             </tr>
@@ -176,7 +176,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The OCID of the image.</div>
+                                                                        <div>The <a href='https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm'>OCID</a> of the image.</div>
                                                     <div>Required to get a specific image.</div>
                                                                                         <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
                                     </td>
@@ -423,7 +423,8 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                                                        <div>Whether instances launched with this image can be used to create new images. For example, you cannot create an image of an Oracle Database instance. Example: `true`</div>
+                                                                        <div>Whether instances launched with this image can be used to create new images. For example, you cannot create an image of an Oracle Database instance.</div>
+                                                    <div>Example: `true`</div>
                                                                 <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
@@ -452,7 +453,8 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                                                        <div>A user-friendly name for the image. It does not have to be unique, and it&#x27;s changeable. Avoid entering confidential information. You cannot use an Oracle-provided image name as a custom image name.</div>
+                                                                        <div>A user-friendly name for the image. It does not have to be unique, and it&#x27;s changeable. Avoid entering confidential information.</div>
+                                                    <div>You cannot use an Oracle-provided image name as a custom image name.</div>
                                                     <div>Example: `My custom Oracle Linux image`</div>
                                                                 <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
@@ -583,7 +585,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                                                        <div>Emulation type for NIC. * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver. * `VFIO` - Direct attached Virtual Function network controller.  Default for Oracle provided images. * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.</div>
+                                                                        <div>Emulation type for the physical network interface card (NIC). * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver. * `VFIO` - Direct attached Virtual Function network controller. This is the networking type when you launch an instance using hardware-assisted (SR-IOV) networking. * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.</div>
                                                                 <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">E1000</div>
@@ -657,7 +659,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                                                        <div>Image size (1 MB = 1048576 bytes)</div>
+                                                                        <div>The boot volume size for an instance launched from this image, (1 MB = 1048576 bytes). Note this is not the same as the size of the image when it was exported or the actual size of the image.</div>
                                                     <div>Example: `47694`</div>
                                                                 <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>

--- a/docs/modules/oci_instance_module.rst
+++ b/docs/modules/oci_instance_module.rst
@@ -517,7 +517,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>Details for the primary VNIC that is automatically created and attached when the instance is launched. Required when creating a compute instance with <em>state=present</em>.</div>
+                                                                        <div>Details for the primary VNIC that is automatically created and attached when the instance is launched. Required when creating a compute instance with <em>state=present</em>.  Updating any of these child properties is not supported through this module.</div>
                                                                                         <div style="font-size: small; color: darkgreen"><br/>aliases: create_vnic_details</div>
                                     </td>
             </tr>
@@ -532,7 +532,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>Determines whether the VNIC should be assigned a public IP address.  If not set and the VNIC is being created in a private subnet (that is, where <em>prohibitPublicIpOnVnic = true</em> in the Subnet), then no public IP address is assigned. If not set and the subnet is public <em>prohibitPublicIpOnVnic = false</em>, then a public IP address is assigned. If set to true and <em>prohibitPublicIpOnVnic = true</em>, an error is returned.</div>
+                                            <div>Determines whether the VNIC should be assigned a public IP address.  If not set and the VNIC is being created in a private subnet (that is, where <em>prohibitPublicIpOnVnic = true</em> in the Subnet), then no public IP address is assigned. If not set and the subnet is public <em>prohibitPublicIpOnVnic = false</em>, then a public IP address is assigned. If set to true and <em>prohibitPublicIpOnVnic = true</em>, an error is returned. Note this field will be used on initial create but will not be considered when determining whether to match an existing resource or create a new one.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -546,7 +546,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>The hostname for the VNIC&#x27;s primary private IP. Used for DNS. The value is the hostname portion of the primary private IP&#x27;s fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123.</div>
+                                            <div>The hostname for the VNIC&#x27;s primary private IP. Used for DNS. The value is the hostname portion of the primary private IP&#x27;s fully qualified domain name (FQDN) (for example, bminstance-1 in FQDN bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123. Note this field will be used on initial create but will not be considered when determining whether to match an existing resource or create a new one.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -560,7 +560,21 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>A user-friendly name for the VNIC. Does not have to be unique.</div>
+                                            <div>A user-friendly name for the VNIC. Does not have to be unique. Note this field will be used on initial create but will not be considered when determining whether to match an existing resource or create a new one.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>nsg_ids</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. For more information about NSGs, see NetworkSecurityGroup <a href=' https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a>. Note this field will be used on initial create but will not be considered when determining whether to match an existing resource or create a new one.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -574,7 +588,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>The private IP to assign to the VNIC. Must be an available IP address within the subnet&#x27;s CIDR. If you don&#x27;t specify a value, Oracle automatically assigns a private IP address from the subnet. This is the VNIC&#x27;s primary private IP address.</div>
+                                            <div>The private IP to assign to the VNIC. Must be an available IP address within the subnet&#x27;s CIDR. If you don&#x27;t specify a value, Oracle automatically assigns a private IP address from the subnet. This is the VNIC&#x27;s primary private IP address. Note this field will be used on initial create but will not be considered when determining whether to match an existing resource or create a new one.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -589,7 +603,7 @@ Parameters
                                                                                                                                                                                                                 <b>Default:</b><br/><div style="color: blue">"no"</div>
                                     </td>
                                                                 <td>
-                                            <div>Determines whether the source/destination check is disabled on the VNIC. Defaults to false, which means the check is performed.</div>
+                                            <div>Determines whether the source/destination check is disabled on the VNIC. Defaults to false, which means the check is performed. Note this field will be used on initial create but will not be considered when determining whether to match an existing resource or create a new one.</div>
                                                         </td>
             </tr>
                                 <tr>
@@ -603,7 +617,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>The OCID of the subnet to create the VNIC in.</div>
+                                            <div>The OCID of the subnet to create the VNIC in. Note this field will be used on initial create but will not be considered when determining whether to match an existing resource or create a new one.</div>
                                                         </td>
             </tr>
                     

--- a/docs/modules/oci_namespace_metadata_facts_module.rst
+++ b/docs/modules/oci_namespace_metadata_facts_module.rst
@@ -5,8 +5,8 @@
 .. _oci_namespace_metadata_facts_module:
 
 
-oci_namespace_metadata_facts -- Gets the metadata for the Object Storage namespace
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+oci_namespace_metadata_facts -- Fetches details about one or multiple NamespaceMetadata resources in Oracle Cloud Infrastructure
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. versionadded:: 2.5
 
@@ -17,7 +17,9 @@ oci_namespace_metadata_facts -- Gets the metadata for the Object Storage namespa
 
 Synopsis
 --------
+- Fetches details about one or multiple NamespaceMetadata resources in Oracle Cloud Infrastructure
 - Gets the metadata for the Object Storage namespace, which contains defaultS3CompartmentId and defaultSwiftCompartmentId.
+- Any user with the NAMESPACE_READ permission will be able to see the current metadata. If you are not authorized, talk to an administrator. If you are an administrator who needs to write policies to give users access, see `Getting Started with Policies <https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm>`_.
 
 
 
@@ -145,7 +147,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                                                        <div>The Object Storage namespace.</div>
+                                                                        <div>The Object Storage namespace used for the request.</div>
                                                                                 </td>
             </tr>
                                 <tr>
@@ -192,9 +194,10 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Get the object storage namespace metadata
+    - name: Get a specific namespace_metadata
       oci_namespace_metadata_facts:
-        namespace_name: examplenamespace
+        namespace_name: namespace_name_example
+
 
 
 
@@ -218,8 +221,10 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                            <div>The metadata for the Object Storage namespace, which contains defaultS3CompartmentId and defaultSwiftCompartmentId.</div>
-                                        <br/>
+                                                                        <div>List of NamespaceMetadata resources</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;namespace&#x27;: &#x27;namespace_example&#x27;, &#x27;default_s3_compartment_id&#x27;: &#x27;ocid1.defaults3compartment.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;default_swift_compartment_id&#x27;: &#x27;ocid1.defaultswiftcompartment.oc1..xxxxxxEXAMPLExxxxxx&#x27;}]</div>
                                     </td>
             </tr>
                                                             <tr>
@@ -230,10 +235,10 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                            <div>The default compartment assignment for the Amazon S3 Compatibility API.</div>
-                                        <br/>
+                                                                        <div>If the field is set, specifies the default compartment assignment for the Amazon S3 Compatibility API.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.defaults3compartment.oc1..xxxxxxEXAMPLExxxxxx</div>
                                     </td>
             </tr>
                                 <tr>
@@ -244,10 +249,10 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                            <div>The default compartment assignment for the Swift API.</div>
-                                        <br/>
+                                                                        <div>If the field is set, specifies the default compartment assignment for the Swift API.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.defaultswiftcompartment.oc1..xxxxxxEXAMPLExxxxxx</div>
                                     </td>
             </tr>
                                 <tr>
@@ -258,10 +263,10 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                            <div>The Object Storage namespace to which the metadata belongs.</div>
-                                        <br/>
+                                                                        <div>The Object Storage namespace to which the metadata belongs.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">examplenamespace</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">namespace_example</div>
                                     </td>
             </tr>
                     
@@ -288,6 +293,8 @@ Authors
 ~~~~~~~
 
 - Manoj Meda (@manojmeda)
+- Mike Ross (@mross22)
+- Nabeel Al-Saber (@nalsaber)
 
 
 .. hint::

--- a/docs/modules/oci_object_storage_object_lifecycle_policy_module.rst
+++ b/docs/modules/oci_object_storage_object_lifecycle_policy_module.rst
@@ -212,7 +212,7 @@ Parameters
                                                 <td colspan="2">
                     <b>object_name_filter</b>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">dictionary</span>
                                             </div>
                                     </td>
                                 <td>
@@ -227,7 +227,7 @@ Parameters
                                                 <td colspan="1">
                     <b>exclusion_patterns</b>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">list</span>
                                             </div>
                                     </td>
                                 <td>
@@ -244,7 +244,7 @@ Parameters
                                                 <td colspan="1">
                     <b>inclusion_patterns</b>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">list</span>
                                             </div>
                                     </td>
                                 <td>
@@ -261,7 +261,7 @@ Parameters
                                                 <td colspan="1">
                     <b>inclusion_prefixes</b>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">list</span>
                                             </div>
                                     </td>
                                 <td>
@@ -276,7 +276,7 @@ Parameters
                                                 <td colspan="2">
                     <b>time_amount</b>
                     <div style="font-size: small">
-                        <span style="color: purple">-</span>
+                        <span style="color: purple">integer</span>
                          / <span style="color: red">required</span>                    </div>
                                     </td>
                                 <td>
@@ -380,7 +380,7 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Update object_lifecycle_policy from x-example
+    - name: Update object_lifecycle_policy
       oci_object_storage_object_lifecycle_policy:
           namespace_name: namespace_name_example
           bucket_name: my-new-bucket1

--- a/docs/modules/oci_region_facts_module.rst
+++ b/docs/modules/oci_region_facts_module.rst
@@ -5,8 +5,8 @@
 .. _oci_region_facts_module:
 
 
-oci_region_facts -- Retrieve details about all Regions offered by Oracle Cloud Infrastructure
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+oci_region_facts -- Fetches details about one or multiple Region resources in Oracle Cloud Infrastructure
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. versionadded:: 2.5
 
@@ -17,7 +17,8 @@ oci_region_facts -- Retrieve details about all Regions offered by Oracle Cloud I
 
 Synopsis
 --------
-- This module retrieves details about all Regions offered by Oracle Cloud Infrastructure.
+- Fetches details about one or multiple Region resources in Oracle Cloud Infrastructure
+- Lists all the regions offered by Oracle Cloud Infrastructure.
 
 
 
@@ -192,8 +193,9 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Get details of all regions offered by OCI
+    - name: List regions
       oci_region_facts:
+
 
 
 
@@ -217,10 +219,10 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                     </td>
                 <td>on success</td>
                 <td>
-                                            <div>Information about regions offered by OCI</div>
-                                        <br/>
+                                                                        <div>List of Region resources</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;name&#x27;: &#x27;eu-frankfurt-1&#x27;, &#x27;key&#x27;: &#x27;FRA&#x27;}, {&#x27;name&#x27;: &#x27;us-ashburn-1&#x27;, &#x27;key&#x27;: &#x27;IAD&#x27;}, {&#x27;name&#x27;: &#x27;us-phoenix-1&#x27;, &#x27;key&#x27;: &#x27;PHX&#x27;}]</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;name&#x27;: &#x27;name_example&#x27;, &#x27;key&#x27;: &#x27;key_example&#x27;}]</div>
                                     </td>
             </tr>
                                                             <tr>
@@ -229,12 +231,13 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>key</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The key of the region.</div>
-                                        <br/>
+                                                                        <div>The key of the region.</div>
+                                                    <div>Allowed values are: - `PHX` - `IAD` - `FRA` - `LHR`</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">PHX</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">key_example</div>
                                     </td>
             </tr>
                                 <tr>
@@ -243,12 +246,13 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                     <b>name</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The name of the region.</div>
-                                        <br/>
+                                                                        <div>The name of the region.</div>
+                                                    <div>Allowed values are: - `us-phoenix-1` - `us-ashburn-1` - `eu-frankfurt-1` - `uk-london-1`</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">us-phoenix-1</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">name_example</div>
                                     </td>
             </tr>
                     
@@ -274,7 +278,9 @@ Status
 Authors
 ~~~~~~~
 
-- Sivakumar Thyagarajan (@sivakumart)
+- Manoj Meda (@manojmeda)
+- Mike Ross (@mross22)
+- Nabeel Al-Saber (@nalsaber)
 
 
 .. hint::

--- a/docs/modules/oci_security_rule_actions_module.rst
+++ b/docs/modules/oci_security_rule_actions_module.rst
@@ -1,0 +1,1239 @@
+:source: cloud/oracle/oci_security_rule_actions.py
+
+:orphan:
+
+.. _oci_security_rule_actions_module:
+
+
+oci_security_rule_actions -- Perform actions on a SecurityRule resource in Oracle Cloud Infrastructure
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Perform actions on a SecurityRule resource in Oracle Cloud Infrastructure
+- For *action=add_network_security_group_security_rules*, adds one or more security rules to the specified network security group.
+- For *action=remove_network_security_group_security_rules*, removes one or more security rules from the specified network security group.
+- For *action=update_network_security_group_security_rules*, updates one or more security rules in the specified network security group.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.7
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="4">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="4">
+                    <b>action</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>add_network_security_group_security_rules</li>
+                                                                                                                                                                                                <li>remove_network_security_group_security_rules</li>
+                                                                                                                                                                                                <li>update_network_security_group_security_rules</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The action to perform on the SecurityRule.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>api_user</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user&#x27;s OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>api_user_fingerprint</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair&#x27;s fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>api_user_key_file</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>api_user_key_pass_phrase</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>auth_type</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this &#x27;auth_type&#x27; module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>config_file_location</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>config_profile_name</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>network_security_group_id</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The <a href='https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm'>OCID</a> of the network security group.</div>
+                                                                                        <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>region</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>security_rule_ids</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle-assigned ID of each <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/SecurityRule/'>SecurityRule</a> to be deleted.</div>
+                                                    <div>Applicable only for <em>action=remove_network_security_group_security_rules</em>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="4">
+                    <b>security_rules</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The NSG security rules to add.</div>
+                                                    <div>Applicable only for <em>action=add_network_security_group_security_rules</em><em>action=update_network_security_group_security_rules</em>.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>description</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>An optional description of your choice for the rule. Avoid entering confidential information.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>destination</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Conceptually, this is the range of IP addresses that a packet originating from the instance can go to.</div>
+                                                    <div>Allowed values:</div>
+                                                    <div>* An IP address range in CIDR notation. For example: `192.168.1.0/24`</div>
+                                                    <div>* The `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a>, if you&#x27;re setting up a security rule for traffic destined for a particular `Service` through a service gateway. For example: `oci-phx-objectstorage`.</div>
+                                                    <div>* The OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a> in the same VCN. The value can be the NSG that the rule belongs to if the rule&#x27;s intent is to control traffic between VNICs in the same NSG.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>destination_type</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>CIDR_BLOCK</li>
+                                                                                                                                                                                                <li>SERVICE_CIDR_BLOCK</li>
+                                                                                                                                                                                                <li>NETWORK_SECURITY_GROUP</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Type of destination for the rule. Required if `direction` = `EGRESS`.</div>
+                                                    <div>Allowed values:</div>
+                                                    <div>* `CIDR_BLOCK`: If the rule&#x27;s `destination` is an IP address range in CIDR notation.</div>
+                                                    <div>* `SERVICE_CIDR_BLOCK`: If the rule&#x27;s `destination` is the `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a> (the rule is for traffic destined for a particular `Service` through a service gateway).</div>
+                                                    <div>* `NETWORK_SECURITY_GROUP`: If the rule&#x27;s `destination` is the OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>direction</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>EGRESS</li>
+                                                                                                                                                                                                <li>INGRESS</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets, or `INGRESS` for rules to allow inbound IP packets.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>icmp_options</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code as defined in: - <a href='http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml'>ICMP Parameters</a> - <a href='https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml'>ICMPv6 Parameters</a></div>
+                                                    <div>If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and codes are allowed. If you do provide this object, the type is required and the code is optional. To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 (&quot;Destination Unreachable&quot;) code 4 (&quot;Fragmentation Needed and Don&#x27;t Fragment was Set&quot;). If you need to specify multiple codes for a single type, create a separate security list rule for each.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>code</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The ICMP code (optional).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>type</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The ICMP type.</div>
+                                                                                </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>id</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle-assigned ID of the security rule that you want to update. You can&#x27;t change this value.</div>
+                                                    <div>Example: `04ABEC`</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>is_stateless</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>A stateless rule allows traffic in one direction. Remember to add a corresponding stateless rule in the other direction if you need to support bidirectional traffic. For example, if egress traffic allows TCP destination port 80, there should be an ingress rule to allow TCP source port 80. Defaults to false, which means the rule is stateful and a corresponding rule is not necessary for bidirectional traffic.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>protocol</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The transport protocol. Specify either `all` or an IPv4 protocol number as defined in <a href='http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'>Protocol Numbers</a>. Options are supported only for ICMP (&quot;1&quot;), TCP (&quot;6&quot;), UDP (&quot;17&quot;), and ICMPv6 (&quot;58&quot;).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>source</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Conceptually, this is the range of IP addresses that a packet coming into the instance can come from.</div>
+                                                    <div>Allowed values:</div>
+                                                    <div>* An IP address range in CIDR notation. For example: `192.168.1.0/24`</div>
+                                                    <div>* The `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a>, if you&#x27;re setting up a security rule for traffic coming from a particular `Service` through a service gateway. For example: `oci-phx-objectstorage`.</div>
+                                                    <div>* The OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a> in the same VCN. The value can be the NSG that the rule belongs to if the rule&#x27;s intent is to control traffic between VNICs in the same NSG.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>source_type</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>CIDR_BLOCK</li>
+                                                                                                                                                                                                <li>SERVICE_CIDR_BLOCK</li>
+                                                                                                                                                                                                <li>NETWORK_SECURITY_GROUP</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Type of source for the rule. Required if `direction` = `INGRESS`.</div>
+                                                    <div>* `CIDR_BLOCK`: If the rule&#x27;s `source` is an IP address range in CIDR notation.</div>
+                                                    <div>* `SERVICE_CIDR_BLOCK`: If the rule&#x27;s `source` is the `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a> (the rule is for traffic coming from a particular `Service` through a service gateway).</div>
+                                                    <div>* `NETWORK_SECURITY_GROUP`: If the rule&#x27;s `source` is the OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>tcp_options</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Optional and valid only for TCP. Use to specify particular destination ports for TCP rules. If you specify TCP as the protocol but omit this object, then all destination ports are allowed.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>destination_port_range</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>An inclusive range of allowed destination ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                                </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>source_port_range</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>An inclusive range of allowed source ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                                </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="3">
+                    <b>udp_options</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Optional and valid only for UDP. Use to specify particular destination ports for UDP rules. If you specify UDP as the protocol but omit this object, then all destination ports are allowed.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>destination_port_range</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>An inclusive range of allowed destination ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                                </td>
+            </tr>
+                    
+                                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="2">
+                    <b>source_port_range</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>An inclusive range of allowed source ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                                </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                                </td>
+            </tr>
+                    
+                                    
+                                    
+                                                <tr>
+                                                                <td colspan="4">
+                    <b>tenancy</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Perform action add_network_security_group_security_rules on security_rule
+      oci_security_rule_actions:
+        network_security_group_id: ocid1.networksecuritygroup.oc1..xxxxxxEXAMPLExxxxxx
+        security_rules:
+        - description: Example ingress security rule
+          source_type: CIDR_BLOCK
+          source: 10.0.0.0/16
+          direction: INGRESS
+          protocol: all
+        - description: Example egress security rule
+          source_type: CIDR_BLOCK
+          source: 10.0.0.0/16
+          direction: EGRESS
+          protocol: all
+        action: add_network_security_group_security_rules
+
+    - name: Perform action remove_network_security_group_security_rules on security_rule
+      oci_security_rule_actions:
+        network_security_group_id: ocid1.networksecuritygroup.oc1..xxxxxxEXAMPLExxxxxx
+        security_rule_ids:
+        - 880233
+        - 203597
+        action: remove_network_security_group_security_rules
+
+    - name: Perform action update_network_security_group_security_rules on security_rule
+      oci_security_rule_actions:
+        network_security_group_id: ocid1.networksecuritygroup.oc1..xxxxxxEXAMPLExxxxxx
+        security_rules:
+        - description: Example ingress security rule - updated
+          id: 203597
+          source_type: CIDR_BLOCK
+          source: 10.0.0.0/24
+          direction: INGRESS
+          protocol: all
+        - description: Example egress security rule - updated
+          id: 880233
+          source_type: CIDR_BLOCK
+          source: 10.0.0.0/24
+          direction: EGRESS
+          protocol: all
+        action: update_network_security_group_security_rules
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="5">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="5">
+                    <b>security_rule</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Details of the SecurityRule resource acted upon by the current operation</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;security_rules&#x27;: [{&#x27;direction&#x27;: &#x27;EGRESS&#x27;, &#x27;icmp_options&#x27;: {&#x27;code&#x27;: 56, &#x27;type&#x27;: 56}, &#x27;description&#x27;: &#x27;description_example&#x27;, &#x27;source&#x27;: &#x27;source_example&#x27;, &#x27;tcp_options&#x27;: {&#x27;source_port_range&#x27;: {&#x27;max&#x27;: 56, &#x27;min&#x27;: 56}, &#x27;destination_port_range&#x27;: {&#x27;max&#x27;: 56, &#x27;min&#x27;: 56}}, &#x27;destination&#x27;: &#x27;destination_example&#x27;, &#x27;is_stateless&#x27;: True, &#x27;time_created&#x27;: &#x27;2013-10-20T19:20:30+01:00&#x27;, &#x27;source_type&#x27;: &#x27;CIDR_BLOCK&#x27;, &#x27;is_valid&#x27;: True, &#x27;udp_options&#x27;: {&#x27;source_port_range&#x27;: {&#x27;max&#x27;: 56, &#x27;min&#x27;: 56}, &#x27;destination_port_range&#x27;: {&#x27;max&#x27;: 56, &#x27;min&#x27;: 56}}, &#x27;destination_type&#x27;: &#x27;CIDR_BLOCK&#x27;, &#x27;protocol&#x27;: &#x27;protocol_example&#x27;, &#x27;id&#x27;: &#x27;04ABEC&#x27;}]}</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="4">
+                    <b>security_rules</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The NSG security rules that were added.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>description</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An optional description of your choice for the rule.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">description_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>destination</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Conceptually, this is the range of IP addresses that a packet originating from the instance can go to.</div>
+                                                    <div>Allowed values:</div>
+                                                    <div>* An IP address range in CIDR notation. For example: `192.168.1.0/24`</div>
+                                                    <div>* The `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a>, if you&#x27;re setting up a security rule for traffic destined for a particular `Service` through a service gateway. For example: `oci-phx-objectstorage`.</div>
+                                                    <div>* The OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a> in the same VCN. The value can be the NSG that the rule belongs to if the rule&#x27;s intent is to control traffic between VNICs in the same NSG.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">destination_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>destination_type</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Type of destination for the rule. Required if `direction` = `EGRESS`.</div>
+                                                    <div>Allowed values:</div>
+                                                    <div>* `CIDR_BLOCK`: If the rule&#x27;s `destination` is an IP address range in CIDR notation.</div>
+                                                    <div>* `SERVICE_CIDR_BLOCK`: If the rule&#x27;s `destination` is the `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a> (the rule is for traffic destined for a particular `Service` through a service gateway).</div>
+                                                    <div>* `NETWORK_SECURITY_GROUP`: If the rule&#x27;s `destination` is the OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CIDR_BLOCK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>direction</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets, or `INGRESS` for rules to allow inbound IP packets.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">EGRESS</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>icmp_options</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code as defined in: - <a href='http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml'>ICMP Parameters</a> - <a href='https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml'>ICMPv6 Parameters</a></div>
+                                                    <div>If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and codes are allowed. If you do provide this object, the type is required and the code is optional. To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 (&quot;Destination Unreachable&quot;) code 4 (&quot;Fragmentation Needed and Don&#x27;t Fragment was Set&quot;). If you need to specify multiple codes for a single type, create a separate security rule for each.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>code</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The ICMP code (optional).</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>type</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The ICMP type.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>id</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An Oracle-assigned identifier for the security rule. You specify this ID when you want to update or delete the rule.</div>
+                                                    <div>Example: `04ABEC`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">04ABEC</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>is_stateless</b>
+                    <div style="font-size: small; color: purple">boolean</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>A stateless rule allows traffic in one direction. Remember to add a corresponding stateless rule in the other direction if you need to support bidirectional traffic. For example, if egress traffic allows TCP destination port 80, there should be an ingress rule to allow TCP source port 80. Defaults to false, which means the rule is stateful and a corresponding rule is not necessary for bidirectional traffic.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>is_valid</b>
+                    <div style="font-size: small; color: purple">boolean</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Whether the rule is valid. The value is `True` when the rule is first created. If the rule&#x27;s `source` or `destination` is a network security group, the value changes to `False` if that network security group is deleted.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>protocol</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The transport protocol. Specify either `all` or an IPv4 protocol number as defined in <a href='http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'>Protocol Numbers</a>. Options are supported only for ICMP (&quot;1&quot;), TCP (&quot;6&quot;), UDP (&quot;17&quot;), and ICMPv6 (&quot;58&quot;).</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">protocol_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>source</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Conceptually, this is the range of IP addresses that a packet coming into the instance can come from.</div>
+                                                    <div>Allowed values:</div>
+                                                    <div>* An IP address range in CIDR notation. For example: `192.168.1.0/24`</div>
+                                                    <div>* The `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a>, if you&#x27;re setting up a security rule for traffic coming from a particular `Service` through a service gateway. For example: `oci-phx-objectstorage`.</div>
+                                                    <div>* The OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a> in the same VCN. The value can be the NSG that the rule belongs to if the rule&#x27;s intent is to control traffic between VNICs in the same NSG.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">source_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>source_type</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Type of source for the rule. Required if `direction` = `INGRESS`.</div>
+                                                    <div>* `CIDR_BLOCK`: If the rule&#x27;s `source` is an IP address range in CIDR notation.</div>
+                                                    <div>* `SERVICE_CIDR_BLOCK`: If the rule&#x27;s `source` is the `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a> (the rule is for traffic coming from a particular `Service` through a service gateway).</div>
+                                                    <div>* `NETWORK_SECURITY_GROUP`: If the rule&#x27;s `source` is the OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CIDR_BLOCK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>tcp_options</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Optional and valid only for TCP. Use to specify particular destination ports for TCP rules. If you specify TCP as the protocol but omit this object, then all destination ports are allowed.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>destination_port_range</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An inclusive range of allowed destination ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>source_port_range</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An inclusive range of allowed source ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>time_created</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The date and time the security rule was created. Format defined by RFC3339.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2013-10-20 18:20:30</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>udp_options</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Optional and valid only for UDP. Use to specify particular destination ports for UDP rules. If you specify UDP as the protocol but omit this object, then all destination ports are allowed.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>destination_port_range</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An inclusive range of allowed destination ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>source_port_range</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An inclusive range of allowed source ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                    
+                                    
+                                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+
+- This module is not guaranteed to have a backwards compatible interface. *[preview]*
+
+
+- This module is :ref:`maintained by the Ansible Community <modules_support>`. *[community]*
+
+
+
+
+
+Authors
+~~~~~~~
+
+- Manoj Meda (@manojmeda)
+- Mike Ross (@mross22)
+- Nabeel Al-Saber (@nalsaber)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_security_rule_actions.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_security_rule_facts_module.rst
+++ b/docs/modules/oci_security_rule_facts_module.rst
@@ -1,0 +1,732 @@
+:source: cloud/oracle/oci_security_rule_facts.py
+
+:orphan:
+
+.. _oci_security_rule_facts_module:
+
+
+oci_security_rule_facts -- Fetches details about one or multiple SecurityRule resources in Oracle Cloud Infrastructure
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.5
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Fetches details about one or multiple SecurityRule resources in Oracle Cloud Infrastructure
+- Lists the security rules in the specified network security group.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.7
+- Python SDK for Oracle Cloud Infrastructure https://oracle-cloud-infrastructure-python-sdk.readthedocs.io
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <b>api_user</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user is not specified through a configuration file (See <code>config_file_location</code>). To get the user&#x27;s OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_fingerprint</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT environment variable, if any, is used. This option is required if the key fingerprint is not specified through a configuration file (See <code>config_file_location</code>). To get the key pair&#x27;s fingerprint value please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_file</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Full path and filename of the private key (in PEM format). If not set, then the value of the OCI_USER_KEY_FILE variable, if any, is used. This option is required if the private key is not specified through a configuration file (See <code>config_file_location</code>). If the key is encrypted with a pass-phrase, the <code>api_user_key_pass_phrase</code> option must also be provided.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>api_user_key_pass_phrase</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Passphrase used by the key referenced in <code>api_user_key_file</code>, if it is encrypted. If not set, then the value of the OCI_USER_KEY_PASS_PHRASE variable, if any, is used. This option is required if the key passphrase is not specified through a configuration file (See <code>config_file_location</code>).</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>auth_type</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>api_key</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>instance_principal</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The type of authentication to use for making API requests. By default <code>auth_type=&quot;api_key&quot;</code> based authentication is performed and the API key (see <em>api_user_key_file</em>) in your config file will be used. If this &#x27;auth_type&#x27; module option is not specified, the value of the OCI_ANSIBLE_AUTH_TYPE, if any, is used. Use <code>auth_type=&quot;instance_principal&quot;</code> to use instance principal based authentication when running ansible playbooks within an OCI compute instance.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_file_location</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable, if any, is used. Otherwise, defaults to ~/.oci/config.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>config_profile_name</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The profile to load from the config file referenced by <code>config_file_location</code>. If not set, then the value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the &quot;DEFAULT&quot; profile in <code>config_file_location</code>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>direction</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>EGRESS</li>
+                                                                                                                                                                                                <li>INGRESS</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>Direction of the security rule. Set to `EGRESS` for rules that allow outbound IP packets, or `INGRESS` for rules that allow inbound IP packets.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>network_security_group_id</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The <a href='https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm'>OCID</a> of the network security group.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>region</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The Oracle Cloud Infrastructure region to use for all OCI API requests. If not set, then the value of the OCI_REGION variable, if any, is used. This option is required if the region is not specified through a configuration file (See <code>config_file_location</code>). Please refer to <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm</a> for more information on OCI regions.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>sort_by</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>TIMECREATED</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The field to sort by.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>sort_order</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>ASC</li>
+                                                                                                                                                                                                <li>DESC</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order is case sensitive.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <b>tenancy</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>OCID of your tenancy. If not set, then the value of the OCI_TENANCY variable, if any, is used. This option is required if the tenancy OCID is not specified through a configuration file (See <code>config_file_location</code>). To get the tenancy OCID, please refer <a href='https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm'>https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm</a></div>
+                                                                                </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - For OCI python sdk configuration, please refer to https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/configuration.html
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: List security_rules
+      oci_security_rule_facts:
+        network_security_group_id: ocid1.networksecuritygroup.oc1..xxxxxxEXAMPLExxxxxx
+
+
+
+
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="4">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="4">
+                    <b>security_rules</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>List of SecurityRule resources</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;direction&#x27;: &#x27;EGRESS&#x27;, &#x27;icmp_options&#x27;: {&#x27;code&#x27;: 56, &#x27;type&#x27;: 56}, &#x27;description&#x27;: &#x27;description_example&#x27;, &#x27;source&#x27;: &#x27;source_example&#x27;, &#x27;tcp_options&#x27;: {&#x27;source_port_range&#x27;: {&#x27;max&#x27;: 56, &#x27;min&#x27;: 56}, &#x27;destination_port_range&#x27;: {&#x27;max&#x27;: 56, &#x27;min&#x27;: 56}}, &#x27;destination&#x27;: &#x27;destination_example&#x27;, &#x27;is_stateless&#x27;: True, &#x27;time_created&#x27;: &#x27;2013-10-20T19:20:30+01:00&#x27;, &#x27;source_type&#x27;: &#x27;CIDR_BLOCK&#x27;, &#x27;is_valid&#x27;: True, &#x27;udp_options&#x27;: {&#x27;source_port_range&#x27;: {&#x27;max&#x27;: 56, &#x27;min&#x27;: 56}, &#x27;destination_port_range&#x27;: {&#x27;max&#x27;: 56, &#x27;min&#x27;: 56}}, &#x27;destination_type&#x27;: &#x27;CIDR_BLOCK&#x27;, &#x27;protocol&#x27;: &#x27;protocol_example&#x27;, &#x27;id&#x27;: &#x27;04ABEC&#x27;}]</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>description</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An optional description of your choice for the rule.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">description_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>destination</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Conceptually, this is the range of IP addresses that a packet originating from the instance can go to.</div>
+                                                    <div>Allowed values:</div>
+                                                    <div>* An IP address range in CIDR notation. For example: `192.168.1.0/24`</div>
+                                                    <div>* The `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a>, if you&#x27;re setting up a security rule for traffic destined for a particular `Service` through a service gateway. For example: `oci-phx-objectstorage`.</div>
+                                                    <div>* The OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a> in the same VCN. The value can be the NSG that the rule belongs to if the rule&#x27;s intent is to control traffic between VNICs in the same NSG.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">destination_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>destination_type</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Type of destination for the rule. Required if `direction` = `EGRESS`.</div>
+                                                    <div>Allowed values:</div>
+                                                    <div>* `CIDR_BLOCK`: If the rule&#x27;s `destination` is an IP address range in CIDR notation.</div>
+                                                    <div>* `SERVICE_CIDR_BLOCK`: If the rule&#x27;s `destination` is the `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a> (the rule is for traffic destined for a particular `Service` through a service gateway).</div>
+                                                    <div>* `NETWORK_SECURITY_GROUP`: If the rule&#x27;s `destination` is the OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CIDR_BLOCK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>direction</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets, or `INGRESS` for rules to allow inbound IP packets.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">EGRESS</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>icmp_options</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code as defined in: - <a href='http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml'>ICMP Parameters</a> - <a href='https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml'>ICMPv6 Parameters</a></div>
+                                                    <div>If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and codes are allowed. If you do provide this object, the type is required and the code is optional. To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 (&quot;Destination Unreachable&quot;) code 4 (&quot;Fragmentation Needed and Don&#x27;t Fragment was Set&quot;). If you need to specify multiple codes for a single type, create a separate security rule for each.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>code</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The ICMP code (optional).</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>type</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The ICMP type.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>id</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An Oracle-assigned identifier for the security rule. You specify this ID when you want to update or delete the rule.</div>
+                                                    <div>Example: `04ABEC`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">04ABEC</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>is_stateless</b>
+                    <div style="font-size: small; color: purple">boolean</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>A stateless rule allows traffic in one direction. Remember to add a corresponding stateless rule in the other direction if you need to support bidirectional traffic. For example, if egress traffic allows TCP destination port 80, there should be an ingress rule to allow TCP source port 80. Defaults to false, which means the rule is stateful and a corresponding rule is not necessary for bidirectional traffic.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>is_valid</b>
+                    <div style="font-size: small; color: purple">boolean</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Whether the rule is valid. The value is `True` when the rule is first created. If the rule&#x27;s `source` or `destination` is a network security group, the value changes to `False` if that network security group is deleted.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>protocol</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The transport protocol. Specify either `all` or an IPv4 protocol number as defined in <a href='http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'>Protocol Numbers</a>. Options are supported only for ICMP (&quot;1&quot;), TCP (&quot;6&quot;), UDP (&quot;17&quot;), and ICMPv6 (&quot;58&quot;).</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">protocol_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>source</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Conceptually, this is the range of IP addresses that a packet coming into the instance can come from.</div>
+                                                    <div>Allowed values:</div>
+                                                    <div>* An IP address range in CIDR notation. For example: `192.168.1.0/24`</div>
+                                                    <div>* The `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a>, if you&#x27;re setting up a security rule for traffic coming from a particular `Service` through a service gateway. For example: `oci-phx-objectstorage`.</div>
+                                                    <div>* The OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a> in the same VCN. The value can be the NSG that the rule belongs to if the rule&#x27;s intent is to control traffic between VNICs in the same NSG.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">source_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>source_type</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Type of source for the rule. Required if `direction` = `INGRESS`.</div>
+                                                    <div>* `CIDR_BLOCK`: If the rule&#x27;s `source` is an IP address range in CIDR notation.</div>
+                                                    <div>* `SERVICE_CIDR_BLOCK`: If the rule&#x27;s `source` is the `cidrBlock` value for a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/'>Service</a> (the rule is for traffic coming from a particular `Service` through a service gateway).</div>
+                                                    <div>* `NETWORK_SECURITY_GROUP`: If the rule&#x27;s `source` is the OCID of a <a href='https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CIDR_BLOCK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>tcp_options</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Optional and valid only for TCP. Use to specify particular destination ports for TCP rules. If you specify TCP as the protocol but omit this object, then all destination ports are allowed.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>destination_port_range</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An inclusive range of allowed destination ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>source_port_range</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An inclusive range of allowed source ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>time_created</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The date and time the security rule was created. Format defined by RFC3339.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2013-10-20 18:20:30</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <b>udp_options</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Optional and valid only for UDP. Use to specify particular destination ports for UDP rules. If you specify UDP as the protocol but omit this object, then all destination ports are allowed.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>destination_port_range</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An inclusive range of allowed destination ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <b>source_port_range</b>
+                    <div style="font-size: small; color: purple">complex</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>An inclusive range of allowed source ports. Use the same number for the min and max to indicate a single port. Defaults to all ports if not specified.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>max</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The maximum port number. Must not be lower than the minimum port number. To specify a single port number, set both the min and max to the same value.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>min</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The minimum port number. Must not be greater than the maximum port number.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                    
+                                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+
+
+- This module is not guaranteed to have a backwards compatible interface. *[preview]*
+
+
+- This module is :ref:`maintained by the Ansible Community <modules_support>`. *[community]*
+
+
+
+
+
+Authors
+~~~~~~~
+
+- Manoj Meda (@manojmeda)
+- Mike Ross (@mross22)
+- Nabeel Al-Saber (@nalsaber)
+
+
+.. hint::
+    If you notice any issues in this documentation you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/cloud/oracle/oci_security_rule_facts.py?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.

--- a/docs/modules/oci_vnic_attachment_module.rst
+++ b/docs/modules/oci_vnic_attachment_module.rst
@@ -305,6 +305,20 @@ Parameters
                                 <tr>
                                                     <td class="elbow-placeholder"></td>
                                                 <td colspan="1">
+                    <b>nsg_ids</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. For more information about NSGs, see NetworkSecurityGroup <a href=' https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
                     <b>private_ip</b>
                     <div style="font-size: small">
                         <span style="color: purple">-</span>

--- a/docs/modules/oci_vnic_module.rst
+++ b/docs/modules/oci_vnic_module.rst
@@ -164,6 +164,19 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>nsg_ids</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. Setting this as an empty array removes the VNIC from all network security groups. For more information about NSGs, see <a href=' https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/NetworkSecurityGroup/'>NetworkSecurityGroup</a>.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>region</b>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
@@ -288,7 +301,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                             <div>Details of the VNIC attachment</div>
                                         <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;lifecycle_state&#x27;: &#x27;AVAILABLE&#x27;, &#x27;availability_domain&#x27;: &#x27;BnQb:PHX-AD-1&#x27;, &#x27;display_name&#x27;: &#x27;my_test_secondary_vnic_name_mod&#x27;, &#x27;hostname_label&#x27;: &#x27;ansible-test-45-1&#x27;, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...lwbvm62xq&#x27;, &#x27;subnet_id&#x27;: &#x27;ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...smpqpaoa&#x27;, &#x27;is_primary&#x27;: False, &#x27;time_created&#x27;: &#x27;2017-11-26T16:24:39.642000+00:00&#x27;, &#x27;public_ip&#x27;: None, &#x27;skip_source_dest_check&#x27;: False, &#x27;private_ip&#x27;: &#x27;10.0.0.11&#x27;, &#x27;mac_address&#x27;: &#x27;00:00:17:00:BC:6A&#x27;, &#x27;id&#x27;: &#x27;ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...2beqa&#x27;}</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;lifecycle_state&#x27;: &#x27;AVAILABLE&#x27;, &#x27;availability_domain&#x27;: &#x27;BnQb:PHX-AD-1&#x27;, &#x27;display_name&#x27;: &#x27;my_test_secondary_vnic_name_mod&#x27;, &#x27;hostname_label&#x27;: &#x27;ansible-test-45-1&#x27;, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx...lwbvm62xq&#x27;, &#x27;subnet_id&#x27;: &#x27;ocid1.subnet.oc1.phx.xxxxxEXAMPLExxxxx...smpqpaoa&#x27;, &#x27;is_primary&#x27;: False, &#x27;time_created&#x27;: &#x27;2017-11-26T16:24:39.642000+00:00&#x27;, &#x27;nsg_ids&#x27;: [&#x27;ocid1.networksecuritygroup.oc1.iad.aaaaaaaas5tfvdhvt6sfam3wfzarw&#x27;], &#x27;skip_source_dest_check&#x27;: False, &#x27;private_ip&#x27;: &#x27;10.0.0.11&#x27;, &#x27;public_ip&#x27;: None, &#x27;mac_address&#x27;: &#x27;00:00:17:00:BC:6A&#x27;, &#x27;id&#x27;: &#x27;ocid1.vnic.oc1.phx.xxxxxEXAMPLExxxxx...2beqa&#x27;}</div>
                                     </td>
             </tr>
                         </table>

--- a/docs/modules/oci_volume_attachment_module.rst
+++ b/docs/modules/oci_volume_attachment_module.rst
@@ -137,6 +137,19 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>device</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                                                        <div>The device name.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>display_name</b>
                     <div style="font-size: small">
                         <span style="color: purple">-</span>
@@ -366,24 +379,285 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
     <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-            <th colspan="1">Key</th>
+            <th colspan="2">Key</th>
             <th>Returned</th>
             <th width="100%">Description</th>
         </tr>
                     <tr>
-                                <td colspan="1">
+                                <td colspan="2">
                     <b>volume_attachment</b>
-                    <div style="font-size: small; color: purple">dictionary</div>
+                    <div style="font-size: small; color: purple">complex</div>
                                     </td>
-                <td>On successful attach operation</td>
+                <td>on success</td>
                 <td>
-                                            <div>Information about the volume attachment</div>
-                                        <br/>
+                                                                        <div>Details of the VolumeAttachment resource acted upon by the current operation</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;chap_username&#x27;: None, &#x27;iscsi_detach_commands&#x27;: [&#x27;sudo iscsiadm -m node -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260 -u&#x27;, &#x27;sudo iscsiadm -m node -o delete -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328&#x27;], &#x27;time_created&#x27;: &#x27;2017-11-23T11:17:50.139000+00:00&#x27;, &#x27;volume_id&#x27;: &#x27;ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx&#x27;, &#x27;port&#x27;: 3260, &#x27;lifecycle_state&#x27;: &#x27;ATTACHED&#x27;, &#x27;availability_domain&#x27;: &#x27;BnQb:PHX-AD-1&#x27;, &#x27;display_name&#x27;: &#x27;ansible_volume_attachment&#x27;, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;id&#x27;: &#x27;ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx&#x27;, &#x27;instance_id&#x27;: &#x27;ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx&#x27;, &#x27;iqn&#x27;: &#x27;iqn.2015-12.com.oracleiaas:472a085d-41a9-4c18-ae7d-dea5b296dad3&#x27;, &#x27;ipv4&#x27;: &#x27;169.254.2.2&#x27;, &#x27;attachment_type&#x27;: &#x27;iscsi&#x27;, &#x27;chap_secret&#x27;: None, &#x27;iscsi_attach_commands&#x27;: [&#x27;sudo iscsiadm -m node -o new -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260&#x27;, &#x27;sudo iscsiadm -m node -o update -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -n node.startup -v automatic&#x27;, &#x27;sudo iscsiadm -m node -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260 -l&#x27;]}</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;chap_username&#x27;: &#x27;ocid1.volume.oc1.phx.abyhqljrgvttnlx73nmrwfaux7kcvzfs3s66izvxf2h4lgvyndsdsnoiwr5q&#x27;, &#x27;iscsi_detach_commands&#x27;: [&#x27;sudo iscsiadm -m node -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260 -u&#x27;, &#x27;sudo iscsiadm -m node -o delete -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328&#x27;], &#x27;time_created&#x27;: &#x27;2016-08-25T21:10:29.600Z&#x27;, &#x27;is_read_only&#x27;: True, &#x27;volume_id&#x27;: &#x27;ocid1.volume.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;device&#x27;: &#x27;/dev/oracleoci/oraclevdb&#x27;, &#x27;is_shareable&#x27;: True, &#x27;port&#x27;: 3260, &#x27;ipv4&#x27;: &#x27;169.254.0.2&#x27;, &#x27;lifecycle_state&#x27;: &#x27;ATTACHING&#x27;, &#x27;availability_domain&#x27;: &#x27;Uocm:PHX-AD-1&#x27;, &#x27;display_name&#x27;: &#x27;My volume attachment&#x27;, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;id&#x27;: &#x27;ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;instance_id&#x27;: &#x27;ocid1.instance.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;iqn&#x27;: &#x27;iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9&#x27;, &#x27;is_pv_encryption_in_transit_enabled&#x27;: True, &#x27;attachment_type&#x27;: &#x27;attachment_type_example&#x27;, &#x27;chap_secret&#x27;: &#x27;d6866c0d-298b-48ba-95af-309b4faux45e&#x27;, &#x27;iscsi_attach_commands&#x27;: [&#x27;sudo iscsiadm -m node -o new -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260&#x27;, &#x27;sudo iscsiadm -m node -o update -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -n node.startup -v automatic&#x27;, &#x27;sudo iscsiadm -m node -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260 -l&#x27;]}</div>
                                     </td>
             </tr>
-                        </table>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>attachment_type</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The type of volume attachment.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">attachment_type_example</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>availability_domain</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The availability domain of an instance.</div>
+                                                    <div>Example: `Uocm:PHX-AD-1`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Uocm:PHX-AD-1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_secret</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name. (Also called the &quot;CHAP password&quot;.)</div>
+                                                    <div>Example: `d6866c0d-298b-48ba-95af-309b4faux45e`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">d6866c0d-298b-48ba-95af-309b4faux45e</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>chap_username</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The volume&#x27;s system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.</div>
+                                                    <div>Example: `ocid1.volume.oc1.phx.abyhqljrgvttnlx73nmrwfaux7kcvzfs3s66izvxf2h4lgvyndsdsnoiwr5q`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1.phx.abyhqljrgvttnlx73nmrwfaux7kcvzfs3s66izvxf2h4lgvyndsdsnoiwr5q</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>compartment_id</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The OCID of the compartment.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>device</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The device name.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">/dev/oracleoci/oraclevdb</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>display_name</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>A user-friendly name. Does not have to be unique, and it cannot be changed. Avoid entering confidential information.</div>
+                                                    <div>Example: `My volume attachment`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My volume attachment</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>id</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The OCID of the volume attachment.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>instance_id</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The OCID of the instance the volume is attached to.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.instance.oc1..xxxxxxEXAMPLExxxxxx</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>ipv4</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The volume&#x27;s iSCSI IP address.</div>
+                                                    <div>Example: `169.254.0.2`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">169.254.0.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>iqn</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The target volume&#x27;s iSCSI Qualified Name in the format defined by RFC 3720.</div>
+                                                    <div>Example: `iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_pv_encryption_in_transit_enabled</b>
+                    <div style="font-size: small; color: purple">boolean</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Whether in-transit encryption for the data volume&#x27;s paravirtualized attachment is enabled or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_read_only</b>
+                    <div style="font-size: small; color: purple">boolean</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Whether the attachment was created in read-only mode.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>is_shareable</b>
+                    <div style="font-size: small; color: purple">boolean</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>Whether the attachment should be created in shareable mode. If an attachment is created in shareable mode, then other instances can attach the same volume, provided that they also create their attachments in shareable mode. Only certain volume types can be attached in shareable mode. Defaults to false if not specified.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>lifecycle_state</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The current state of the volume attachment.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ATTACHING</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>port</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The volume&#x27;s iSCSI port.</div>
+                                                    <div>Example: `3260`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3260</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>time_created</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The date and time the volume was created, in the format defined by RFC3339.</div>
+                                                    <div>Example: `2016-08-25T21:10:29.600Z`</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-08-25 21:10:29.600000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>volume_id</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The OCID of the volume.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volume.oc1..xxxxxxEXAMPLExxxxxx</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
     <br/><br/>
 
 

--- a/docs/modules/oci_volume_backup_policy_facts_module.rst
+++ b/docs/modules/oci_volume_backup_policy_facts_module.rst
@@ -5,8 +5,8 @@
 .. _oci_volume_backup_policy_facts_module:
 
 
-oci_volume_backup_policy_facts -- Retrieve information of volume backup policies in OCI Block Volume service
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+oci_volume_backup_policy_facts -- Fetches details about one or multiple VolumeBackupPolicy resources in Oracle Cloud Infrastructure
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. versionadded:: 2.5
 
@@ -17,7 +17,9 @@ oci_volume_backup_policy_facts -- Retrieve information of volume backup policies
 
 Synopsis
 --------
-- This module retrieves information of the specified volume backup policy or all volume backup policies available to the caller.
+- Fetches details about one or multiple VolumeBackupPolicy resources in Oracle Cloud Infrastructure
+- Lists all volume backup policies available to the caller.
+- If *policy_id* is specified, the details of a single VolumeBackupPolicy will be returned.
 
 
 
@@ -159,6 +161,7 @@ Parameters
                                                                                                                                                             </td>
                                                                 <td>
                                                                         <div>The OCID of the volume backup policy.</div>
+                                                    <div>Required to get a specific volume_backup_policy.</div>
                                                                                         <div style="font-size: small; color: darkgreen"><br/>aliases: id</div>
                                     </td>
             </tr>
@@ -206,12 +209,13 @@ Examples
 .. code-block:: yaml+jinja
 
     
-    - name: Get information of a volume backup policy
+    - name: List volume_backup_policies
       oci_volume_backup_policy_facts:
-        id: ocid1.volumebackuppolicy.oc1..xxxxxEXAMPLExxxxx
 
-    - name: Get information of all available volume backup policies
-      oci_volume_backup_policy_assignment_facts:
+    - name: Get a specific volume_backup_policy
+      oci_volume_backup_policy_facts:
+        policy_id: ocid1.policy.oc1..xxxxxxEXAMPLExxxxxx
+
 
 
 
@@ -224,77 +228,136 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
     <table border=0 cellpadding=0 class="documentation-table">
         <tr>
-            <th colspan="2">Key</th>
+            <th colspan="3">Key</th>
             <th>Returned</th>
             <th width="100%">Description</th>
         </tr>
                     <tr>
-                                <td colspan="2">
-                    <b>volume_backup_polices</b>
+                                <td colspan="3">
+                    <b>volume_backup_policies</b>
                     <div style="font-size: small; color: purple">complex</div>
                                     </td>
                 <td>on success</td>
                 <td>
-                                            <div>List of volume backup policies</div>
-                                        <br/>
+                                                                        <div>List of VolumeBackupPolicy resources</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;display_name&#x27;: &#x27;silver&#x27;, &#x27;id&#x27;: &#x27;ocid1.volumebackuppolicy.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;time_created&#x27;: &#x27;2017-10-01T00:00:00+00:00&#x27;, &#x27;schedules&#x27;: [{&#x27;backup_type&#x27;: &#x27;INCREMENTAL&#x27;, &#x27;period&#x27;: &#x27;ONE_WEEK&#x27;, &#x27;retention_seconds&#x27;: 2419200, &#x27;offset_seconds&#x27;: 0}, {&#x27;backup_type&#x27;: &#x27;INCREMENTAL&#x27;, &#x27;period&#x27;: &#x27;ONE_MONTH&#x27;, &#x27;retention_seconds&#x27;: 31560000, &#x27;offset_seconds&#x27;: 0}, {&#x27;backup_type&#x27;: &#x27;FULL&#x27;, &#x27;period&#x27;: &#x27;ONE_YEAR&#x27;, &#x27;retention_seconds&#x27;: 157680000, &#x27;offset_seconds&#x27;: 0}]}]</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;display_name&#x27;: &#x27;display_name_example&#x27;, &#x27;id&#x27;: &#x27;ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx&#x27;, &#x27;time_created&#x27;: &#x27;2013-10-20T19:20:30+01:00&#x27;, &#x27;schedules&#x27;: [{&#x27;backup_type&#x27;: &#x27;FULL&#x27;, &#x27;period&#x27;: &#x27;ONE_HOUR&#x27;, &#x27;retention_seconds&#x27;: 56, &#x27;offset_seconds&#x27;: 56}]}]</div>
                                     </td>
             </tr>
                                                             <tr>
                                     <td class="elbow-placeholder">&nbsp;</td>
-                                <td colspan="1">
+                                <td colspan="2">
                     <b>display_name</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>A user-friendly name for the volume backup policy. Does not have to be unique and it&#x27;s changeable. Avoid entering confidential information.</div>
-                                        <br/>
+                                                                        <div>A user-friendly name for the volume backup policy. Does not have to be unique and it&#x27;s changeable. Avoid entering confidential information.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">gold</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">display_name_example</div>
                                     </td>
             </tr>
                                 <tr>
                                     <td class="elbow-placeholder">&nbsp;</td>
-                                <td colspan="1">
+                                <td colspan="2">
                     <b>id</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The OCID of the volume backup policy.</div>
-                                        <br/>
+                                                                        <div>The OCID of the volume backup policy.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.volumebackuppolicy.oc1..xxxxxEXAMPLExxxxx</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx</div>
                                     </td>
             </tr>
                                 <tr>
                                     <td class="elbow-placeholder">&nbsp;</td>
-                                <td colspan="1">
+                                <td colspan="2">
                     <b>schedules</b>
-                    <div style="font-size: small; color: purple">list</div>
+                    <div style="font-size: small; color: purple">complex</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The collection of schedules that this policy will apply.</div>
-                                        <br/>
+                                                                        <div>The collection of schedules that this policy will apply.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>backup_type</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The type of backup to create.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;backup-type&#x27;: &#x27;INCREMENTAL&#x27;, &#x27;offset-seconds&#x27;: 0, &#x27;period&#x27;: &#x27;ONE_DAY&#x27;, &#x27;retention-seconds&#x27;: 604800}, {&#x27;backup-type&#x27;: &#x27;INCREMENTAL&#x27;, &#x27;offset-seconds&#x27;: 0, &#x27;period&#x27;: &#x27;ONE_WEEK&#x27;, &#x27;retention-seconds&#x27;: 2419200}, {&#x27;backup-type&#x27;: &#x27;INCREMENTAL&#x27;, &#x27;offset-seconds&#x27;: 0, &#x27;period&#x27;: &#x27;ONE_MONTH&#x27;, &#x27;retention-seconds&#x27;: 31560000}, {&#x27;backup-type&#x27;: &#x27;FULL&#x27;, &#x27;offset-seconds&#x27;: 0, &#x27;period&#x27;: &#x27;ONE_YEAR&#x27;, &#x27;retention-seconds&#x27;: 157680000}]</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">FULL</div>
                                     </td>
             </tr>
                                 <tr>
                                     <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
                                 <td colspan="1">
+                    <b>offset_seconds</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The number of seconds that the backup time should be shifted from the default interval boundaries specified by the period. Backup time = Frequency start time + Offset.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>period</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>How often the backup should occur.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ONE_HOUR</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>retention_seconds</b>
+                    <div style="font-size: small; color: purple">integer</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>How long, in seconds, backups created by this schedule should be kept until being automatically deleted.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">56</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
                     <b>time_created</b>
                     <div style="font-size: small; color: purple">string</div>
                                     </td>
-                <td>always</td>
+                <td>on success</td>
                 <td>
-                                            <div>The date and time the volume backup policy was created. Format defined by RFC3339.</div>
-                                        <br/>
+                                                                        <div>The date and time the volume backup policy was created. Format defined by RFC3339.</div>
+                                                                <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-12-22 15:40:53.219000</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2013-10-20 18:20:30</div>
                                     </td>
             </tr>
                     
@@ -320,7 +383,9 @@ Status
 Authors
 ~~~~~~~
 
-- Rohit Chaware (@rohitChaware)
+- Manoj Meda (@manojmeda)
+- Mike Ross (@mross22)
+- Nabeel Al-Saber (@nalsaber)
 
 
 .. hint::

--- a/docs/modules/oci_waas_policy_module.rst
+++ b/docs/modules/oci_waas_policy_module.rst
@@ -25,7 +25,6 @@ Synopsis
 - You must specify a display name and domain for the WAAS policy. The display name does not have to be unique and can be changed. The domain name should be different from every origin specified in `WaasPolicy`.
 - All Oracle Cloud Infrastructure resources, including WAAS policies, receive a unique, Oracle-assigned ID called an Oracle Cloud Identifier (OCID). When a resource is created, you can find its OCID in the response. You can also retrieve a resource's OCID by using a list API operation for that resource type, or by viewing the resource in the Console. Fore more information, see `Resource Identifiers <https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm>`_.
 - **Note:** After sending the POST request, the new object's state will temporarily be `CREATING`. Ensure that the resource's state has changed to `ACTIVE` before use.
-- This resource has the following action operations in the :ref:`oci_waas_policy_actions <oci_waas_policy_actions_module>` module: accept_recommendations.
 
 
 

--- a/install.py
+++ b/install.py
@@ -38,7 +38,7 @@ import pkg_resources
 
 debug = False
 
-MIN_OCI_PYTHON_SDK_REQUIRED = "2.2.21"
+MIN_OCI_PYTHON_SDK_REQUIRED = "2.5.0"
 
 
 def parse_cli_args():

--- a/inventory-script/oci_inventory.py
+++ b/inventory-script/oci_inventory.py
@@ -182,7 +182,7 @@ When run for a specific host using the --host option, this script returns the fo
       "foo": "bar"
     },
     "region": "iad",
-    "shape": "VM.Standard1.1",
+    "shape": "VM.Standard2.1",
     "source_details": {
       "image_id": "ocid1.image.oc1.iad.xxxxxEXAMPLExxxxx",
       "source_type": "image"
@@ -226,7 +226,7 @@ try:
 except ImportError:
     HAS_OCI_PY_SDK = False
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"
 inventory_agent_name = "Oracle-Ansible-Inv/"
 
 

--- a/library/oci_api_key.py
+++ b/library/oci_api_key.py
@@ -84,7 +84,7 @@ oci_api_key:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -119,17 +119,35 @@ class ApiKeyHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_api_key_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.upload_api_key,
-            user_id=self.module.params.get("user_id"),
-            create_api_key_details=create_api_key_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.upload_api_key,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                user_id=self.module.params.get("user_id"),
+                create_api_key_details=create_api_key_details,
+            ),
+            type=oci_wait_utils.NONE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_api_key,
-            user_id=self.module.params.get("user_id"),
-            fingerprint=self.module.params.get("fingerprint"),
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_api_key,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                user_id=self.module.params.get("user_id"),
+                fingerprint=self.module.params.get("fingerprint"),
+            ),
+            type=oci_wait_utils.NONE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -164,7 +182,10 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_helper = ResourceHelper(
-        module=module, resource_type="api_key", service_client_class=IdentityClient
+        module=module,
+        resource_type="api_key",
+        service_client_class=IdentityClient,
+        namespace="identity",
     )
 
     result = dict(changed=False)

--- a/library/oci_audit_configuration.py
+++ b/library/oci_audit_configuration.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -73,7 +74,7 @@ configuration:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -91,6 +92,9 @@ except ImportError:
 class ConfigurationHelperGen(OCIResourceHelperBase):
     """Supported operations: update and get"""
 
+    def get_get_fn(self):
+        return self.client.get_configuration
+
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
             self.client.get_configuration,
@@ -102,10 +106,19 @@ class ConfigurationHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_configuration,
-            compartment_id=self.module.params.get("compartment_id"),
-            update_configuration_details=update_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_configuration,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                compartment_id=self.module.params.get("compartment_id"),
+                update_configuration_details=update_details,
+            ),
+            waiter_type=oci_wait_utils.WORK_REQUEST_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_work_request_completed_states(),
         )
 
 
@@ -134,7 +147,10 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_helper = ResourceHelper(
-        module=module, resource_type="configuration", service_client_class=AuditClient
+        module=module,
+        resource_type="configuration",
+        service_client_class=AuditClient,
+        namespace="audit",
     )
 
     result = dict(changed=False)

--- a/library/oci_audit_configuration_facts.py
+++ b/library/oci_audit_configuration_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -106,13 +107,16 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_facts_helper = ResourceFactsHelper(
-        module=module, resource_type="configuration", service_client_class=AuditClient
+        module=module,
+        resource_type="configuration",
+        service_client_class=AuditClient,
+        namespace="audit",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_audit_event_facts.py
+++ b/library/oci_audit_event_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -56,9 +57,9 @@ extends_documentation_fragment: [ oracle ]
 EXAMPLES = """
 - name: List audit_events
   oci_audit_event_facts:
-      compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
-      start_time: 2013-10-20T19:20:30+01:00
-      end_time: 2013-10-20T19:20:30+01:00
+    compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
+    start_time: 2013-10-20T19:20:30+01:00
+    end_time: 2013-10-20T19:20:30+01:00
 
 """
 
@@ -290,13 +291,16 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_facts_helper = ResourceFactsHelper(
-        module=module, resource_type="audit_event", service_client_class=AuditClient
+        module=module,
+        resource_type="audit_event",
+        service_client_class=AuditClient,
+        namespace="audit",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_auth_token_facts.py
+++ b/library/oci_auth_token_facts.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
+
 
 from __future__ import absolute_import, division, print_function
 
@@ -18,108 +20,169 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: oci_auth_token_facts
-short_description: Retrieve facts of auth tokens in OCI Identity and Access Management Service
+short_description: Fetches details about one or multiple AuthToken resources in Oracle Cloud Infrastructure
 description:
-    - This module retrieves information of all the auth tokens for a specified user.
+    - Fetches details about one or multiple AuthToken resources in Oracle Cloud Infrastructure
+    - Lists the auth tokens for the specified user. The returned object contains the token's OCID, but not
+      the token itself. The actual token is returned only upon creation.
 version_added: "2.5"
 options:
     user_id:
-        description: The OCID of the user.
+        description:
+            - The OCID of the user.
         required: true
-author: "Sivakumar Thyagarajan (@sivakumart)"
+author:
+    - Manoj Meda (@manojmeda)
+    - Mike Ross (@mross22)
+    - Nabeel Al-Saber (@nalsaber)
 extends_documentation_fragment: [ oracle ]
 """
 
 EXAMPLES = """
-- name: Get information of all the auth tokens for a specific user
+- name: List auth_tokens
   oci_auth_token_facts:
-    user_id: ocid1.user.oc1..xxxxxEXAMPLExxxxx...h5hq
+    user_id: ocid1.user.oc1..xxxxxxEXAMPLExxxxxx
+
 """
 
 RETURN = """
-auth_groups:
-    description: List of auth token information
-    returned: On success
+auth_tokens:
+    description:
+        - List of AuthToken resources
+    returned: on success
     type: complex
     contains:
         token:
-            description: The Auth token. The value is available only in the response for CreateAuthToken, and not for
-                         ListAuthTokens or UpdateAuthToken. So the value returned by this fact module would always be
-                         null.
-            returned: always
+            description:
+                - The auth token. The value is available only in the response for `CreateAuthToken`, and not
+                  for `ListAuthTokens` or `UpdateAuthToken`.
+            returned: on success
             type: string
+            sample: token_example
         id:
-            description: The OCID of the auth token.
-            returned: always
+            description:
+                - The OCID of the auth token.
+            returned: on success
             type: string
-            sample: ocid1.credential.oc1..xxxxxEXAMPLExxxxx...l5aq
+            sample: ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx
         user_id:
-            description: The OCID of the user the auth token belongs to.
-            returned: always
+            description:
+                - The OCID of the user the auth token belongs to.
+            returned: on success
             type: string
-            sample: ocid1.user.oc1..xxxxxEXAMPLExxxxx...h5hq
+            sample: ocid1.user.oc1..xxxxxxEXAMPLExxxxxx
         description:
-            description: The description you assign to the auth token. Does not have to be unique, and it's changeable.
-            returned: always
+            description:
+                - The description you assign to the auth token. Does not have to be unique, and it's changeable.
+            returned: on success
             type: string
-            sample: "My test auth token"
+            sample: description_example
         time_created:
-            description: Date and time the AuthToken object was created, in the format defined by RFC3339.
-            returned: always
+            description:
+                - Date and time the `AuthToken` object was created, in the format defined by RFC3339.
+                - "Example: `2016-08-25T21:10:29.600Z`"
+            returned: on success
             type: string
-            sample: "2018-11-08T02:40:25.118000+00:00"
+            sample: 2016-08-25T21:10:29.600Z
         time_expires:
-            description: Date and time when this auth token will expire, in the format defined by RFC3339. Null if it
-                         never expires.
-            returned: always
+            description:
+                - Date and time when this auth token will expire, in the format defined by RFC3339.
+                  Null if it never expires.
+                - "Example: `2016-08-25T21:10:29.600Z`"
+            returned: on success
             type: string
-            sample: null
+            sample: 2016-08-25T21:10:29.600Z
+        lifecycle_state:
+            description:
+                - The token's current state. After creating an auth token, make sure its `lifecycleState` changes from
+                  CREATING to ACTIVE before using it.
+            returned: on success
+            type: string
+            sample: CREATING
+        inactive_status:
+            description:
+                - The detailed status of INACTIVE lifecycleState.
+            returned: on success
+            type: int
+            sample: 56
     sample: [{
-            "description": "test auth token 1",
-            "id": "ocid1.credential.oc1..xxxxxEXAMPLExxxxx...l5aq",
-            "inactive-status": null,
-            "lifecycle-state": "ACTIVE",
-            "time-created": "2018-11-08T02:40:25.118000+00:00",
-            "time-expires": null,
-            "token": null,
-            "user-id": "ocid1.user.oc1..xxxxxEXAMPLExxxxx...h5hq"
-        }]
+        "token": "token_example",
+        "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
+        "user_id": "ocid1.user.oc1..xxxxxxEXAMPLExxxxxx",
+        "description": "description_example",
+        "time_created": "2016-08-25T21:10:29.600Z",
+        "time_expires": "2016-08-25T21:10:29.600Z",
+        "lifecycle_state": "CREATING",
+        "inactive_status": 56
+    }]
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_utils
+from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle.oci_resource_utils import (
+    OCIResourceFactsHelperBase,
+    get_custom_class,
+)
 
 try:
-    from oci.identity.identity_client import IdentityClient
-    from oci.util import to_dict
-    from oci.exceptions import ServiceError
+    from oci.identity import IdentityClient
 
     HAS_OCI_PY_SDK = True
-
 except ImportError:
     HAS_OCI_PY_SDK = False
 
 
-def main():
-    module_args = oci_utils.get_common_arg_spec()
-    module_args.update(dict(user_id=dict(type="str", required=False)))
+class AuthTokenFactsHelperGen(OCIResourceFactsHelperBase):
+    """Supported operations: list"""
 
-    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+    def get_required_params_for_list(self):
+        return ["user_id"]
+
+    def list_resources(self):
+        optional_list_method_params = []
+        optional_kwargs = dict(
+            (param, self.module.params[param])
+            for param in optional_list_method_params
+            if self.module.params.get(param) is not None
+        )
+        return oci_common_utils.list_all_resources(
+            self.client.list_auth_tokens,
+            user_id=self.module.params.get("user_id"),
+            **optional_kwargs
+        )
+
+
+AuthTokenFactsHelperCustom = get_custom_class("AuthTokenFactsHelperCustom")
+
+
+class ResourceFactsHelper(AuthTokenFactsHelperCustom, AuthTokenFactsHelperGen):
+    pass
+
+
+def main():
+    module_args = oci_common_utils.get_common_arg_spec()
+    module_args.update(dict(user_id=dict(type="str", required=True)))
+
+    module = AnsibleModule(argument_spec=module_args)
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg="oci python sdk required for this module.")
 
-    identity_client = oci_utils.create_service_client(module, IdentityClient)
+    resource_facts_helper = ResourceFactsHelper(
+        module=module,
+        resource_type="auth_token",
+        service_client_class=IdentityClient,
+        namespace="identity",
+    )
 
-    try:
-        result = to_dict(
-            oci_utils.list_all_resources(
-                identity_client.list_auth_tokens, user_id=module.params["user_id"]
-            )
-        )
+    result = []
 
-    except ServiceError as ex:
-        module.fail_json(msg=ex.message)
+    if resource_facts_helper.is_get():
+        result = [resource_facts_helper.get()]
+    elif resource_facts_helper.is_list():
+        result = resource_facts_helper.list()
+    else:
+        resource_facts_helper.fail()
 
     module.exit_json(auth_tokens=result)
 

--- a/library/oci_autonomous_database.py
+++ b/library/oci_autonomous_database.py
@@ -75,6 +75,11 @@ options:
         description: The destination file path with file name when downloading wallet. The file must have 'zip' extension.
                      I(wallet_file) is required if I(state='generate_wallet').
         required: false
+    is_free_tier:
+        description: Indicates if this is an Always Free resource. The default value is false. Note that Always Free
+                     Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU
+                     cannot be scaled.
+        required: false
     force:
         description: Force overwriting existing wallet file when downloading wallet.
         required: false
@@ -230,6 +235,13 @@ RETURN = """
                 returned: always
                 type: string
                 sample: AVAILABLE
+            is_free_tier:
+                description: Indicates if this is an Always Free resource. The default value is false. Note that Always Free
+                             Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU
+                             cannot be scaled.
+                returned: always
+                type: bool
+                sample: false
 
         sample: {
                   "compartment_id":"ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
@@ -257,7 +269,8 @@ RETURN = """
                   "service_console_url":"https://example1.oraclecloud.com/console/index.html?
                         tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx
                         &database_name=ANSIBLEAUTODB&service_type=ATP",
-                  "time_created":"2018-09-22T15:06:55.426000+00:00"
+                  "time_created":"2018-09-22T15:06:55.426000+00:00",
+                  "is_free_tier": false
               }
 """
 
@@ -522,6 +535,7 @@ def main():
             ),
             timestamp=dict(type="str", required=False),
             wallet_file=dict(type="str", required=False),
+            is_free_tier=dict(type="bool", required=False),
             force=dict(
                 type="bool", required=False, default=True, aliases=["overwrite"]
             ),

--- a/library/oci_autonomous_database_facts.py
+++ b/library/oci_autonomous_database_facts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -30,6 +30,11 @@ options:
         description: Identifier of the Autonomous Database whose details needs to be fetched.
         required: false
         aliases: ['id']
+    is_free_tier:
+        description: Filter on the value of the resource's 'is_free_tier' property. A value of true returns only
+                     Always Free resources. A value of false excludes Always Free resources from the returned
+                     results. Omitting this parameter returns both Always Free and paid resources.
+        required: false
 author:
     - "Debayan Gupta(@debayan_gupta)"
 extends_documentation_fragment: [ oracle, oracle_display_name_option ]
@@ -127,6 +132,13 @@ RETURN = """
                 returned: always
                 type: string
                 sample: AVAILABLE
+            is_free_tier:
+                description: Indicates if this is an Always Free resource. The default value is false. Note that Always Free
+                             Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU
+                             cannot be scaled.
+                returned: always
+                type: bool
+                sample: false
 
         sample: [{
                   "compartment_id":"ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
@@ -154,7 +166,8 @@ RETURN = """
                   "service_console_url":"https://example1.oraclecloud.com/console/index.html?
                         tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx
                         &database_name=ANSIBLEAUTODB&service_type=ATP",
-                  "time_created":"2018-09-22T15:06:55.426000+00:00"
+                  "time_created":"2018-09-22T15:06:55.426000+00:00",
+                  "is_free_tier": false
               },
               {
                   "compartment_id":"ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
@@ -182,7 +195,8 @@ RETURN = """
                   "service_console_url":"https://example1.oraclecloud.com/console/index.html?
                         tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx
                         &database_name=ANSIBLEAUTODB&service_type=ATP",
-                  "time_created":"2018-09-22T15:06:55.426000+00:00"
+                  "time_created":"2018-09-22T15:06:55.426000+00:00",
+                  "is_free_tier": false
               }]
 """
 
@@ -214,6 +228,7 @@ def list_autonomous_databases(db_client, module):
                 db_client.list_autonomous_databases,
                 compartment_id=compartment_id,
                 display_name=module.params.get("display_name"),
+                is_free_tier=module.params.get("is_free_tier"),
             )
         elif autonomous_database_id:
             get_logger().debug("Listing Autonomous Database %s", autonomous_database_id)
@@ -246,6 +261,7 @@ def main():
         dict(
             compartment_id=dict(type="str", required=False),
             autonomous_database_id=dict(type="str", required=False, aliases=["id"]),
+            is_free_tier=dict(type="bool", required=False),
         )
     )
     module = AnsibleModule(

--- a/library/oci_autonomous_exadata_infrastructure.py
+++ b/library/oci_autonomous_exadata_infrastructure.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -130,23 +131,23 @@ extends_documentation_fragment: [ oracle, oracle_creatable_resource, oracle_wait
 EXAMPLES = """
 - name: Create autonomous_exadata_infrastructure
   oci_autonomous_exadata_infrastructure:
-      compartment_id: ocid1.tenancy.oc1.<var>&lt;unique_ID&gt;</var>
-      display_name: tst3dbsys
-      availability_domain: Uocm:PHX-AD-1
-      subnet_id: ocid1.subnet.oc1.<var>&lt;unique_ID&gt;</var>
-      shape: Exadata.Half1.168
-      hostname: athena
-      domain: my.company.com
+    availability_domain: Uocm:PHX-AD-1
+    compartment_id: ocid1.tenancy.oc1.unique_ID
+    display_name: tst3dbsys
+    domain: my.company.com
+    hostname: athena
+    shape: Exadata.Half1.168
+    subnet_id: ocid1.subnet.oc1.unique_ID
 
 - name: Update autonomous_exadata_infrastructure
   oci_autonomous_exadata_infrastructure:
-      display_name: new displayname
-      autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
+    display_name: new displayname
+    autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
 
 - name: Delete autonomous_exadata_infrastructure
   oci_autonomous_exadata_infrastructure:
-      autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
-      state: absent
+    autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
+    state: absent
 
 """
 
@@ -429,7 +430,7 @@ autonomous_exadata_infrastructure:
                 - "Example: `{\\"Department\\": \\"Finance\\"}`"
             returned: on success
             type: dict
-            sample: {Department: Finance}
+            sample: {'Department': 'Finance'}
         defined_tags:
             description:
                 - Defined tags for this resource. Each key is predefined and scoped to a namespace.
@@ -437,7 +438,7 @@ autonomous_exadata_infrastructure:
                 - "Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
             returned: on success
             type: dict
-            sample: {Operations: {CostCenter: US}}
+            sample: {'Operations': {'CostCenter': 'US'}}
     sample: {
         "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
         "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
@@ -485,13 +486,13 @@ autonomous_exadata_infrastructure:
             "maintenance_type": "PLANNED",
             "maintenance_subtype": "QUARTERLY"
         },
-        "freeform_tags": {Department: Finance},
-        "defined_tags": {Operations: {CostCenter: US}}
+        "freeform_tags": {'Department': 'Finance'},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}}
     }
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -517,6 +518,9 @@ class AutonomousExadataInfrastructureHelperGen(OCIResourceHelperBase):
     def get_module_resource_id(self):
         return self.module.params.get("autonomous_exadata_infrastructure_id")
 
+    def get_get_fn(self):
+        return self.client.get_autonomous_exadata_infrastructure
+
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
             self.client.get_autonomous_exadata_infrastructure,
@@ -526,17 +530,25 @@ class AutonomousExadataInfrastructureHelperGen(OCIResourceHelperBase):
         )
 
     def list_resources(self):
-        list_method_params = ["compartment_id"]
+        required_list_method_params = ["compartment_id"]
 
-        kwargs = dict(
+        optional_list_method_params = ["availability_domain", "display_name"]
+
+        required_kwargs = dict(
+            (param, self.module.params[param]) for param in required_list_method_params
+        )
+
+        optional_kwargs = dict(
             (param, self.module.params[param])
-            for param in list_method_params
+            for param in optional_list_method_params
             if self.module.params.get(param) is not None
             and (
                 not self.module.params.get("key_by")
                 or param in self.module.params.get("key_by")
             )
         )
+
+        kwargs = oci_common_utils.merge_dicts(required_kwargs, optional_kwargs)
 
         return oci_common_utils.list_all_resources(
             self.client.list_autonomous_exadata_infrastructures, **kwargs
@@ -547,9 +559,18 @@ class AutonomousExadataInfrastructureHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.launch_autonomous_exadata_infrastructure,
-            launch_autonomous_exadata_infrastructure_details=create_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.launch_autonomous_exadata_infrastructure,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                launch_autonomous_exadata_infrastructure_details=create_details
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def get_update_model_class(self):
@@ -557,20 +578,38 @@ class AutonomousExadataInfrastructureHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_autonomous_exadata_infrastructure,
-            autonomous_exadata_infrastructure_id=self.module.params.get(
-                "autonomous_exadata_infrastructure_id"
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_autonomous_exadata_infrastructure,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                autonomous_exadata_infrastructure_id=self.module.params.get(
+                    "autonomous_exadata_infrastructure_id"
+                ),
+                update_autonomous_exadata_infrastructures_details=update_details,
             ),
-            update_autonomous_exadata_infrastructures_details=update_details,
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.terminate_autonomous_exadata_infrastructure,
-            autonomous_exadata_infrastructure_id=self.module.params.get(
-                "autonomous_exadata_infrastructure_id"
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.terminate_autonomous_exadata_infrastructure,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                autonomous_exadata_infrastructure_id=self.module.params.get(
+                    "autonomous_exadata_infrastructure_id"
+                )
             ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -638,6 +677,7 @@ def main():
         module=module,
         resource_type="autonomous_exadata_infrastructure",
         service_client_class=DatabaseClient,
+        namespace="database",
     )
 
     result = dict(changed=False)

--- a/library/oci_autonomous_exadata_infrastructure_facts.py
+++ b/library/oci_autonomous_exadata_infrastructure_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -76,11 +77,11 @@ extends_documentation_fragment: [ oracle ]
 EXAMPLES = """
 - name: List autonomous_exadata_infrastructures
   oci_autonomous_exadata_infrastructure_facts:
-      compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
+    compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
 
 - name: Get a specific autonomous_exadata_infrastructure
   oci_autonomous_exadata_infrastructure_facts:
-      autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
+    autonomous_exadata_infrastructure_id: ocid1.autonomousexadatainfrastructure.oc1..xxxxxxEXAMPLExxxxxx
 
 """
 
@@ -363,7 +364,7 @@ autonomous_exadata_infrastructures:
                 - "Example: `{\\"Department\\": \\"Finance\\"}`"
             returned: on success
             type: dict
-            sample: {Department: Finance}
+            sample: {'Department': 'Finance'}
         defined_tags:
             description:
                 - Defined tags for this resource. Each key is predefined and scoped to a namespace.
@@ -371,7 +372,7 @@ autonomous_exadata_infrastructures:
                 - "Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
             returned: on success
             type: dict
-            sample: {Operations: {CostCenter: US}}
+            sample: {'Operations': {'CostCenter': 'US'}}
     sample: [{
         "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
         "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
@@ -419,8 +420,8 @@ autonomous_exadata_infrastructures:
             "maintenance_type": "PLANNED",
             "maintenance_subtype": "QUARTERLY"
         },
-        "freeform_tags": {Department: Finance},
-        "defined_tags": {Operations: {CostCenter: US}}
+        "freeform_tags": {'Department': 'Finance'},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}}
     }]
 """
 
@@ -521,12 +522,13 @@ def main():
         module=module,
         resource_type="autonomous_exadata_infrastructure",
         service_client_class=DatabaseClient,
+        namespace="database",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_autonomous_exadata_infrastructure_shape_facts.py
+++ b/library/oci_autonomous_exadata_infrastructure_shape_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -38,14 +39,14 @@ author:
     - Manoj Meda (@manojmeda)
     - Mike Ross (@mross22)
     - Nabeel Al-Saber (@nalsaber)
-extends_documentation_fragment: [ oracle ]
+extends_documentation_fragment: [ oracle, oracle_name_option ]
 """
 
 EXAMPLES = """
 - name: List autonomous_exadata_infrastructure_shapes
   oci_autonomous_exadata_infrastructure_shape_facts:
-      availability_domain: Uocm:PHX-AD-1
-      compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
+    availability_domain: Uocm:PHX-AD-1
+    compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
 
 """
 
@@ -124,7 +125,7 @@ class AutonomousExadataInfrastructureShapeFactsHelperGen(OCIResourceFactsHelperB
         return ["availability_domain", "compartment_id"]
 
     def list_resources(self):
-        optional_list_method_params = []
+        optional_list_method_params = ["name"]
         optional_kwargs = dict(
             (param, self.module.params[param])
             for param in optional_list_method_params
@@ -156,6 +157,7 @@ def main():
         dict(
             availability_domain=dict(type="str", required=True),
             compartment_id=dict(type="str", required=True),
+            name=dict(type="str"),
         )
     )
 
@@ -168,12 +170,13 @@ def main():
         module=module,
         resource_type="autonomous_exadata_infrastructure_shape",
         service_client_class=DatabaseClient,
+        namespace="database",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_autoscaling_auto_scaling_configuration.py
+++ b/library/oci_autoscaling_auto_scaling_configuration.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -196,7 +197,7 @@ extends_documentation_fragment: [ oracle, oracle_creatable_resource ]
 EXAMPLES = """
 - name: Create auto_scaling_configuration
   oci_autoscaling_auto_scaling_configuration:
-    compartment_id: ocid1.compartment.oc1..<var>&lt;unique_ID&gt;</var>
+    compartment_id: ocid1.compartment.oc1..unique_ID
     display_name: example_autoscaling_configuration
     cool_down_in_seconds: 300
     is_enabled: true
@@ -228,7 +229,7 @@ EXAMPLES = """
             value: 25
     resource:
       type: instancePool
-      id: ocid1.instancepool.oc1..<var>&lt;unique_ID&gt;</var>
+      id: ocid1.instancepool.oc1..unique_ID
 
 - name: Update auto_scaling_configuration
   oci_autoscaling_auto_scaling_configuration:
@@ -496,7 +497,7 @@ auto_scaling_configuration:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -521,6 +522,9 @@ class AutoScalingConfigurationHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("auto_scaling_configuration_id")
+
+    def get_get_fn(self):
+        return self.client.get_auto_scaling_configuration
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -560,9 +564,18 @@ class AutoScalingConfigurationHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.create_auto_scaling_configuration,
-            create_auto_scaling_configuration_details=create_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_auto_scaling_configuration,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                create_auto_scaling_configuration_details=create_details
+            ),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def get_update_model_class(self):
@@ -570,20 +583,38 @@ class AutoScalingConfigurationHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_auto_scaling_configuration,
-            auto_scaling_configuration_id=self.module.params.get(
-                "auto_scaling_configuration_id"
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_auto_scaling_configuration,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                auto_scaling_configuration_id=self.module.params.get(
+                    "auto_scaling_configuration_id"
+                ),
+                update_auto_scaling_configuration_details=update_details,
             ),
-            update_auto_scaling_configuration_details=update_details,
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_auto_scaling_configuration,
-            auto_scaling_configuration_id=self.module.params.get(
-                "auto_scaling_configuration_id"
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_auto_scaling_configuration,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                auto_scaling_configuration_id=self.module.params.get(
+                    "auto_scaling_configuration_id"
+                )
             ),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -694,6 +725,7 @@ def main():
         module=module,
         resource_type="auto_scaling_configuration",
         service_client_class=AutoScalingClient,
+        namespace="autoscaling",
     )
 
     result = dict(changed=False)

--- a/library/oci_autoscaling_auto_scaling_configuration_facts.py
+++ b/library/oci_autoscaling_auto_scaling_configuration_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -403,12 +404,13 @@ def main():
         module=module,
         resource_type="auto_scaling_configuration",
         service_client_class=AutoScalingClient,
+        namespace="autoscaling",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_autoscaling_auto_scaling_configuration_policy.py
+++ b/library/oci_autoscaling_auto_scaling_configuration_policy.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -328,7 +329,7 @@ auto_scaling_configuration_policy:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -352,6 +353,9 @@ class AutoScalingConfigurationPolicyHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("auto_scaling_policy_id")
+
+    def get_get_fn(self):
+        return self.client.get_auto_scaling_policy
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -392,13 +396,22 @@ class AutoScalingConfigurationPolicyHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_auto_scaling_policy,
-            auto_scaling_configuration_id=self.module.params.get(
-                "auto_scaling_configuration_id"
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_auto_scaling_policy,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                auto_scaling_configuration_id=self.module.params.get(
+                    "auto_scaling_configuration_id"
+                ),
+                auto_scaling_policy_id=self.module.params.get("auto_scaling_policy_id"),
+                update_auto_scaling_policy_details=update_details,
             ),
-            auto_scaling_policy_id=self.module.params.get("auto_scaling_policy_id"),
-            update_auto_scaling_policy_details=update_details,
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
 
@@ -484,6 +497,7 @@ def main():
         module=module,
         resource_type="auto_scaling_configuration_policy",
         service_client_class=AutoScalingClient,
+        namespace="autoscaling",
     )
 
     result = dict(changed=False)

--- a/library/oci_autoscaling_auto_scaling_configuration_policy_facts.py
+++ b/library/oci_autoscaling_auto_scaling_configuration_policy_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -309,12 +310,13 @@ def main():
         module=module,
         resource_type="auto_scaling_configuration_policy",
         service_client_class=AutoScalingClient,
+        namespace="autoscaling",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_budget.py
+++ b/library/oci_budget.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -239,7 +240,7 @@ budget:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -264,6 +265,9 @@ class BudgetHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("budget_id")
+
+    def get_get_fn(self):
+        return self.client.get_budget
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -298,8 +302,16 @@ class BudgetHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.create_budget, create_budget_details=create_details
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_budget,
+            call_fn_args=(),
+            call_fn_kwargs=dict(create_budget_details=create_details),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def get_update_model_class(self):
@@ -307,15 +319,32 @@ class BudgetHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_budget,
-            budget_id=self.module.params.get("budget_id"),
-            update_budget_details=update_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_budget,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                budget_id=self.module.params.get("budget_id"),
+                update_budget_details=update_details,
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_budget, budget_id=self.module.params.get("budget_id")
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_budget,
+            call_fn_args=(),
+            call_fn_kwargs=dict(budget_id=self.module.params.get("budget_id")),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -351,7 +380,10 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_helper = ResourceHelper(
-        module=module, resource_type="budget", service_client_class=BudgetClient
+        module=module,
+        resource_type="budget",
+        service_client_class=BudgetClient,
+        namespace="budget",
     )
 
     result = dict(changed=False)

--- a/library/oci_budget_alert_rule.py
+++ b/library/oci_budget_alert_rule.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -243,7 +244,7 @@ budget_alert_rule:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -268,6 +269,9 @@ class BudgetAlertRuleHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("alert_rule_id")
+
+    def get_get_fn(self):
+        return self.client.get_alert_rule
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -306,10 +310,19 @@ class BudgetAlertRuleHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.create_alert_rule,
-            budget_id=self.module.params.get("budget_id"),
-            create_alert_rule_details=create_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_alert_rule,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                budget_id=self.module.params.get("budget_id"),
+                create_alert_rule_details=create_details,
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def get_update_model_class(self):
@@ -317,18 +330,36 @@ class BudgetAlertRuleHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_alert_rule,
-            budget_id=self.module.params.get("budget_id"),
-            alert_rule_id=self.module.params.get("alert_rule_id"),
-            update_alert_rule_details=update_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_alert_rule,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                budget_id=self.module.params.get("budget_id"),
+                alert_rule_id=self.module.params.get("alert_rule_id"),
+                update_alert_rule_details=update_details,
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_alert_rule,
-            budget_id=self.module.params.get("budget_id"),
-            alert_rule_id=self.module.params.get("alert_rule_id"),
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_alert_rule,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                budget_id=self.module.params.get("budget_id"),
+                alert_rule_id=self.module.params.get("alert_rule_id"),
+            ),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -369,6 +400,7 @@ def main():
         module=module,
         resource_type="budget_alert_rule",
         service_client_class=BudgetClient,
+        namespace="budget",
     )
 
     result = dict(changed=False)

--- a/library/oci_budget_alert_rule_facts.py
+++ b/library/oci_budget_alert_rule_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -276,12 +277,13 @@ def main():
         module=module,
         resource_type="budget_alert_rule",
         service_client_class=BudgetClient,
+        namespace="budget",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_budget_facts.py
+++ b/library/oci_budget_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -280,13 +281,16 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_facts_helper = ResourceFactsHelper(
-        module=module, resource_type="budget", service_client_class=BudgetClient
+        module=module,
+        resource_type="budget",
+        service_client_class=BudgetClient,
+        namespace="budget",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_cpe.py
+++ b/library/oci_cpe.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -42,8 +43,8 @@ options:
             - Required for create using I(state=present).
     defined_tags:
         description:
-            - Defined tags for this resource. Each key is predefined and scoped to a namespace.
-              For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+            - Defined tags for this resource. Each key is predefined and scoped to a
+              namespace. For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
             - "Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
         type: dict
     display_name:
@@ -53,8 +54,8 @@ options:
     freeform_tags:
         description:
             - Free-form tags for this resource. Each tag is a simple key-value pair with no
-              predefined name, type, or namespace. For more information, see
-              L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+              predefined name, type, or namespace. For more information, see L(Resource
+              Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
             - "Example: `{\\"Department\\": \\"Finance\\"}`"
         type: dict
     ip_address:
@@ -91,7 +92,7 @@ EXAMPLES = """
 
 - name: Update cpe
   oci_cpe:
-    defined_tags: {Operations: {CostCenter: US}}
+    defined_tags: {'Operations': {'CostCenter': 'US'}}
     display_name: MyCpe
     cpe_id: ocid1.cpe.oc1..xxxxxxEXAMPLExxxxxx
 
@@ -117,12 +118,12 @@ cpe:
             sample: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
         defined_tags:
             description:
-                - Defined tags for this resource. Each key is predefined and scoped to a namespace.
-                  For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                - Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
                 - "Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
             returned: on success
             type: dict
-            sample: {Operations: {CostCenter: US}}
+            sample: {'Operations': {'CostCenter': 'US'}}
         display_name:
             description:
                 - A user-friendly name. Does not have to be unique, and it's changeable.
@@ -133,12 +134,12 @@ cpe:
         freeform_tags:
             description:
                 - Free-form tags for this resource. Each tag is a simple key-value pair with no
-                  predefined name, type, or namespace. For more information, see
-                  L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                  predefined name, type, or namespace. For more information, see L(Resource
+                  Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
                 - "Example: `{\\"Department\\": \\"Finance\\"}`"
             returned: on success
             type: dict
-            sample: {Department: Finance}
+            sample: {'Department': 'Finance'}
         id:
             description:
                 - The CPE's Oracle ID (OCID).
@@ -160,9 +161,9 @@ cpe:
             sample: 2016-08-25T21:10:29.600Z
     sample: {
         "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
-        "defined_tags": {Operations: {CostCenter: US}},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}},
         "display_name": "display_name_example",
-        "freeform_tags": {Department: Finance},
+        "freeform_tags": {'Department': 'Finance'},
         "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
         "ip_address": "ip_address_example",
         "time_created": "2016-08-25T21:10:29.600Z"
@@ -170,7 +171,7 @@ cpe:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -195,6 +196,9 @@ class CpeHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("cpe_id")
+
+    def get_get_fn(self):
+        return self.client.get_cpe
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -229,8 +233,16 @@ class CpeHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.create_cpe, create_cpe_details=create_details
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_cpe,
+            call_fn_args=(),
+            call_fn_kwargs=dict(create_cpe_details=create_details),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def get_update_model_class(self):
@@ -238,15 +250,32 @@ class CpeHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_cpe,
-            cpe_id=self.module.params.get("cpe_id"),
-            update_cpe_details=update_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_cpe,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                cpe_id=self.module.params.get("cpe_id"),
+                update_cpe_details=update_details,
+            ),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_cpe, cpe_id=self.module.params.get("cpe_id")
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_cpe,
+            call_fn_args=(),
+            call_fn_kwargs=dict(cpe_id=self.module.params.get("cpe_id")),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -279,7 +308,10 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_helper = ResourceHelper(
-        module=module, resource_type="cpe", service_client_class=VirtualNetworkClient
+        module=module,
+        resource_type="cpe",
+        service_client_class=VirtualNetworkClient,
+        namespace="core",
     )
 
     result = dict(changed=False)

--- a/library/oci_db_system.py
+++ b/library/oci_db_system.py
@@ -699,7 +699,10 @@ def update_db_system(db_client, module, db_system_id):
     )
     ssh_public_keys_changed = False
     if input_ssh_public_keys is not None:
-        ssh_public_keys, ssh_public_keys_changed = oci_utils.get_component_list_difference(
+        (
+            ssh_public_keys,
+            ssh_public_keys_changed,
+        ) = oci_utils.get_component_list_difference(
             input_ssh_public_keys,
             existing_ssh_public_keys,
             purge_ssh_public_keys,

--- a/library/oci_drg.py
+++ b/library/oci_drg.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -40,8 +41,8 @@ options:
             - Required for create using I(state=present).
     defined_tags:
         description:
-            - Defined tags for this resource. Each key is predefined and scoped to a namespace.
-              For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+            - Defined tags for this resource. Each key is predefined and scoped to a
+              namespace. For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
             - "Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
         type: dict
     display_name:
@@ -51,8 +52,8 @@ options:
     freeform_tags:
         description:
             - Free-form tags for this resource. Each tag is a simple key-value pair with no
-              predefined name, type, or namespace. For more information, see
-              L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+              predefined name, type, or namespace. For more information, see L(Resource
+              Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
             - "Example: `{\\"Department\\": \\"Finance\\"}`"
         type: dict
     drg_id:
@@ -83,7 +84,7 @@ EXAMPLES = """
 
 - name: Update drg
   oci_drg:
-    defined_tags: {Operations: {CostCenter: US}}
+    defined_tags: {'Operations': {'CostCenter': 'US'}}
     display_name: MyDrg
     drg_id: ocid1.drg.oc1..xxxxxxEXAMPLExxxxxx
 
@@ -109,12 +110,12 @@ drg:
             sample: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
         defined_tags:
             description:
-                - Defined tags for this resource. Each key is predefined and scoped to a namespace.
-                  For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                - Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
                 - "Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
             returned: on success
             type: dict
-            sample: {Operations: {CostCenter: US}}
+            sample: {'Operations': {'CostCenter': 'US'}}
         display_name:
             description:
                 - A user-friendly name. Does not have to be unique, and it's changeable.
@@ -125,12 +126,12 @@ drg:
         freeform_tags:
             description:
                 - Free-form tags for this resource. Each tag is a simple key-value pair with no
-                  predefined name, type, or namespace. For more information, see
-                  L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                  predefined name, type, or namespace. For more information, see L(Resource
+                  Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
                 - "Example: `{\\"Department\\": \\"Finance\\"}`"
             returned: on success
             type: dict
-            sample: {Department: Finance}
+            sample: {'Department': 'Finance'}
         id:
             description:
                 - The DRG's Oracle ID (OCID).
@@ -152,9 +153,9 @@ drg:
             sample: 2016-08-25T21:10:29.600Z
     sample: {
         "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
-        "defined_tags": {Operations: {CostCenter: US}},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}},
         "display_name": "display_name_example",
-        "freeform_tags": {Department: Finance},
+        "freeform_tags": {'Department': 'Finance'},
         "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
         "lifecycle_state": "PROVISIONING",
         "time_created": "2016-08-25T21:10:29.600Z"
@@ -162,7 +163,7 @@ drg:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -187,6 +188,9 @@ class DrgHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("drg_id")
+
+    def get_get_fn(self):
+        return self.client.get_drg
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -221,8 +225,16 @@ class DrgHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.create_drg, create_drg_details=create_details
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_drg,
+            call_fn_args=(),
+            call_fn_kwargs=dict(create_drg_details=create_details),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def get_update_model_class(self):
@@ -230,15 +242,32 @@ class DrgHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_drg,
-            drg_id=self.module.params.get("drg_id"),
-            update_drg_details=update_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_drg,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                drg_id=self.module.params.get("drg_id"),
+                update_drg_details=update_details,
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_drg, drg_id=self.module.params.get("drg_id")
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_drg,
+            call_fn_args=(),
+            call_fn_kwargs=dict(drg_id=self.module.params.get("drg_id")),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -270,7 +299,10 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_helper = ResourceHelper(
-        module=module, resource_type="drg", service_client_class=VirtualNetworkClient
+        module=module,
+        resource_type="drg",
+        service_client_class=VirtualNetworkClient,
+        namespace="core",
     )
 
     result = dict(changed=False)

--- a/library/oci_drg_attachment.py
+++ b/library/oci_drg_attachment.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -132,8 +133,8 @@ drg_attachment:
             sample: ATTACHING
         route_table_id:
             description:
-                - "The OCID of the route table the DRG attachment is using. For information about why you
-                  would associate a route table with a DRG attachment, see
+                - The OCID of the route table the DRG attachment is using.
+                - "For information about why you would associate a route table with a DRG attachment, see
                   L(Advanced Scenario: Transit Routing,https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm)."
             returned: on success
             type: string
@@ -164,7 +165,7 @@ drg_attachment:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -190,6 +191,9 @@ class DrgAttachmentHelperGen(OCIResourceHelperBase):
     def get_module_resource_id(self):
         return self.module.params.get("drg_attachment_id")
 
+    def get_get_fn(self):
+        return self.client.get_drg_attachment
+
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
             self.client.get_drg_attachment,
@@ -200,9 +204,10 @@ class DrgAttachmentHelperGen(OCIResourceHelperBase):
         required_list_method_params = ["compartment_id"]
 
         optional_list_method_params = ["vcn_id", "drg_id"]
-        self.module.params["compartment_id"] = self.get_compartment_id(
-            "vcn_id", self.client.get_vcn
-        )
+        if self.module.params.get("compartment_id") is None:
+            self.module.params["compartment_id"] = self.get_compartment_id(
+                "vcn_id", self.client.get_vcn
+            )
 
         required_kwargs = dict(
             (param, self.module.params[param]) for param in required_list_method_params
@@ -229,9 +234,16 @@ class DrgAttachmentHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.create_drg_attachment,
-            create_drg_attachment_details=create_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_drg_attachment,
+            call_fn_args=(),
+            call_fn_kwargs=dict(create_drg_attachment_details=create_details),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def get_update_model_class(self):
@@ -239,16 +251,34 @@ class DrgAttachmentHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_drg_attachment,
-            drg_attachment_id=self.module.params.get("drg_attachment_id"),
-            update_drg_attachment_details=update_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_drg_attachment,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                drg_attachment_id=self.module.params.get("drg_attachment_id"),
+                update_drg_attachment_details=update_details,
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_drg_attachment,
-            drg_attachment_id=self.module.params.get("drg_attachment_id"),
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_drg_attachment,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                drg_attachment_id=self.module.params.get("drg_attachment_id")
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -283,6 +313,7 @@ def main():
         module=module,
         resource_type="drg_attachment",
         service_client_class=VirtualNetworkClient,
+        namespace="core",
     )
 
     result = dict(changed=False)

--- a/library/oci_drg_attachment_facts.py
+++ b/library/oci_drg_attachment_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -34,11 +35,11 @@ options:
         aliases: ["id"]
     compartment_id:
         description:
-            - The OCID of the compartment.
+            - The L(OCID,https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
             - Required to list multiple drg_attachments.
     vcn_id:
         description:
-            - The OCID of the VCN.
+            - The L(OCID,https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
     drg_id:
         description:
             - The OCID of the DRG.
@@ -46,7 +47,7 @@ author:
     - Manoj Meda (@manojmeda)
     - Mike Ross (@mross22)
     - Nabeel Al-Saber (@nalsaber)
-extends_documentation_fragment: [ oracle ]
+extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 """
 
 EXAMPLES = """
@@ -100,8 +101,8 @@ drg_attachments:
             sample: ATTACHING
         route_table_id:
             description:
-                - "The OCID of the route table the DRG attachment is using. For information about why you
-                  would associate a route table with a DRG attachment, see
+                - The OCID of the route table the DRG attachment is using.
+                - "For information about why you would associate a route table with a DRG attachment, see
                   L(Advanced Scenario: Transit Routing,https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm)."
             returned: on success
             type: string
@@ -162,7 +163,7 @@ class DrgAttachmentFactsHelperGen(OCIResourceFactsHelperBase):
         )
 
     def list_resources(self):
-        optional_list_method_params = ["vcn_id", "drg_id"]
+        optional_list_method_params = ["vcn_id", "drg_id", "display_name"]
         optional_kwargs = dict(
             (param, self.module.params[param])
             for param in optional_list_method_params
@@ -190,6 +191,7 @@ def main():
             compartment_id=dict(type="str"),
             vcn_id=dict(type="str"),
             drg_id=dict(type="str"),
+            display_name=dict(type="str"),
         )
     )
 
@@ -202,12 +204,13 @@ def main():
         module=module,
         resource_type="drg_attachment",
         service_client_class=VirtualNetworkClient,
+        namespace="core",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_dynamic_group.py
+++ b/library/oci_dynamic_group.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
+
 
 from __future__ import absolute_import, division, print_function
 
@@ -18,190 +20,345 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: oci_dynamic_group
-short_description: Manage dynamic groups in OCI
+short_description: Manage a DynamicGroup resource in Oracle Cloud Infrastructure
 description:
-    - This module allows the user to create, delete and update dynamic groups in Oracle Cloud Infrastructure.
+    - This module allows the user to create, update and delete a DynamicGroup resource in Oracle Cloud Infrastructure
+    - For I(state=present), creates a new dynamic group in your tenancy.
+    - You must specify your tenancy's OCID as the compartment ID in the request object (remember that the tenancy
+      is simply the root compartment). Notice that IAM resources (users, groups, compartments, and some policies)
+      reside within the tenancy itself, unlike cloud resources such as compute instances, which typically
+      reside within compartments inside the tenancy. For information about OCIDs, see
+      L(Resource Identifiers,https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+    - "You must also specify a *name* for the dynamic group, which must be unique across all dynamic groups in your
+      tenancy, and cannot be changed. Note that this name has to be also unique accross all groups in your tenancy.
+      You can use this name or the OCID when writing policies that apply to the dynamic group. For more information
+      about policies, see L(How Policies Work,https://docs.cloud.oracle.com/Content/Identity/Concepts/policies.htm)."
+    - "You must also specify a *description* for the dynamic group (although it can be an empty string). It does not
+      have to be unique, and you can change it anytime with
+      L(UpdateDynamicGroup,https://docs.cloud.oracle.com/#/en/identity/20160918/DynamicGroup/UpdateDynamicGroup)."
+    - After you send your request, the new object's `lifecycleState` will temporarily be CREATING. Before using the
+      object, first make sure its `lifecycleState` has changed to ACTIVE.
 version_added: "2.5"
 options:
     compartment_id:
-        description: The OCID of the tenancy containing the group. Required to create a dynamic group.
-        required: false
-    description:
-        description: The description you assign to the group during creation. Does not have to be unique, and it's
-                     changeable. Required to create a dynamic group.
-        required: false
-    dynamic_group_id:
-        description: The OCID of the dynamic group. Required to delete or update a dynamic group.
-        required: false
-        aliases: [ 'id' ]
-    matching_rule:
-        description: The matching rule to dynamically match an instance certificate to this dynamic group. For rule
-                     syntax, see
-                     U(https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm).
-                     Required to create a dynamic group.
-        required: false
+        description:
+            - The OCID of the tenancy containing the group.
+            - Required for create using I(state=present).
     name:
-        description: The name you assign to the group during creation. The name must be unique across all groups in the
-                     tenancy and cannot be changed. Required to create a dynamic group.
-        required: false
+        description:
+            - The name you assign to the group during creation. The name must be unique across all groups
+              in the tenancy and cannot be changed.
+            - Required for create using I(state=present).
+    matching_rule:
+        description:
+            - The matching rule to dynamically match an instance certificate to this dynamic group.
+              For rule syntax, see L(Managing Dynamic Groups,https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm).
+            - Required for create using I(state=present).
+    description:
+        description:
+            - The description you assign to the group during creation. Does not have to be unique, and it's changeable.
+            - Required for create using I(state=present).
+    freeform_tags:
+        description:
+            - "Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+              For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+              Example: `{\\"Department\\": \\"Finance\\"}`"
+        type: dict
+    defined_tags:
+        description:
+            - "Defined tags for this resource. Each key is predefined and scoped to a namespace.
+              For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+              Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
+        type: dict
+    dynamic_group_id:
+        description:
+            - The OCID of the dynamic group.
+            - Required for update using I(state=present), I(state=absent).
+        aliases: ["id"]
     state:
-        description: Create or update a dynamic group with I(state=present). Use I(state=absent) to delete a dynamic
-                     group.
+        description:
+            - The state of the DynamicGroup.
+            - Use I(state=present) to create or update a DynamicGroup.
+            - Use I(state=absent) to delete a DynamicGroup.
         required: false
-        default: present
-        choices: ['present', 'absent']
-author: "Rohit Chaware (@rohitChaware)"
-extends_documentation_fragment: [ oracle, oracle_wait_options, oracle_tags ]
+        default: 'present'
+        choices: ["present", "absent"]
+author:
+    - Manoj Meda (@manojmeda)
+    - Mike Ross (@mross22)
+    - Nabeel Al-Saber (@nalsaber)
+extends_documentation_fragment: [ oracle, oracle_creatable_resource, oracle_wait_options ]
 """
 
 EXAMPLES = """
-- name: Create a dynamic group
+- name: Create dynamic_group
   oci_dynamic_group:
-    compartment_id: ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx
-    description: Group for all instances that are in a specific compartment
-    matching_rule: "instance.compartment.id = 'ocid1.compartment.oc1..xxxxxEXAMPLExxxxx'"
-    name: Sample dynamic group
+    compartment_id: ocid1.tenancy.oc1..aaaaaaaaba3pv6wkcr4jqae5f44n2b2cmdt2j6rx32uzr4h25vqstifsfdsq
+    description: Instance group for dev compartment
+    name: DevCompartmentDynamicGroup
+    matching_rule: instance.compartment.id=ocid1.compartment.oc1..aaaaaaaayd6inozhadasiiaqmttsgqanpxd6ads5tvo6g27ujaygksvivrnq
 
-- name: Update matching rule and description of a dynamic group
+- name: Update dynamic_group
   oci_dynamic_group:
-    id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
-    description: Group for all instances with the tag namespace and tag key operations.department
-    matching_rule: "tag.operations.department.value"
+    matching_rule: instance.compartment.id=ocid1.compartment.oc1..aaaaaaaayd6inozhadasiiaqmttsgqanpxd6ads5tvo6g27ujaygksvivrnq
+    description: Instance group for dev compartment
+    dynamic_group_id: ocid1.dynamicgroup.oc1..xxxxxxEXAMPLExxxxxx
 
-- name: Delete a dynamic group
+- name: Delete dynamic_group
   oci_dynamic_group:
-    id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+    dynamic_group_id: ocid1.dynamicgroup.oc1..xxxxxxEXAMPLExxxxxx
     state: absent
+
 """
 
 RETURN = """
 dynamic_group:
-    description: Information about the dynamic group
-    returned: On successful create, delete & update operation
-    type: dict
+    description:
+        - Details of the DynamicGroup resource acted upon by the current operation
+    returned: on success
+    type: complex
+    contains:
+        id:
+            description:
+                - The OCID of the group.
+            returned: on success
+            type: string
+            sample: ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx
+        compartment_id:
+            description:
+                - The OCID of the tenancy containing the group.
+            returned: on success
+            type: string
+            sample: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
+        name:
+            description:
+                - The name you assign to the group during creation. The name must be unique across all groups in
+                  the tenancy and cannot be changed.
+            returned: on success
+            type: string
+            sample: name_example
+        description:
+            description:
+                - The description you assign to the group. Does not have to be unique, and it's changeable.
+            returned: on success
+            type: string
+            sample: description_example
+        matching_rule:
+            description:
+                - A rule string that defines which instance certificates will be matched.
+                  For syntax, see L(Managing Dynamic Groups,https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm).
+            returned: on success
+            type: string
+            sample: matching_rule_example
+        time_created:
+            description:
+                - Date and time the group was created, in the format defined by RFC3339.
+                - "Example: `2016-08-25T21:10:29.600Z`"
+            returned: on success
+            type: string
+            sample: 2016-08-25T21:10:29.600Z
+        lifecycle_state:
+            description:
+                - The group's current state. After creating a group, make sure its `lifecycleState` changes from CREATING to
+                  ACTIVE before using it.
+            returned: on success
+            type: string
+            sample: CREATING
+        inactive_status:
+            description:
+                - The detailed status of INACTIVE lifecycleState.
+            returned: on success
+            type: int
+            sample: 56
+        freeform_tags:
+            description:
+                - "Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+                  For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                  Example: `{\\"Department\\": \\"Finance\\"}`"
+            returned: on success
+            type: dict
+            sample: {'Department': 'Finance'}
+        defined_tags:
+            description:
+                - "Defined tags for this resource. Each key is predefined and scoped to a namespace.
+                  For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                  Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
+            returned: on success
+            type: dict
+            sample: {'Operations': {'CostCenter': 'US'}}
     sample: {
-            "compartment_id": "ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx",
-            "description": "Group for all instances with the tag namespace and tag key operations.department",
-            "id": "ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx",
-            "inactive_status": null,
-            "lifecycle_state": "ACTIVE",
-            "matching_rule": "tag.operations.department.value",
-            "name": "Sample dynamic group",
-            "time_created": "2018-07-05T09:38:27.176000+00:00"
+        "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
+        "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
+        "name": "name_example",
+        "description": "description_example",
+        "matching_rule": "matching_rule_example",
+        "time_created": "2016-08-25T21:10:29.600Z",
+        "lifecycle_state": "CREATING",
+        "inactive_status": 56,
+        "freeform_tags": {'Department': 'Finance'},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}}
     }
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
+from ansible.module_utils.oracle.oci_resource_utils import (
+    OCIResourceHelperBase,
+    get_custom_class,
+)
 
 try:
-    from oci.identity.identity_client import IdentityClient
+    from oci.identity import IdentityClient
     from oci.identity.models import CreateDynamicGroupDetails
     from oci.identity.models import UpdateDynamicGroupDetails
 
     HAS_OCI_PY_SDK = True
-
 except ImportError:
     HAS_OCI_PY_SDK = False
 
 
-def delete_dynamic_group(identity_client, module):
-    result = oci_utils.delete_and_wait(
-        resource_type="dynamic_group",
-        client=identity_client,
-        get_fn=identity_client.get_dynamic_group,
-        kwargs_get={"dynamic_group_id": module.params["dynamic_group_id"]},
-        delete_fn=identity_client.delete_dynamic_group,
-        kwargs_delete={"dynamic_group_id": module.params["dynamic_group_id"]},
-        module=module,
-    )
-    return result
+class DynamicGroupHelperGen(OCIResourceHelperBase):
+    """Supported operations: create, update, get, list and delete"""
+
+    @staticmethod
+    def get_module_resource_id_param():
+        return "dynamic_group_id"
+
+    def get_module_resource_id(self):
+        return self.module.params.get("dynamic_group_id")
+
+    def get_get_fn(self):
+        return self.client.get_dynamic_group
+
+    def get_resource(self):
+        return oci_common_utils.call_with_backoff(
+            self.client.get_dynamic_group,
+            dynamic_group_id=self.module.params.get("dynamic_group_id"),
+        )
+
+    def list_resources(self):
+        required_list_method_params = ["compartment_id"]
+
+        optional_list_method_params = []
+
+        required_kwargs = dict(
+            (param, self.module.params[param]) for param in required_list_method_params
+        )
+
+        optional_kwargs = dict(
+            (param, self.module.params[param])
+            for param in optional_list_method_params
+            if self.module.params.get(param) is not None
+            and (
+                not self.module.params.get("key_by")
+                or param in self.module.params.get("key_by")
+            )
+        )
+
+        kwargs = oci_common_utils.merge_dicts(required_kwargs, optional_kwargs)
+
+        return oci_common_utils.list_all_resources(
+            self.client.list_dynamic_groups, **kwargs
+        )
+
+    def get_create_model_class(self):
+        return CreateDynamicGroupDetails
+
+    def create_resource(self):
+        create_details = self.get_create_model()
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_dynamic_group,
+            call_fn_args=(),
+            call_fn_kwargs=dict(create_dynamic_group_details=create_details),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
+        )
+
+    def get_update_model_class(self):
+        return UpdateDynamicGroupDetails
+
+    def update_resource(self):
+        update_details = self.get_update_model()
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_dynamic_group,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                dynamic_group_id=self.module.params.get("dynamic_group_id"),
+                update_dynamic_group_details=update_details,
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
+        )
+
+    def delete_resource(self):
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_dynamic_group,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                dynamic_group_id=self.module.params.get("dynamic_group_id")
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
+        )
 
 
-def update_dynamic_group(identity_client, module):
-    result = oci_utils.check_and_update_resource(
-        resource_type="dynamic_group",
-        client=identity_client,
-        get_fn=identity_client.get_dynamic_group,
-        kwargs_get={"dynamic_group_id": module.params["dynamic_group_id"]},
-        update_fn=identity_client.update_dynamic_group,
-        primitive_params_update=["dynamic_group_id"],
-        kwargs_non_primitive_update={
-            UpdateDynamicGroupDetails: "update_dynamic_group_details"
-        },
-        module=module,
-        update_attributes=UpdateDynamicGroupDetails().attribute_map.keys(),
-    )
-
-    return result
+DynamicGroupHelperCustom = get_custom_class("DynamicGroupHelperCustom")
 
 
-def create_dynamic_group(identity_client, module):
-    create_dynamic_group_details = CreateDynamicGroupDetails()
-    for attribute in create_dynamic_group_details.attribute_map.keys():
-        if attribute in module.params:
-            setattr(create_dynamic_group_details, attribute, module.params[attribute])
-
-    result = oci_utils.create_and_wait(
-        resource_type="dynamic_group",
-        create_fn=identity_client.create_dynamic_group,
-        kwargs_create={"create_dynamic_group_details": create_dynamic_group_details},
-        client=identity_client,
-        get_fn=identity_client.get_dynamic_group,
-        get_param="dynamic_group_id",
-        module=module,
-    )
-    return result
+class ResourceHelper(DynamicGroupHelperCustom, DynamicGroupHelperGen):
+    pass
 
 
 def main():
-    module_args = oci_utils.get_taggable_arg_spec(supports_wait=True)
+    module_args = oci_common_utils.get_common_arg_spec(
+        supports_create=True, supports_wait=True
+    )
     module_args.update(
         dict(
-            compartment_id=dict(type="str", required=False),
-            description=dict(type="str", required=False),
-            matching_rule=dict(type="str", required=False),
-            name=dict(type="str", required=False),
-            state=dict(
-                type="str",
-                required=False,
-                default="present",
-                choices=["absent", "present"],
-            ),
-            dynamic_group_id=dict(type="str", required=False, aliases=["id"]),
+            compartment_id=dict(type="str"),
+            name=dict(type="str"),
+            matching_rule=dict(type="str"),
+            description=dict(type="str"),
+            freeform_tags=dict(type="dict"),
+            defined_tags=dict(type="dict"),
+            dynamic_group_id=dict(aliases=["id"], type="str"),
+            state=dict(type="str", default="present", choices=["present", "absent"]),
         )
     )
 
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=False,
-        required_if=[("state", "absent", ["dynamic_group_id"])],
-    )
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg="oci python sdk required for this module.")
 
-    identity_client = oci_utils.create_service_client(module, IdentityClient)
+    resource_helper = ResourceHelper(
+        module=module,
+        resource_type="dynamic_group",
+        service_client_class=IdentityClient,
+        namespace="identity",
+    )
 
-    state = module.params["state"]
-    dynamic_group_id = module.params["dynamic_group_id"]
+    result = dict(changed=False)
 
-    if state == "absent":
-        result = delete_dynamic_group(identity_client, module)
+    if resource_helper.is_delete():
+        result = resource_helper.delete()
+    elif resource_helper.is_update():
+        result = resource_helper.update()
+    elif resource_helper.is_create():
+        result = resource_helper.create()
 
-    else:
-        if dynamic_group_id is not None:
-            result = update_dynamic_group(identity_client, module)
-        else:
-            result = oci_utils.check_and_create_resource(
-                resource_type="dynamic_group",
-                create_fn=create_dynamic_group,
-                kwargs_create={"identity_client": identity_client, "module": module},
-                list_fn=identity_client.list_dynamic_groups,
-                kwargs_list={"compartment_id": module.params["compartment_id"]},
-                module=module,
-                model=CreateDynamicGroupDetails(),
-            )
     module.exit_json(**result)
 
 

--- a/library/oci_dynamic_group_facts.py
+++ b/library/oci_dynamic_group_facts.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python
-# Copyright (c) 2018, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
+
 
 from __future__ import absolute_import, division, print_function
 
@@ -18,148 +20,212 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: oci_dynamic_group_facts
-short_description: Retrieve facts of dynamic groups
+short_description: Fetches details about one or multiple DynamicGroup resources in Oracle Cloud Infrastructure
 description:
-    - This module retrieves information of the specified dynamic group or lists all the dynamic groups in a tenancy.
+    - Fetches details about one or multiple DynamicGroup resources in Oracle Cloud Infrastructure
+    - Lists the dynamic groups in your tenancy. You must specify your tenancy's OCID as the value for
+      the compartment ID (remember that the tenancy is simply the root compartment).
+      See L(Where to Get the Tenancy's OCID and User's OCID,https://docs.cloud.oracle.com/Content/API/Concepts/apisigningkey.htm#five).
+    - If I(dynamic_group_id) is specified, the details of a single DynamicGroup will be returned.
 version_added: "2.5"
 options:
     dynamic_group_id:
-        description: The OCID of the dynamic group. I(dynamic_group_id) is required to get a specific dynamic group's
-                     information.
-        required: false
-        aliases: [ 'id' ]
+        description:
+            - The OCID of the dynamic group.
+            - Required to get a specific dynamic_group.
+        aliases: ["id"]
     compartment_id:
-        description: The OCID of the compartment (remember that the tenancy is simply the root compartment).
-                     Required to list all the dynamic groups in a tenancy.
-        required: false
-author: "Rohit Chaware (@rohitChaware)"
+        description:
+            - The OCID of the compartment (remember that the tenancy is simply the root compartment).
+            - Required to list multiple dynamic_groups.
+author:
+    - Manoj Meda (@manojmeda)
+    - Mike Ross (@mross22)
+    - Nabeel Al-Saber (@nalsaber)
 extends_documentation_fragment: [ oracle, oracle_name_option ]
 """
 
 EXAMPLES = """
-- name: Get all the dynamic groups in a tenancy
+- name: List dynamic_groups
   oci_dynamic_group_facts:
-    compartment_id: ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx
+    compartment_id: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
 
-- name: Get information of a specific dynamic group
+- name: Get a specific dynamic_group
   oci_dynamic_group_facts:
-    dynamic_group_id: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
+    dynamic_group_id: ocid1.dynamicgroup.oc1..xxxxxxEXAMPLExxxxxx
+
 """
 
 RETURN = """
 dynamic_groups:
-    description: List of dynamic group details
-    returned: always
+    description:
+        - List of DynamicGroup resources
+    returned: on success
     type: complex
     contains:
-        compartment_id:
-            description: The OCID of the tenancy containing the group.
-            returned: always
-            type: string
-            sample: ocid1.compartment.oc1..xxxxxEXAMPLExxxxx
-        description:
-            description: The description you assign to the group. Does not have to be unique, and it's changeable.
-            returned: always
-            type: string
-            sample: "Group for all instances with the tag namespace and tag key operations.department"
         id:
-            description: The OCID of the group.
-            returned: always
+            description:
+                - The OCID of the group.
+            returned: on success
             type: string
-            sample: ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx
-        inactive_status:
-            description: The detailed status of INACTIVE lifecycleState.
-            returned: always
-            type: int
-            sample: 1
-        lifecycle_state:
-            description: The group's current state. After creating a group, make sure its lifecycleState changes from
-                         CREATING to ACTIVE before using it.
-            returned: always
+            sample: ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx
+        compartment_id:
+            description:
+                - The OCID of the tenancy containing the group.
+            returned: on success
             type: string
-            sample: ACTIVE
-        matching_rule:
-            description: A rule string that defines which instance certificates will be matched. For syntax, see
-                         U(https://docs.us-phoenix-1.oraclecloud.com/Content/Identity/Tasks/managingdynamicgroups.htm).
-            returned: always
-            type: string
-            sample: tag.operations.department.value
-        time_created:
-            description: Date and time the group was created, in the format defined by RFC3339.
-            returned: always
-            type: datetime
-            sample: 2018-03-28T18:37:56.190000+00:00
+            sample: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
         name:
-            description: The name you assign to the group during creation. The name must be unique across all groups in
-                         the tenancy and cannot be changed.
-            returned: always
+            description:
+                - The name you assign to the group during creation. The name must be unique across all groups in
+                  the tenancy and cannot be changed.
+            returned: on success
             type: string
-            sample: Sample dynamic group
+            sample: name_example
+        description:
+            description:
+                - The description you assign to the group. Does not have to be unique, and it's changeable.
+            returned: on success
+            type: string
+            sample: description_example
+        matching_rule:
+            description:
+                - A rule string that defines which instance certificates will be matched.
+                  For syntax, see L(Managing Dynamic Groups,https://docs.cloud.oracle.com/Content/Identity/Tasks/managingdynamicgroups.htm).
+            returned: on success
+            type: string
+            sample: matching_rule_example
+        time_created:
+            description:
+                - Date and time the group was created, in the format defined by RFC3339.
+                - "Example: `2016-08-25T21:10:29.600Z`"
+            returned: on success
+            type: string
+            sample: 2016-08-25T21:10:29.600Z
+        lifecycle_state:
+            description:
+                - The group's current state. After creating a group, make sure its `lifecycleState` changes from CREATING to
+                  ACTIVE before using it.
+            returned: on success
+            type: string
+            sample: CREATING
+        inactive_status:
+            description:
+                - The detailed status of INACTIVE lifecycleState.
+            returned: on success
+            type: int
+            sample: 56
+        freeform_tags:
+            description:
+                - "Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+                  For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                  Example: `{\\"Department\\": \\"Finance\\"}`"
+            returned: on success
+            type: dict
+            sample: {'Department': 'Finance'}
+        defined_tags:
+            description:
+                - "Defined tags for this resource. Each key is predefined and scoped to a namespace.
+                  For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                  Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
+            returned: on success
+            type: dict
+            sample: {'Operations': {'CostCenter': 'US'}}
     sample: [{
-            "compartment_id": "ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx",
-            "description": "Group for all instances with the tag namespace and tag key operations.department",
-            "id": "ocid1.dynamicgroup.oc1..xxxxxEXAMPLExxxxx",
-            "inactive_status": null,
-            "lifecycle_state": "ACTIVE",
-            "matching_rule": "tag.operations.department.value",
-            "name": "Sample dynamic group",
-            "time_created": "2018-07-05T09:38:27.176000+00:00"
-        }]
+        "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
+        "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
+        "name": "name_example",
+        "description": "description_example",
+        "matching_rule": "matching_rule_example",
+        "time_created": "2016-08-25T21:10:29.600Z",
+        "lifecycle_state": "CREATING",
+        "inactive_status": 56,
+        "freeform_tags": {'Department': 'Finance'},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}}
+    }]
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_utils
-
+from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle.oci_resource_utils import (
+    OCIResourceFactsHelperBase,
+    get_custom_class,
+)
 
 try:
-    from oci.identity.identity_client import IdentityClient
-    from oci.util import to_dict
-    from oci.exceptions import ServiceError
+    from oci.identity import IdentityClient
 
     HAS_OCI_PY_SDK = True
-
 except ImportError:
     HAS_OCI_PY_SDK = False
 
 
+class DynamicGroupFactsHelperGen(OCIResourceFactsHelperBase):
+    """Supported operations: get, list"""
+
+    def get_required_params_for_get(self):
+        return ["dynamic_group_id"]
+
+    def get_required_params_for_list(self):
+        return ["compartment_id"]
+
+    def get_resource(self):
+        return oci_common_utils.call_with_backoff(
+            self.client.get_dynamic_group,
+            dynamic_group_id=self.module.params.get("dynamic_group_id"),
+        )
+
+    def list_resources(self):
+        optional_list_method_params = ["name"]
+        optional_kwargs = dict(
+            (param, self.module.params[param])
+            for param in optional_list_method_params
+            if self.module.params.get(param) is not None
+        )
+        return oci_common_utils.list_all_resources(
+            self.client.list_dynamic_groups,
+            compartment_id=self.module.params.get("compartment_id"),
+            **optional_kwargs
+        )
+
+
+DynamicGroupFactsHelperCustom = get_custom_class("DynamicGroupFactsHelperCustom")
+
+
+class ResourceFactsHelper(DynamicGroupFactsHelperCustom, DynamicGroupFactsHelperGen):
+    pass
+
+
 def main():
-    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
+    module_args = oci_common_utils.get_common_arg_spec()
     module_args.update(
         dict(
-            dynamic_group_id=dict(type="str", required=False, aliases=["id"]),
-            compartment_id=dict(type="str", required=False),
+            dynamic_group_id=dict(aliases=["id"], type="str"),
+            compartment_id=dict(type="str"),
+            name=dict(type="str"),
         )
     )
 
-    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+    module = AnsibleModule(argument_spec=module_args)
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg="oci python sdk required for this module.")
 
-    identity_client = oci_utils.create_service_client(module, IdentityClient)
+    resource_facts_helper = ResourceFactsHelper(
+        module=module,
+        resource_type="dynamic_group",
+        service_client_class=IdentityClient,
+        namespace="identity",
+    )
 
-    dynamic_group_id = module.params["dynamic_group_id"]
+    result = []
 
-    try:
-        if dynamic_group_id is not None:
-            result = [
-                to_dict(
-                    oci_utils.call_with_backoff(
-                        identity_client.get_dynamic_group,
-                        dynamic_group_id=dynamic_group_id,
-                    ).data
-                )
-            ]
-        else:
-            result = to_dict(
-                oci_utils.list_all_resources(
-                    identity_client.list_dynamic_groups,
-                    compartment_id=module.params["compartment_id"],
-                    name=module.params["name"],
-                )
-            )
-    except ServiceError as ex:
-        module.fail_json(msg=ex.message)
+    if resource_facts_helper.is_get():
+        result = [resource_facts_helper.get()]
+    elif resource_facts_helper.is_list():
+        result = resource_facts_helper.list()
+    else:
+        resource_facts_helper.fail()
 
     module.exit_json(dynamic_groups=result)
 

--- a/library/oci_export.py
+++ b/library/oci_export.py
@@ -335,7 +335,10 @@ def update_export(file_storage_client, module, export):
     )
     export_option_changed = False
     if input_export_options is not None:
-        export_options, export_option_changed = oci_utils.check_and_return_component_list_difference(
+        (
+            export_options,
+            export_option_changed,
+        ) = oci_utils.check_and_return_component_list_difference(
             input_export_options,
             existing_export_options,
             purge_export_options,

--- a/library/oci_identity_identity_provider_actions.py
+++ b/library/oci_identity_identity_provider_actions.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -76,9 +77,9 @@ identity_provider:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
-    OCIResourceHelperBase,
+    OCIActionsHelperBase,
     get_custom_class,
 )
 
@@ -90,8 +91,11 @@ except ImportError:
     HAS_OCI_PY_SDK = False
 
 
-class IdentityProviderActionsHelperGen(OCIResourceHelperBase):
-    """Supported actions: reset_idp_scim_client"""
+class IdentityProviderActionsHelperGen(OCIActionsHelperBase):
+    """
+    Supported actions:
+        reset_idp_scim_client
+    """
 
     @staticmethod
     def get_module_resource_id_param():
@@ -100,6 +104,9 @@ class IdentityProviderActionsHelperGen(OCIResourceHelperBase):
     def get_module_resource_id(self):
         return self.module.params.get("identity_provider_id")
 
+    def get_get_fn(self):
+        return self.client.get_identity_provider
+
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
             self.client.get_identity_provider,
@@ -107,9 +114,21 @@ class IdentityProviderActionsHelperGen(OCIResourceHelperBase):
         )
 
     def reset_idp_scim_client(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.reset_idp_scim_client,
-            identity_provider_id=self.module.params.get("identity_provider_id"),
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.reset_idp_scim_client,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                identity_provider_id=self.module.params.get("identity_provider_id")
+            ),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation="{0}_{1}".format(
+                self.module.params.get("action").upper(),
+                oci_common_utils.ACTION_OPERATION_KEY,
+            ),
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or self.get_action_desired_states(self.module.params.get("action")),
         )
 
 
@@ -144,6 +163,7 @@ def main():
         module=module,
         resource_type="identity_provider",
         service_client_class=IdentityClient,
+        namespace="identity",
     )
 
     result = resource_helper.perform_action(module.params.get("action"))

--- a/library/oci_identity_tag_default.py
+++ b/library/oci_identity_tag_default.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -145,7 +146,7 @@ tag_default:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -170,6 +171,9 @@ class TagDefaultHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("tag_default_id")
+
+    def get_get_fn(self):
+        return self.client.get_tag_default
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -207,8 +211,16 @@ class TagDefaultHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.create_tag_default, create_tag_default_details=create_details
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_tag_default,
+            call_fn_args=(),
+            call_fn_kwargs=dict(create_tag_default_details=create_details),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def get_update_model_class(self):
@@ -216,16 +228,34 @@ class TagDefaultHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_tag_default,
-            tag_default_id=self.module.params.get("tag_default_id"),
-            update_tag_default_details=update_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_tag_default,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                tag_default_id=self.module.params.get("tag_default_id"),
+                update_tag_default_details=update_details,
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_tag_default,
-            tag_default_id=self.module.params.get("tag_default_id"),
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_tag_default,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                tag_default_id=self.module.params.get("tag_default_id")
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -256,7 +286,10 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_helper = ResourceHelper(
-        module=module, resource_type="tag_default", service_client_class=IdentityClient
+        module=module,
+        resource_type="tag_default",
+        service_client_class=IdentityClient,
+        namespace="identity",
     )
 
     result = dict(changed=False)

--- a/library/oci_identity_tag_default_facts.py
+++ b/library/oci_identity_tag_default_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -203,13 +204,16 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_facts_helper = ResourceFactsHelper(
-        module=module, resource_type="tag_default", service_client_class=IdentityClient
+        module=module,
+        resource_type="tag_default",
+        service_client_class=IdentityClient,
+        namespace="identity",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_image_actions.py
+++ b/library/oci_image_actions.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -34,7 +35,7 @@ version_added: "2.5"
 options:
     image_id:
         description:
-            - The OCID of the image.
+            - The L(OCID,https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
         aliases: ["id"]
         required: true
     destination_type:
@@ -79,19 +80,19 @@ extends_documentation_fragment: [ oracle, oracle_wait_options ]
 EXAMPLES = """
 - name: Perform action export on image
   oci_image_actions:
-      image_id: ocid1.image.oc1..xxxxxxEXAMPLExxxxxx
-      destination_type: objectStorageTuple
-      bucket_name: MyBucket
-      namespace_name: MyNamespace
-      object_name: exported-image.oci
-      action: export
+    object_name: exported-image.oci
+    bucket_name: MyBucket
+    namespace_name: MyNamespace
+    destination_type: objectStorageTuple
+    image_id: ocid1.image.oc1..xxxxxxEXAMPLExxxxxx
+    action: export
 
 - name: Perform action export on image
   oci_image_actions:
-      image_id: ocid1.image.oc1..xxxxxxEXAMPLExxxxxx
-      destination_type: objectStorageUri
-      destination_uri: https://objectstorage.us-phoenix-1.oraclecloud.com/n/MyNamespace/b/MyBucket/o/exported-image.oci
-      action: export
+    destination_uri: https://objectstorage.us-phoenix-1.oraclecloud.com/n/MyNamespace/b/MyBucket/o/exported-image.oci
+    destination_type: objectStorageUri
+    image_id: ocid1.image.oc1..xxxxxxEXAMPLExxxxxx
+    action: export
 
 """
 
@@ -116,25 +117,25 @@ image:
             sample: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
         create_image_allowed:
             description:
-                - "Whether instances launched with this image can be used to create new images.
+                - Whether instances launched with this image can be used to create new images.
                   For example, you cannot create an image of an Oracle Database instance.
-                  Example: `true`"
+                - "Example: `true`"
             returned: on success
             type: bool
             sample: true
         defined_tags:
             description:
-                - Defined tags for this resource. Each key is predefined and scoped to a namespace.
-                  For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                - Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
                 - "Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
             returned: on success
             type: dict
-            sample: {Operations: {CostCenter: US}}
+            sample: {'Operations': {'CostCenter': 'US'}}
         display_name:
             description:
                 - A user-friendly name for the image. It does not have to be unique, and it's changeable.
                   Avoid entering confidential information.
-                  You cannot use an Oracle-provided image name as a custom image name.
+                - You cannot use an Oracle-provided image name as a custom image name.
                 - "Example: `My custom Oracle Linux image`"
             returned: on success
             type: string
@@ -142,12 +143,12 @@ image:
         freeform_tags:
             description:
                 - Free-form tags for this resource. Each tag is a simple key-value pair with no
-                  predefined name, type, or namespace. For more information, see
-                  L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                  predefined name, type, or namespace. For more information, see L(Resource
+                  Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
                 - "Example: `{\\"Department\\": \\"Finance\\"}`"
             returned: on success
             type: dict
-            sample: {Department: Finance}
+            sample: {'Department': 'Finance'}
         id:
             description:
                 - The OCID of the image.
@@ -195,9 +196,10 @@ image:
                     sample: BIOS
                 network_type:
                     description:
-                        - "Emulation type for NIC.
+                        - "Emulation type for the physical network interface card (NIC).
                           * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
-                          * `VFIO` - Direct attached Virtual Function network controller.  Default for Oracle provided images.
+                          * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+                          when you launch an instance using hardware-assisted (SR-IOV) networking.
                           * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers."
                     returned: on success
                     type: string
@@ -261,7 +263,8 @@ image:
                     sample: true
         size_in_mbs:
             description:
-                - Image size (1 MB = 1048576 bytes)
+                - The boot volume size for an instance launched from this image, (1 MB = 1048576 bytes).
+                  Note this is not the same as the size of the image when it was exported or the actual size of the image.
                 - "Example: `47694`"
             returned: on success
             type: int
@@ -277,9 +280,9 @@ image:
         "base_image_id": "ocid1.baseimage.oc1..xxxxxxEXAMPLExxxxxx",
         "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
         "create_image_allowed": true,
-        "defined_tags": {Operations: {CostCenter: US}},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}},
         "display_name": "My custom Oracle Linux image",
-        "freeform_tags": {Department: Finance},
+        "freeform_tags": {'Department': 'Finance'},
         "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
         "launch_mode": "NATIVE",
         "launch_options": {
@@ -302,9 +305,9 @@ image:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
-    OCIResourceHelperBase,
+    OCIActionsHelperBase,
     get_custom_class,
     convert_input_data_to_model_class,
 )
@@ -318,8 +321,11 @@ except ImportError:
     HAS_OCI_PY_SDK = False
 
 
-class ImageActionsHelperGen(OCIResourceHelperBase):
-    """Supported actions: export"""
+class ImageActionsHelperGen(OCIActionsHelperBase):
+    """
+    Supported actions:
+        export
+    """
 
     @staticmethod
     def get_module_resource_id_param():
@@ -327,6 +333,9 @@ class ImageActionsHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("image_id")
+
+    def get_get_fn(self):
+        return self.client.get_image
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -337,10 +346,22 @@ class ImageActionsHelperGen(OCIResourceHelperBase):
         action_details = convert_input_data_to_model_class(
             self.module.params, ExportImageDetails
         )
-        return oci_common_utils.call_with_backoff(
-            self.client.export_image,
-            image_id=self.module.params.get("image_id"),
-            export_image_details=action_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.export_image,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                image_id=self.module.params.get("image_id"),
+                export_image_details=action_details,
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation="{0}_{1}".format(
+                self.module.params.get("action").upper(),
+                oci_common_utils.ACTION_OPERATION_KEY,
+            ),
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or self.get_action_desired_states(self.module.params.get("action")),
         )
 
 
@@ -377,7 +398,10 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_helper = ResourceHelper(
-        module=module, resource_type="image", service_client_class=ComputeClient
+        module=module,
+        resource_type="image",
+        service_client_class=ComputeClient,
+        namespace="core",
     )
 
     result = resource_helper.perform_action(module.params.get("action"))

--- a/library/oci_image_facts.py
+++ b/library/oci_image_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -33,12 +34,12 @@ version_added: "2.5"
 options:
     image_id:
         description:
-            - The OCID of the image.
+            - The L(OCID,https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the image.
             - Required to get a specific image.
         aliases: ["id"]
     compartment_id:
         description:
-            - The OCID of the compartment.
+            - The L(OCID,https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
             - Required to list multiple images.
     display_name:
         description:
@@ -123,25 +124,25 @@ images:
             sample: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
         create_image_allowed:
             description:
-                - "Whether instances launched with this image can be used to create new images.
+                - Whether instances launched with this image can be used to create new images.
                   For example, you cannot create an image of an Oracle Database instance.
-                  Example: `true`"
+                - "Example: `true`"
             returned: on success
             type: bool
             sample: true
         defined_tags:
             description:
-                - Defined tags for this resource. Each key is predefined and scoped to a namespace.
-                  For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                - Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
                 - "Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
             returned: on success
             type: dict
-            sample: {Operations: {CostCenter: US}}
+            sample: {'Operations': {'CostCenter': 'US'}}
         display_name:
             description:
                 - A user-friendly name for the image. It does not have to be unique, and it's changeable.
                   Avoid entering confidential information.
-                  You cannot use an Oracle-provided image name as a custom image name.
+                - You cannot use an Oracle-provided image name as a custom image name.
                 - "Example: `My custom Oracle Linux image`"
             returned: on success
             type: string
@@ -149,12 +150,12 @@ images:
         freeform_tags:
             description:
                 - Free-form tags for this resource. Each tag is a simple key-value pair with no
-                  predefined name, type, or namespace. For more information, see
-                  L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                  predefined name, type, or namespace. For more information, see L(Resource
+                  Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
                 - "Example: `{\\"Department\\": \\"Finance\\"}`"
             returned: on success
             type: dict
-            sample: {Department: Finance}
+            sample: {'Department': 'Finance'}
         id:
             description:
                 - The OCID of the image.
@@ -202,9 +203,10 @@ images:
                     sample: BIOS
                 network_type:
                     description:
-                        - "Emulation type for NIC.
+                        - "Emulation type for the physical network interface card (NIC).
                           * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
-                          * `VFIO` - Direct attached Virtual Function network controller.  Default for Oracle provided images.
+                          * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+                          when you launch an instance using hardware-assisted (SR-IOV) networking.
                           * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers."
                     returned: on success
                     type: string
@@ -268,7 +270,8 @@ images:
                     sample: true
         size_in_mbs:
             description:
-                - Image size (1 MB = 1048576 bytes)
+                - The boot volume size for an instance launched from this image, (1 MB = 1048576 bytes).
+                  Note this is not the same as the size of the image when it was exported or the actual size of the image.
                 - "Example: `47694`"
             returned: on success
             type: int
@@ -284,9 +287,9 @@ images:
         "base_image_id": "ocid1.baseimage.oc1..xxxxxxEXAMPLExxxxxx",
         "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
         "create_image_allowed": true,
-        "defined_tags": {Operations: {CostCenter: US}},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}},
         "display_name": "My custom Oracle Linux image",
-        "freeform_tags": {Department: Finance},
+        "freeform_tags": {'Department': 'Finance'},
         "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
         "launch_mode": "NATIVE",
         "launch_options": {
@@ -398,13 +401,16 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_facts_helper = ResourceFactsHelper(
-        module=module, resource_type="image", service_client_class=ComputeClient
+        module=module,
+        resource_type="image",
+        service_client_class=ComputeClient,
+        namespace="core",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_instance.py
+++ b/library/oci_instance.py
@@ -139,7 +139,8 @@ options:
                 description: The OCID of the volume to be attached to or detached from the instance I(instance_id).
     vnic:
         description: Details for the primary VNIC that is automatically created and attached when the instance is
-                     launched. Required when creating a compute instance with I(state=present).
+                     launched. Required when creating a compute instance with I(state=present).  Updating any of these
+                     child properties is not supported through this module.
         aliases: ['create_vnic_details']
         suboptions:
             assign_public_ip:
@@ -150,25 +151,43 @@ options:
                              I(prohibitPublicIpOnVnic = false), then a public IP address is
                              assigned. If set to true and I(prohibitPublicIpOnVnic = true),
                              an error is returned.
+                             Note this field will be used on initial create but will not be considered when
+                             determining whether to match an existing resource or create a new one.
             hostname_label:
                 description: The hostname for the VNIC's primary private IP. Used for DNS. The value
                              is the hostname portion of the primary private IP's fully qualified
                              domain name (FQDN) (for example, bminstance-1 in FQDN
                              bminstance-1.subnet123.vcn1.oraclevcn.com). Must be unique across all
                              VNICs in the subnet and comply with RFC 952 and RFC 1123.
+                             Note this field will be used on initial create but will not be considered when
+                             determining whether to match an existing resource or create a new one.
             name:
                 description: A user-friendly name for the VNIC. Does not have to be unique.
+                             Note this field will be used on initial create but will not be considered when
+                             determining whether to match an existing resource or create a new one.
+            nsg_ids:
+                description: A list of the OCIDs of the network security groups (NSGs) to add the VNIC to.
+                             For more information about NSGs, see NetworkSecurityGroup L(NetworkSecurityGroup,
+                             https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/NetworkSecurityGroup/).
+                             Note this field will be used on initial create but will not be considered when
+                             determining whether to match an existing resource or create a new one.
             private_ip:
                 description: The private IP to assign to the VNIC. Must be an available IP address
                              within the subnet's CIDR. If you don't specify a value, Oracle
                              automatically assigns a private IP address from the subnet. This is
                              the VNIC's primary private IP address.
+                             Note this field will be used on initial create but will not be considered when
+                             determining whether to match an existing resource or create a new one.
             skip_source_dest_check:
                 description: Determines whether the source/destination check is disabled on the VNIC.
                              Defaults to false, which means the check is performed.
+                             Note this field will be used on initial create but will not be considered when
+                             determining whether to match an existing resource or create a new one.
                 default: false
             subnet_id:
                 description: The OCID of the subnet to create the VNIC in.
+                             Note this field will be used on initial create but will not be considered when
+                             determining whether to match an existing resource or create a new one.
                 required: true
 
 author: "Sivakumar Thyagarajan (@sivakumart)"
@@ -778,6 +797,7 @@ def get_vnic_details(module):
     cvd.private_ip = vnic_details.get("private_ip", None)
     cvd.skip_source_dest_check = vnic_details.get("skip_source_dest_check", None)
     cvd.subnet_id = vnic_details["subnet_id"]
+    cvd.nsg_ids = vnic_details.get("nsg_ids", None)
     return cvd
 
 

--- a/library/oci_load_balancer_backend_set.py
+++ b/library/oci_load_balancer_backend_set.py
@@ -457,7 +457,10 @@ def update_backend_set(lb_client, module, lb_id, backend_set, name):
     get_logger().info("Updating backend set %s in the load balancer %s", name, lb_id)
     backends_changed = False
     if input_backends is not None:
-        backends, backends_changed = oci_utils.check_and_return_component_list_difference(
+        (
+            backends,
+            backends_changed,
+        ) = oci_utils.check_and_return_component_list_difference(
             input_backends, existing_backends, purge_backends, delete_backends
         )
     if backends_changed:

--- a/library/oci_load_balancer_listener.py
+++ b/library/oci_load_balancer_listener.py
@@ -441,7 +441,10 @@ def update_listener(lb_client, module, listener, lb_id, name):
     update_listener_details.hostname_names = listener.hostname_names
     hostname_names_changed = False
     if input_hostname_names is not None:
-        changed_hostname_names, hostname_names_changed = oci_utils.check_and_return_component_list_difference(
+        (
+            changed_hostname_names,
+            hostname_names_changed,
+        ) = oci_utils.check_and_return_component_list_difference(
             input_hostname_names,
             listener.hostname_names,
             module.params.get("purge_hostname_names"),

--- a/library/oci_namespace_facts.py
+++ b/library/oci_namespace_facts.py
@@ -100,12 +100,13 @@ def main():
         module=module,
         resource_type="namespace",
         service_client_class=ObjectStorageClient,
+        namespace="object_storage",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_namespace_metadata_facts.py
+++ b/library/oci_namespace_metadata_facts.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
-# Copyright (c) 2019 Oracle and/or its affiliates.
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -19,46 +20,65 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: oci_namespace_metadata_facts
-short_description: Gets the metadata for the Object Storage namespace
-description: Gets the metadata for the Object Storage namespace, which contains defaultS3CompartmentId and
-             defaultSwiftCompartmentId.
+short_description: Fetches details about one or multiple NamespaceMetadata resources in Oracle Cloud Infrastructure
+description:
+    - Fetches details about one or multiple NamespaceMetadata resources in Oracle Cloud Infrastructure
+    - Gets the metadata for the Object Storage namespace, which contains defaultS3CompartmentId and
+      defaultSwiftCompartmentId.
+    - Any user with the NAMESPACE_READ permission will be able to see the current metadata. If you are
+      not authorized, talk to an administrator. If you are an administrator who needs to write policies
+      to give users access, see
+      L(Getting Started with Policies,https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
 version_added: "2.5"
 options:
     namespace_name:
-        description: The Object Storage namespace.
+        description:
+            - The Object Storage namespace used for the request.
         required: true
-author: "Manoj Meda (@manojmeda)"
-extends_documentation_fragment: oracle
+author:
+    - Manoj Meda (@manojmeda)
+    - Mike Ross (@mross22)
+    - Nabeel Al-Saber (@nalsaber)
+extends_documentation_fragment: [ oracle ]
 """
 
 EXAMPLES = """
-- name: Get the object storage namespace metadata
+- name: Get a specific namespace_metadata
   oci_namespace_metadata_facts:
-    namespace_name: examplenamespace
+    namespace_name: namespace_name_example
+
 """
 
 RETURN = """
 namespace_metadatas:
-    description: The metadata for the Object Storage namespace, which contains defaultS3CompartmentId and
-                 defaultSwiftCompartmentId.
+    description:
+        - List of NamespaceMetadata resources
     returned: on success
     type: complex
     contains:
         namespace:
-            description: The Object Storage namespace to which the metadata belongs.
+            description:
+                - The Object Storage namespace to which the metadata belongs.
             returned: on success
             type: string
-            sample: examplenamespace
+            sample: namespace_example
         default_s3_compartment_id:
-            description:  The default compartment assignment for the Amazon S3 Compatibility API.
+            description:
+                - If the field is set, specifies the default compartment assignment for the Amazon S3 Compatibility API.
             returned: on success
             type: string
-            sample: ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx
+            sample: ocid1.defaults3compartment.oc1..xxxxxxEXAMPLExxxxxx
         default_swift_compartment_id:
-            description:  The default compartment assignment for the Swift API.
+            description:
+                - If the field is set, specifies the default compartment assignment for the Swift API.
             returned: on success
             type: string
-            sample: ocid1.tenancy.oc1..xxxxxEXAMPLExxxxx
+            sample: ocid1.defaultswiftcompartment.oc1..xxxxxxEXAMPLExxxxxx
+    sample: [{
+        "namespace": "namespace_example",
+        "default_s3_compartment_id": "ocid1.defaults3compartment.oc1..xxxxxxEXAMPLExxxxxx",
+        "default_swift_compartment_id": "ocid1.defaultswiftcompartment.oc1..xxxxxxEXAMPLExxxxxx"
+    }]
 """
 
 from ansible.module_utils.basic import AnsibleModule
@@ -80,7 +100,7 @@ class NamespaceMetadataFactsHelperGen(OCIResourceFactsHelperBase):
     """Supported operations: get"""
 
     def get_required_params_for_get(self):
-        return []
+        return ["namespace_name"]
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -113,12 +133,13 @@ def main():
         module=module,
         resource_type="namespace_metadata",
         service_client_class=ObjectStorageClient,
+        namespace="object_storage",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_network_security_group.py
+++ b/library/oci_network_security_group.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -167,7 +168,7 @@ network_security_group:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -192,6 +193,9 @@ class NetworkSecurityGroupHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("network_security_group_id")
+
+    def get_get_fn(self):
+        return self.client.get_network_security_group
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -231,9 +235,16 @@ class NetworkSecurityGroupHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.create_network_security_group,
-            create_network_security_group_details=create_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_network_security_group,
+            call_fn_args=(),
+            call_fn_kwargs=dict(create_network_security_group_details=create_details),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def get_update_model_class(self):
@@ -241,20 +252,38 @@ class NetworkSecurityGroupHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_network_security_group,
-            network_security_group_id=self.module.params.get(
-                "network_security_group_id"
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_network_security_group,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                network_security_group_id=self.module.params.get(
+                    "network_security_group_id"
+                ),
+                update_network_security_group_details=update_details,
             ),
-            update_network_security_group_details=update_details,
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_network_security_group,
-            network_security_group_id=self.module.params.get(
-                "network_security_group_id"
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_network_security_group,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                network_security_group_id=self.module.params.get(
+                    "network_security_group_id"
+                )
             ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -290,6 +319,7 @@ def main():
         module=module,
         resource_type="network_security_group",
         service_client_class=VirtualNetworkClient,
+        namespace="core",
     )
 
     result = dict(changed=False)

--- a/library/oci_network_security_group_facts.py
+++ b/library/oci_network_security_group_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -250,12 +251,13 @@ def main():
         module=module,
         resource_type="network_security_group",
         service_client_class=VirtualNetworkClient,
+        namespace="core",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_object_storage_bucket_actions.py
+++ b/library/oci_object_storage_bucket_actions.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -291,9 +292,9 @@ bucket:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
-    OCIResourceHelperBase,
+    OCIActionsHelperBase,
     get_custom_class,
     convert_input_data_to_model_class,
 )
@@ -309,8 +310,13 @@ except ImportError:
     HAS_OCI_PY_SDK = False
 
 
-class BucketActionsHelperGen(OCIResourceHelperBase):
-    """Supported actions: copy_object, rename_object, restore_objects"""
+class BucketActionsHelperGen(OCIActionsHelperBase):
+    """
+    Supported actions:
+        copy_object
+        rename_object
+        restore_objects
+    """
 
     @staticmethod
     def get_module_resource_id_param():
@@ -318,6 +324,9 @@ class BucketActionsHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("bucket_name")
+
+    def get_get_fn(self):
+        return self.client.get_bucket
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -330,33 +339,69 @@ class BucketActionsHelperGen(OCIResourceHelperBase):
         action_details = convert_input_data_to_model_class(
             self.module.params, CopyObjectDetails
         )
-        return oci_common_utils.call_with_backoff(
-            self.client.copy_object,
-            namespace_name=self.module.params.get("namespace_name"),
-            bucket_name=self.module.params.get("bucket_name"),
-            copy_object_details=action_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.copy_object,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                namespace_name=self.module.params.get("namespace_name"),
+                bucket_name=self.module.params.get("bucket_name"),
+                copy_object_details=action_details,
+            ),
+            waiter_type=oci_wait_utils.WORK_REQUEST_WAITER_KEY,
+            operation="{0}_{1}".format(
+                self.module.params.get("action").upper(),
+                oci_common_utils.ACTION_OPERATION_KEY,
+            ),
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_work_request_completed_states(),
         )
 
     def rename_object(self):
         action_details = convert_input_data_to_model_class(
             self.module.params, RenameObjectDetails
         )
-        return oci_common_utils.call_with_backoff(
-            self.client.rename_object,
-            namespace_name=self.module.params.get("namespace_name"),
-            bucket_name=self.module.params.get("bucket_name"),
-            rename_object_details=action_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.rename_object,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                namespace_name=self.module.params.get("namespace_name"),
+                bucket_name=self.module.params.get("bucket_name"),
+                rename_object_details=action_details,
+            ),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation="{0}_{1}".format(
+                self.module.params.get("action").upper(),
+                oci_common_utils.ACTION_OPERATION_KEY,
+            ),
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or self.get_action_desired_states(self.module.params.get("action")),
         )
 
     def restore_objects(self):
         action_details = convert_input_data_to_model_class(
             self.module.params, RestoreObjectsDetails
         )
-        return oci_common_utils.call_with_backoff(
-            self.client.restore_objects,
-            namespace_name=self.module.params.get("namespace_name"),
-            bucket_name=self.module.params.get("bucket_name"),
-            restore_objects_details=action_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.restore_objects,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                namespace_name=self.module.params.get("namespace_name"),
+                bucket_name=self.module.params.get("bucket_name"),
+                restore_objects_details=action_details,
+            ),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation="{0}_{1}".format(
+                self.module.params.get("action").upper(),
+                oci_common_utils.ACTION_OPERATION_KEY,
+            ),
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or self.get_action_desired_states(self.module.params.get("action")),
         )
 
 
@@ -405,7 +450,10 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_helper = ResourceHelper(
-        module=module, resource_type="bucket", service_client_class=ObjectStorageClient
+        module=module,
+        resource_type="bucket",
+        service_client_class=ObjectStorageClient,
+        namespace="object_storage",
     )
 
     result = resource_helper.perform_action(module.params.get("action"))

--- a/library/oci_object_storage_object_lifecycle_policy_facts.py
+++ b/library/oci_object_storage_object_lifecycle_policy_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -240,12 +241,13 @@ def main():
         module=module,
         resource_type="object_lifecycle_policy",
         service_client_class=ObjectStorageClient,
+        namespace="object_storage",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_region_facts.py
+++ b/library/oci_region_facts.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python
-# Copyright (c) 2017, 2018, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
+
 
 from __future__ import absolute_import, division, print_function
 
@@ -18,88 +20,125 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: oci_region_facts
-short_description: Retrieve details about all Regions offered by Oracle Cloud Infrastructure
+short_description: Fetches details about one or multiple Region resources in Oracle Cloud Infrastructure
 description:
-    - This module retrieves details about all Regions offered by Oracle Cloud Infrastructure.
+    - Fetches details about one or multiple Region resources in Oracle Cloud Infrastructure
+    - Lists all the regions offered by Oracle Cloud Infrastructure.
 version_added: "2.5"
-author: "Sivakumar Thyagarajan (@sivakumart)"
+options: {}
+author:
+    - Manoj Meda (@manojmeda)
+    - Mike Ross (@mross22)
+    - Nabeel Al-Saber (@nalsaber)
 extends_documentation_fragment: [ oracle, oracle_name_option ]
 """
 
 EXAMPLES = """
-- name: Get details of all regions offered by OCI
+- name: List regions
   oci_region_facts:
+
 """
 
 RETURN = """
 regions:
-    description: Information about regions offered by OCI
+    description:
+        - List of Region resources
     returned: on success
     type: complex
     contains:
         key:
-            description: The key of the region.
-            returned: always
+            description:
+                - The key of the region.
+                - "Allowed values are:
+                  - `PHX`
+                  - `IAD`
+                  - `FRA`
+                  - `LHR`"
+            returned: on success
             type: string
-            sample: PHX
+            sample: key_example
         name:
-            description: The name of the region.
-            returned: always
+            description:
+                - The name of the region.
+                - "Allowed values are:
+                  - `us-phoenix-1`
+                  - `us-ashburn-1`
+                  - `eu-frankfurt-1`
+                  - `uk-london-1`"
+            returned: on success
             type: string
-            sample: us-phoenix-1
-
-    sample: [
-                {
-                  "key": "FRA",
-                  "name": "eu-frankfurt-1"
-                },
-                {
-                  "key": "IAD",
-                  "name": "us-ashburn-1"
-                },
-                {
-                  "key": "PHX",
-                  "name": "us-phoenix-1"
-                }
-        ]
-
+            sample: name_example
+    sample: [{
+        "key": "key_example",
+        "name": "name_example"
+    }]
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_utils
+from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle.oci_resource_utils import (
+    OCIResourceFactsHelperBase,
+    get_custom_class,
+)
 
 try:
-    from oci.identity.identity_client import IdentityClient
-    from oci.util import to_dict
-    from oci.exceptions import ServiceError
+    from oci.identity import IdentityClient
 
     HAS_OCI_PY_SDK = True
 except ImportError:
     HAS_OCI_PY_SDK = False
 
 
-def list_regions(identity_client, module):
-    try:
-        regions = oci_utils.list_all_resources(
-            identity_client.list_regions, name=module.params["name"]
-        )
-    except ServiceError as ex:
-        module.fail_json(msg=ex.message)
+class RegionFactsHelperGen(OCIResourceFactsHelperBase):
+    """Supported operations: list"""
 
-    return to_dict(regions)
+    def get_required_params_for_list(self):
+        return []
+
+    def list_resources(self):
+        optional_list_method_params = ["name"]
+        optional_kwargs = dict(
+            (param, self.module.params[param])
+            for param in optional_list_method_params
+            if self.module.params.get(param) is not None
+        )
+        return oci_common_utils.list_all_resources(
+            self.client.list_regions, **optional_kwargs
+        )
+
+
+RegionFactsHelperCustom = get_custom_class("RegionFactsHelperCustom")
+
+
+class ResourceFactsHelper(RegionFactsHelperCustom, RegionFactsHelperGen):
+    pass
 
 
 def main():
-    module_args = oci_utils.get_facts_module_arg_spec(filter_by_name=True)
+    module_args = oci_common_utils.get_common_arg_spec()
+    module_args.update(dict(name=dict(type="str")))
 
-    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+    module = AnsibleModule(argument_spec=module_args)
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg="oci python sdk required for this module.")
 
-    identity_client = oci_utils.create_service_client(module, IdentityClient)
+    resource_facts_helper = ResourceFactsHelper(
+        module=module,
+        resource_type="region",
+        service_client_class=IdentityClient,
+        namespace="identity",
+    )
 
-    result = list_regions(identity_client, module)
+    result = []
+
+    if resource_facts_helper.is_get():
+        result = [resource_facts_helper.get()]
+    elif resource_facts_helper.is_list():
+        result = resource_facts_helper.list()
+    else:
+        resource_facts_helper.fail()
+
     module.exit_json(regions=result)
 
 

--- a/library/oci_security_list.py
+++ b/library/oci_security_list.py
@@ -525,7 +525,10 @@ def update_security_list(virtual_network_client, existing_security_list, module)
         input_egress_security_rules = get_security_rules(
             "egress_security_rules", input_egress_security_rules
         )
-        egress_security_rules, egress_security_rules_changed = oci_utils.check_and_return_component_list_difference(
+        (
+            egress_security_rules,
+            egress_security_rules_changed,
+        ) = oci_utils.check_and_return_component_list_difference(
             input_egress_security_rules,
             get_hashed_security_rules(
                 "egress_security_rules", existing_egress_security_rule
@@ -538,7 +541,10 @@ def update_security_list(virtual_network_client, existing_security_list, module)
         input_ingress_security_rules = get_security_rules(
             "ingress_security_rules", input_ingress_security_rules
         )
-        ingress_security_rules, ingress_security_rules_changed = oci_utils.check_and_return_component_list_difference(
+        (
+            ingress_security_rules,
+            ingress_security_rules_changed,
+        ) = oci_utils.check_and_return_component_list_difference(
             input_ingress_security_rules,
             get_hashed_security_rules(
                 "ingress_security_rules", existing_ingress_security_rule

--- a/library/oci_security_rule_actions.py
+++ b/library/oci_security_rule_actions.py
@@ -1,0 +1,797 @@
+#!/usr/bin/python
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_security_rule_actions
+short_description: Perform actions on a SecurityRule resource in Oracle Cloud Infrastructure
+description:
+    - Perform actions on a SecurityRule resource in Oracle Cloud Infrastructure
+    - For I(action=add_network_security_group_security_rules), adds one or more security rules to the specified network security group.
+    - For I(action=remove_network_security_group_security_rules), removes one or more security rules from the specified network security group.
+    - For I(action=update_network_security_group_security_rules), updates one or more security rules in the specified network security group.
+version_added: "2.5"
+options:
+    network_security_group_id:
+        description:
+            - The L(OCID,https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+        aliases: ["id"]
+        required: true
+    security_rules:
+        description:
+            - The NSG security rules to add.
+            - Applicable only for I(action=add_network_security_group_security_rules)I(action=update_network_security_group_security_rules).
+        type: list
+        suboptions:
+            description:
+                description:
+                    - An optional description of your choice for the rule. Avoid entering confidential information.
+            destination:
+                description:
+                    - Conceptually, this is the range of IP addresses that a packet originating from the instance
+                      can go to.
+                    - "Allowed values:"
+                    - " * An IP address range in CIDR notation. For example: `192.168.1.0/24`"
+                    - " * The `cidrBlock` value for a L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/), if you're
+                          setting up a security rule for traffic destined for a particular `Service` through
+                          a service gateway. For example: `oci-phx-objectstorage`."
+                    - " * The OCID of a L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/) in the same
+                          VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
+                          traffic between VNICs in the same NSG."
+            destination_type:
+                description:
+                    - Type of destination for the rule. Required if `direction` = `EGRESS`.
+                    - "Allowed values:"
+                    - " * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation."
+                    - " * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                          L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/) (the rule is for traffic destined for a
+                          particular `Service` through a service gateway)."
+                    - " * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID of a
+                          L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/)."
+                choices:
+                    - "CIDR_BLOCK"
+                    - "SERVICE_CIDR_BLOCK"
+                    - "NETWORK_SECURITY_GROUP"
+            direction:
+                description:
+                    - Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets, or `INGRESS` for rules to allow inbound IP
+                      packets.
+                choices:
+                    - "EGRESS"
+                    - "INGRESS"
+                required: true
+            icmp_options:
+                description:
+                    - "Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                      as defined in:
+                      - L(ICMP Parameters,http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                      - L(ICMPv6 Parameters,https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)"
+                    - "If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                      codes are allowed. If you do provide this object, the type is required and the code is optional.
+                      To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 (\\"Destination
+                      Unreachable\\") code 4 (\\"Fragmentation Needed and Don't Fragment was Set\\"). If you need to specify
+                      multiple codes for a single type, create a separate security list rule for each."
+                type: dict
+                suboptions:
+                    code:
+                        description:
+                            - The ICMP code (optional).
+                        type: int
+                    type:
+                        description:
+                            - The ICMP type.
+                        type: int
+                        required: true
+            is_stateless:
+                description:
+                    - A stateless rule allows traffic in one direction. Remember to add a corresponding
+                      stateless rule in the other direction if you need to support bidirectional traffic. For
+                      example, if egress traffic allows TCP destination port 80, there should be an ingress
+                      rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                      and a corresponding rule is not necessary for bidirectional traffic.
+                type: bool
+            protocol:
+                description:
+                    - "The transport protocol. Specify either `all` or an IPv4 protocol number as
+                      defined in
+                      L(Protocol Numbers,http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                      Options are supported only for ICMP (\\"1\\"), TCP (\\"6\\"), UDP (\\"17\\"), and ICMPv6 (\\"58\\")."
+                required: true
+            source:
+                description:
+                    - Conceptually, this is the range of IP addresses that a packet coming into the instance
+                      can come from.
+                    - "Allowed values:"
+                    - " * An IP address range in CIDR notation. For example: `192.168.1.0/24`"
+                    - " * The `cidrBlock` value for a L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/), if you're
+                          setting up a security rule for traffic coming from a particular `Service` through
+                          a service gateway. For example: `oci-phx-objectstorage`."
+                    - " * The OCID of a L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/) in the same
+                          VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
+                          traffic between VNICs in the same NSG."
+            source_type:
+                description:
+                    - Type of source for the rule. Required if `direction` = `INGRESS`.
+                    - " * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation."
+                    - " * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                          L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/) (the rule is for traffic coming from a
+                          particular `Service` through a service gateway)."
+                    - " * `NETWORK_SECURITY_GROUP`: If the rule's `source` is the OCID of a
+                          L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/)."
+                choices:
+                    - "CIDR_BLOCK"
+                    - "SERVICE_CIDR_BLOCK"
+                    - "NETWORK_SECURITY_GROUP"
+            tcp_options:
+                description:
+                    - Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                      If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
+                type: dict
+                suboptions:
+                    destination_port_range:
+                        description:
+                            - An inclusive range of allowed destination ports. Use the same number for the min and max
+                              to indicate a single port. Defaults to all ports if not specified.
+                        type: dict
+                        suboptions:
+                            max:
+                                description:
+                                    - The maximum port number. Must not be lower than the minimum port number. To specify
+                                      a single port number, set both the min and max to the same value.
+                                type: int
+                                required: true
+                            min:
+                                description:
+                                    - The minimum port number. Must not be greater than the maximum port number.
+                                type: int
+                                required: true
+                    source_port_range:
+                        description:
+                            - An inclusive range of allowed source ports. Use the same number for the min and max to
+                              indicate a single port. Defaults to all ports if not specified.
+                        type: dict
+                        suboptions:
+                            max:
+                                description:
+                                    - The maximum port number. Must not be lower than the minimum port number. To specify
+                                      a single port number, set both the min and max to the same value.
+                                type: int
+                                required: true
+                            min:
+                                description:
+                                    - The minimum port number. Must not be greater than the maximum port number.
+                                type: int
+                                required: true
+            udp_options:
+                description:
+                    - Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                      If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
+                type: dict
+                suboptions:
+                    destination_port_range:
+                        description:
+                            - An inclusive range of allowed destination ports. Use the same number for the min and max
+                              to indicate a single port. Defaults to all ports if not specified.
+                        type: dict
+                        suboptions:
+                            max:
+                                description:
+                                    - The maximum port number. Must not be lower than the minimum port number. To specify
+                                      a single port number, set both the min and max to the same value.
+                                type: int
+                                required: true
+                            min:
+                                description:
+                                    - The minimum port number. Must not be greater than the maximum port number.
+                                type: int
+                                required: true
+                    source_port_range:
+                        description:
+                            - An inclusive range of allowed source ports. Use the same number for the min and max to
+                              indicate a single port. Defaults to all ports if not specified.
+                        type: dict
+                        suboptions:
+                            max:
+                                description:
+                                    - The maximum port number. Must not be lower than the minimum port number. To specify
+                                      a single port number, set both the min and max to the same value.
+                                type: int
+                                required: true
+                            min:
+                                description:
+                                    - The minimum port number. Must not be greater than the maximum port number.
+                                type: int
+                                required: true
+            id:
+                description:
+                    - The Oracle-assigned ID of the security rule that you want to update. You can't change this value.
+                    - "Example: `04ABEC`"
+    security_rule_ids:
+        description:
+            - The Oracle-assigned ID of each L(SecurityRule,https://docs.cloud.oracle.com/#/en/iaas/20160918/SecurityRule/) to be deleted.
+            - Applicable only for I(action=remove_network_security_group_security_rules).
+        type: list
+    action:
+        description:
+            - The action to perform on the SecurityRule.
+        required: true
+        choices: ["add_network_security_group_security_rules", "remove_network_security_group_security_rules", "update_network_security_group_security_rules"]
+author:
+    - Manoj Meda (@manojmeda)
+    - Mike Ross (@mross22)
+    - Nabeel Al-Saber (@nalsaber)
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+- name: Perform action add_network_security_group_security_rules on security_rule
+  oci_security_rule_actions:
+    network_security_group_id: ocid1.networksecuritygroup.oc1..xxxxxxEXAMPLExxxxxx
+    security_rules:
+    - description: Example ingress security rule
+      source_type: CIDR_BLOCK
+      source: 10.0.0.0/16
+      direction: INGRESS
+      protocol: all
+    - description: Example egress security rule
+      source_type: CIDR_BLOCK
+      source: 10.0.0.0/16
+      direction: EGRESS
+      protocol: all
+    action: add_network_security_group_security_rules
+
+- name: Perform action remove_network_security_group_security_rules on security_rule
+  oci_security_rule_actions:
+    network_security_group_id: ocid1.networksecuritygroup.oc1..xxxxxxEXAMPLExxxxxx
+    security_rule_ids:
+    - 880233
+    - 203597
+    action: remove_network_security_group_security_rules
+
+- name: Perform action update_network_security_group_security_rules on security_rule
+  oci_security_rule_actions:
+    network_security_group_id: ocid1.networksecuritygroup.oc1..xxxxxxEXAMPLExxxxxx
+    security_rules:
+    - description: Example ingress security rule - updated
+      id: 203597
+      source_type: CIDR_BLOCK
+      source: 10.0.0.0/24
+      direction: INGRESS
+      protocol: all
+    - description: Example egress security rule - updated
+      id: 880233
+      source_type: CIDR_BLOCK
+      source: 10.0.0.0/24
+      direction: EGRESS
+      protocol: all
+    action: update_network_security_group_security_rules
+
+"""
+
+RETURN = """
+security_rule:
+    description:
+        - Details of the SecurityRule resource acted upon by the current operation
+    returned: on success
+    type: complex
+    contains:
+        security_rules:
+            description:
+                - The NSG security rules that were added.
+            returned: on success
+            type: complex
+            contains:
+                description:
+                    description:
+                        - An optional description of your choice for the rule.
+                    returned: on success
+                    type: string
+                    sample: description_example
+                destination:
+                    description:
+                        - Conceptually, this is the range of IP addresses that a packet originating from the instance
+                          can go to.
+                        - "Allowed values:"
+                        - " * An IP address range in CIDR notation. For example: `192.168.1.0/24`"
+                        - " * The `cidrBlock` value for a L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/), if you're
+                              setting up a security rule for traffic destined for a particular `Service` through
+                              a service gateway. For example: `oci-phx-objectstorage`."
+                        - " * The OCID of a L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/) in the same
+                              VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
+                              traffic between VNICs in the same NSG."
+                    returned: on success
+                    type: string
+                    sample: destination_example
+                destination_type:
+                    description:
+                        - Type of destination for the rule. Required if `direction` = `EGRESS`.
+                        - "Allowed values:"
+                        - " * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation."
+                        - " * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                              L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/) (the rule is for traffic destined for a
+                              particular `Service` through a service gateway)."
+                        - " * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID of a
+                              L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/)."
+                    returned: on success
+                    type: string
+                    sample: CIDR_BLOCK
+                direction:
+                    description:
+                        - Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets, or `INGRESS` for rules to allow inbound IP
+                          packets.
+                    returned: on success
+                    type: string
+                    sample: EGRESS
+                icmp_options:
+                    description:
+                        - "Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                          as defined in:
+                          - L(ICMP Parameters,http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                          - L(ICMPv6 Parameters,https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)"
+                        - "If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                          codes are allowed. If you do provide this object, the type is required and the code is optional.
+                          To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 (\\"Destination
+                          Unreachable\\") code 4 (\\"Fragmentation Needed and Don't Fragment was Set\\"). If you need to specify
+                          multiple codes for a single type, create a separate security rule for each."
+                    returned: on success
+                    type: complex
+                    contains:
+                        code:
+                            description:
+                                - The ICMP code (optional).
+                            returned: on success
+                            type: int
+                            sample: 56
+                        type:
+                            description:
+                                - The ICMP type.
+                            returned: on success
+                            type: int
+                            sample: 56
+                id:
+                    description:
+                        - An Oracle-assigned identifier for the security rule. You specify this ID when you want to
+                          update or delete the rule.
+                        - "Example: `04ABEC`"
+                    returned: on success
+                    type: string
+                    sample: 04ABEC
+                is_stateless:
+                    description:
+                        - A stateless rule allows traffic in one direction. Remember to add a corresponding
+                          stateless rule in the other direction if you need to support bidirectional traffic. For
+                          example, if egress traffic allows TCP destination port 80, there should be an ingress
+                          rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                          and a corresponding rule is not necessary for bidirectional traffic.
+                    returned: on success
+                    type: bool
+                    sample: true
+                is_valid:
+                    description:
+                        - Whether the rule is valid. The value is `True` when the rule is first created. If
+                          the rule's `source` or `destination` is a network security group, the value changes to
+                          `False` if that network security group is deleted.
+                    returned: on success
+                    type: bool
+                    sample: true
+                protocol:
+                    description:
+                        - "The transport protocol. Specify either `all` or an IPv4 protocol number as
+                          defined in
+                          L(Protocol Numbers,http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                          Options are supported only for ICMP (\\"1\\"), TCP (\\"6\\"), UDP (\\"17\\"), and ICMPv6 (\\"58\\")."
+                    returned: on success
+                    type: string
+                    sample: protocol_example
+                source:
+                    description:
+                        - Conceptually, this is the range of IP addresses that a packet coming into the instance
+                          can come from.
+                        - "Allowed values:"
+                        - " * An IP address range in CIDR notation. For example: `192.168.1.0/24`"
+                        - " * The `cidrBlock` value for a L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/), if you're
+                              setting up a security rule for traffic coming from a particular `Service` through
+                              a service gateway. For example: `oci-phx-objectstorage`."
+                        - " * The OCID of a L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/) in the same
+                              VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
+                              traffic between VNICs in the same NSG."
+                    returned: on success
+                    type: string
+                    sample: source_example
+                source_type:
+                    description:
+                        - Type of source for the rule. Required if `direction` = `INGRESS`.
+                        - " * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation."
+                        - " * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                              L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/) (the rule is for traffic coming from a
+                              particular `Service` through a service gateway)."
+                        - " * `NETWORK_SECURITY_GROUP`: If the rule's `source` is the OCID of a
+                              L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/)."
+                    returned: on success
+                    type: string
+                    sample: CIDR_BLOCK
+                tcp_options:
+                    description:
+                        - Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                          If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
+                    returned: on success
+                    type: complex
+                    contains:
+                        destination_port_range:
+                            description:
+                                - An inclusive range of allowed destination ports. Use the same number for the min and max
+                                  to indicate a single port. Defaults to all ports if not specified.
+                            returned: on success
+                            type: complex
+                            contains:
+                                max:
+                                    description:
+                                        - The maximum port number. Must not be lower than the minimum port number. To specify
+                                          a single port number, set both the min and max to the same value.
+                                    returned: on success
+                                    type: int
+                                    sample: 56
+                                min:
+                                    description:
+                                        - The minimum port number. Must not be greater than the maximum port number.
+                                    returned: on success
+                                    type: int
+                                    sample: 56
+                        source_port_range:
+                            description:
+                                - An inclusive range of allowed source ports. Use the same number for the min and max to
+                                  indicate a single port. Defaults to all ports if not specified.
+                            returned: on success
+                            type: complex
+                            contains:
+                                max:
+                                    description:
+                                        - The maximum port number. Must not be lower than the minimum port number. To specify
+                                          a single port number, set both the min and max to the same value.
+                                    returned: on success
+                                    type: int
+                                    sample: 56
+                                min:
+                                    description:
+                                        - The minimum port number. Must not be greater than the maximum port number.
+                                    returned: on success
+                                    type: int
+                                    sample: 56
+                time_created:
+                    description:
+                        - The date and time the security rule was created. Format defined by RFC3339.
+                    returned: on success
+                    type: string
+                    sample: 2013-10-20T19:20:30+01:00
+                udp_options:
+                    description:
+                        - Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                          If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
+                    returned: on success
+                    type: complex
+                    contains:
+                        destination_port_range:
+                            description:
+                                - An inclusive range of allowed destination ports. Use the same number for the min and max
+                                  to indicate a single port. Defaults to all ports if not specified.
+                            returned: on success
+                            type: complex
+                            contains:
+                                max:
+                                    description:
+                                        - The maximum port number. Must not be lower than the minimum port number. To specify
+                                          a single port number, set both the min and max to the same value.
+                                    returned: on success
+                                    type: int
+                                    sample: 56
+                                min:
+                                    description:
+                                        - The minimum port number. Must not be greater than the maximum port number.
+                                    returned: on success
+                                    type: int
+                                    sample: 56
+                        source_port_range:
+                            description:
+                                - An inclusive range of allowed source ports. Use the same number for the min and max to
+                                  indicate a single port. Defaults to all ports if not specified.
+                            returned: on success
+                            type: complex
+                            contains:
+                                max:
+                                    description:
+                                        - The maximum port number. Must not be lower than the minimum port number. To specify
+                                          a single port number, set both the min and max to the same value.
+                                    returned: on success
+                                    type: int
+                                    sample: 56
+                                min:
+                                    description:
+                                        - The minimum port number. Must not be greater than the maximum port number.
+                                    returned: on success
+                                    type: int
+                                    sample: 56
+    sample: {
+        "security_rules": [{
+            "description": "description_example",
+            "destination": "destination_example",
+            "destination_type": "CIDR_BLOCK",
+            "direction": "EGRESS",
+            "icmp_options": {
+                "code": 56,
+                "type": 56
+            },
+            "id": "04ABEC",
+            "is_stateless": true,
+            "is_valid": true,
+            "protocol": "protocol_example",
+            "source": "source_example",
+            "source_type": "CIDR_BLOCK",
+            "tcp_options": {
+                "destination_port_range": {
+                    "max": 56,
+                    "min": 56
+                },
+                "source_port_range": {
+                    "max": 56,
+                    "min": 56
+                }
+            },
+            "time_created": "2013-10-20T19:20:30+01:00",
+            "udp_options": {
+                "destination_port_range": {
+                    "max": 56,
+                    "min": 56
+                },
+                "source_port_range": {
+                    "max": 56,
+                    "min": 56
+                }
+            }
+        }]
+    }
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
+from ansible.module_utils.oracle.oci_resource_utils import (
+    OCIActionsHelperBase,
+    get_custom_class,
+    convert_input_data_to_model_class,
+)
+
+try:
+    from oci.core import VirtualNetworkClient
+    from oci.core.models import AddNetworkSecurityGroupSecurityRulesDetails
+    from oci.core.models import RemoveNetworkSecurityGroupSecurityRulesDetails
+    from oci.core.models import UpdateNetworkSecurityGroupSecurityRulesDetails
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+class SecurityRuleActionsHelperGen(OCIActionsHelperBase):
+    """
+    Supported actions:
+        add_network_security_group_security_rules
+        remove_network_security_group_security_rules
+        update_network_security_group_security_rules
+    """
+
+    @staticmethod
+    def get_module_resource_id_param():
+        return "network_security_group_id"
+
+    def get_module_resource_id(self):
+        return self.module.params.get("network_security_group_id")
+
+    def add_network_security_group_security_rules(self):
+        action_details = convert_input_data_to_model_class(
+            self.module.params, AddNetworkSecurityGroupSecurityRulesDetails
+        )
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.add_network_security_group_security_rules,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                network_security_group_id=self.module.params.get(
+                    "network_security_group_id"
+                ),
+                add_network_security_group_security_rules_details=action_details,
+            ),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation="{0}_{1}".format(
+                self.module.params.get("action").upper(),
+                oci_common_utils.ACTION_OPERATION_KEY,
+            ),
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or self.get_action_desired_states(self.module.params.get("action")),
+        )
+
+    def remove_network_security_group_security_rules(self):
+        action_details = convert_input_data_to_model_class(
+            self.module.params, RemoveNetworkSecurityGroupSecurityRulesDetails
+        )
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.remove_network_security_group_security_rules,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                network_security_group_id=self.module.params.get(
+                    "network_security_group_id"
+                ),
+                remove_network_security_group_security_rules_details=action_details,
+            ),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation="{0}_{1}".format(
+                self.module.params.get("action").upper(),
+                oci_common_utils.ACTION_OPERATION_KEY,
+            ),
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or self.get_action_desired_states(self.module.params.get("action")),
+        )
+
+    def update_network_security_group_security_rules(self):
+        action_details = convert_input_data_to_model_class(
+            self.module.params, UpdateNetworkSecurityGroupSecurityRulesDetails
+        )
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_network_security_group_security_rules,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                network_security_group_id=self.module.params.get(
+                    "network_security_group_id"
+                ),
+                update_network_security_group_security_rules_details=action_details,
+            ),
+            waiter_type=oci_wait_utils.NONE_WAITER_KEY,
+            operation="{0}_{1}".format(
+                self.module.params.get("action").upper(),
+                oci_common_utils.ACTION_OPERATION_KEY,
+            ),
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or self.get_action_desired_states(self.module.params.get("action")),
+        )
+
+
+SecurityRuleActionsHelperCustom = get_custom_class("SecurityRuleActionsHelperCustom")
+
+
+class ResourceHelper(SecurityRuleActionsHelperCustom, SecurityRuleActionsHelperGen):
+    pass
+
+
+def main():
+    module_args = oci_common_utils.get_common_arg_spec(
+        supports_create=False, supports_wait=False
+    )
+    module_args.update(
+        dict(
+            network_security_group_id=dict(aliases=["id"], type="str", required=True),
+            security_rules=dict(
+                type="list",
+                elements="dict",
+                options=dict(
+                    description=dict(type="str"),
+                    destination=dict(type="str"),
+                    destination_type=dict(
+                        type="str",
+                        choices=[
+                            "CIDR_BLOCK",
+                            "SERVICE_CIDR_BLOCK",
+                            "NETWORK_SECURITY_GROUP",
+                        ],
+                    ),
+                    direction=dict(
+                        type="str", required=True, choices=["EGRESS", "INGRESS"]
+                    ),
+                    icmp_options=dict(
+                        type="dict",
+                        options=dict(
+                            code=dict(type="int"), type=dict(type="int", required=True)
+                        ),
+                    ),
+                    is_stateless=dict(type="bool"),
+                    protocol=dict(type="str", required=True),
+                    source=dict(type="str"),
+                    source_type=dict(
+                        type="str",
+                        choices=[
+                            "CIDR_BLOCK",
+                            "SERVICE_CIDR_BLOCK",
+                            "NETWORK_SECURITY_GROUP",
+                        ],
+                    ),
+                    tcp_options=dict(
+                        type="dict",
+                        options=dict(
+                            destination_port_range=dict(
+                                type="dict",
+                                options=dict(
+                                    max=dict(type="int", required=True),
+                                    min=dict(type="int", required=True),
+                                ),
+                            ),
+                            source_port_range=dict(
+                                type="dict",
+                                options=dict(
+                                    max=dict(type="int", required=True),
+                                    min=dict(type="int", required=True),
+                                ),
+                            ),
+                        ),
+                    ),
+                    udp_options=dict(
+                        type="dict",
+                        options=dict(
+                            destination_port_range=dict(
+                                type="dict",
+                                options=dict(
+                                    max=dict(type="int", required=True),
+                                    min=dict(type="int", required=True),
+                                ),
+                            ),
+                            source_port_range=dict(
+                                type="dict",
+                                options=dict(
+                                    max=dict(type="int", required=True),
+                                    min=dict(type="int", required=True),
+                                ),
+                            ),
+                        ),
+                    ),
+                    id=dict(type="str"),
+                ),
+            ),
+            security_rule_ids=dict(type="list"),
+            action=dict(
+                type="str",
+                required=True,
+                choices=[
+                    "add_network_security_group_security_rules",
+                    "remove_network_security_group_security_rules",
+                    "update_network_security_group_security_rules",
+                ],
+            ),
+        )
+    )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module.")
+
+    resource_helper = ResourceHelper(
+        module=module,
+        resource_type="security_rule",
+        service_client_class=VirtualNetworkClient,
+        namespace="core",
+    )
+
+    result = resource_helper.perform_action(module.params.get("action"))
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_security_rule_facts.py
+++ b/library/oci_security_rule_facts.py
@@ -1,0 +1,420 @@
+#!/usr/bin/python
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: oci_security_rule_facts
+short_description: Fetches details about one or multiple SecurityRule resources in Oracle Cloud Infrastructure
+description:
+    - Fetches details about one or multiple SecurityRule resources in Oracle Cloud Infrastructure
+    - Lists the security rules in the specified network security group.
+version_added: "2.5"
+options:
+    network_security_group_id:
+        description:
+            - The L(OCID,https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+        required: true
+    direction:
+        description:
+            - Direction of the security rule. Set to `EGRESS` for rules that allow outbound IP packets,
+              or `INGRESS` for rules that allow inbound IP packets.
+        choices:
+            - "EGRESS"
+            - "INGRESS"
+    sort_by:
+        description:
+            - The field to sort by.
+        choices:
+            - "TIMECREATED"
+    sort_order:
+        description:
+            - The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+              is case sensitive.
+        choices:
+            - "ASC"
+            - "DESC"
+author:
+    - Manoj Meda (@manojmeda)
+    - Mike Ross (@mross22)
+    - Nabeel Al-Saber (@nalsaber)
+extends_documentation_fragment: [ oracle ]
+"""
+
+EXAMPLES = """
+- name: List security_rules
+  oci_security_rule_facts:
+    network_security_group_id: ocid1.networksecuritygroup.oc1..xxxxxxEXAMPLExxxxxx
+
+"""
+
+RETURN = """
+security_rules:
+    description:
+        - List of SecurityRule resources
+    returned: on success
+    type: complex
+    contains:
+        description:
+            description:
+                - An optional description of your choice for the rule.
+            returned: on success
+            type: string
+            sample: description_example
+        destination:
+            description:
+                - Conceptually, this is the range of IP addresses that a packet originating from the instance
+                  can go to.
+                - "Allowed values:"
+                - " * An IP address range in CIDR notation. For example: `192.168.1.0/24`"
+                - " * The `cidrBlock` value for a L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/), if you're
+                      setting up a security rule for traffic destined for a particular `Service` through
+                      a service gateway. For example: `oci-phx-objectstorage`."
+                - " * The OCID of a L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/) in the same
+                      VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
+                      traffic between VNICs in the same NSG."
+            returned: on success
+            type: string
+            sample: destination_example
+        destination_type:
+            description:
+                - Type of destination for the rule. Required if `direction` = `EGRESS`.
+                - "Allowed values:"
+                - " * `CIDR_BLOCK`: If the rule's `destination` is an IP address range in CIDR notation."
+                - " * `SERVICE_CIDR_BLOCK`: If the rule's `destination` is the `cidrBlock` value for a
+                      L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/) (the rule is for traffic destined for a
+                      particular `Service` through a service gateway)."
+                - " * `NETWORK_SECURITY_GROUP`: If the rule's `destination` is the OCID of a
+                      L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/)."
+            returned: on success
+            type: string
+            sample: CIDR_BLOCK
+        direction:
+            description:
+                - Direction of the security rule. Set to `EGRESS` for rules to allow outbound IP packets, or `INGRESS` for rules to allow inbound IP packets.
+            returned: on success
+            type: string
+            sample: EGRESS
+        icmp_options:
+            description:
+                - "Optional and valid only for ICMP and ICMPv6. Use to specify a particular ICMP type and code
+                  as defined in:
+                  - L(ICMP Parameters,http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                  - L(ICMPv6 Parameters,https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)"
+                - "If you specify ICMP or ICMPv6 as the protocol but omit this object, then all ICMP types and
+                  codes are allowed. If you do provide this object, the type is required and the code is optional.
+                  To enable MTU negotiation for ingress internet traffic via IPv4, make sure to allow type 3 (\\"Destination
+                  Unreachable\\") code 4 (\\"Fragmentation Needed and Don't Fragment was Set\\"). If you need to specify
+                  multiple codes for a single type, create a separate security rule for each."
+            returned: on success
+            type: complex
+            contains:
+                code:
+                    description:
+                        - The ICMP code (optional).
+                    returned: on success
+                    type: int
+                    sample: 56
+                type:
+                    description:
+                        - The ICMP type.
+                    returned: on success
+                    type: int
+                    sample: 56
+        id:
+            description:
+                - An Oracle-assigned identifier for the security rule. You specify this ID when you want to
+                  update or delete the rule.
+                - "Example: `04ABEC`"
+            returned: on success
+            type: string
+            sample: 04ABEC
+        is_stateless:
+            description:
+                - A stateless rule allows traffic in one direction. Remember to add a corresponding
+                  stateless rule in the other direction if you need to support bidirectional traffic. For
+                  example, if egress traffic allows TCP destination port 80, there should be an ingress
+                  rule to allow TCP source port 80. Defaults to false, which means the rule is stateful
+                  and a corresponding rule is not necessary for bidirectional traffic.
+            returned: on success
+            type: bool
+            sample: true
+        is_valid:
+            description:
+                - Whether the rule is valid. The value is `True` when the rule is first created. If
+                  the rule's `source` or `destination` is a network security group, the value changes to
+                  `False` if that network security group is deleted.
+            returned: on success
+            type: bool
+            sample: true
+        protocol:
+            description:
+                - "The transport protocol. Specify either `all` or an IPv4 protocol number as
+                  defined in
+                  L(Protocol Numbers,http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                  Options are supported only for ICMP (\\"1\\"), TCP (\\"6\\"), UDP (\\"17\\"), and ICMPv6 (\\"58\\")."
+            returned: on success
+            type: string
+            sample: protocol_example
+        source:
+            description:
+                - Conceptually, this is the range of IP addresses that a packet coming into the instance
+                  can come from.
+                - "Allowed values:"
+                - " * An IP address range in CIDR notation. For example: `192.168.1.0/24`"
+                - " * The `cidrBlock` value for a L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/), if you're
+                      setting up a security rule for traffic coming from a particular `Service` through
+                      a service gateway. For example: `oci-phx-objectstorage`."
+                - " * The OCID of a L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/) in the same
+                      VCN. The value can be the NSG that the rule belongs to if the rule's intent is to control
+                      traffic between VNICs in the same NSG."
+            returned: on success
+            type: string
+            sample: source_example
+        source_type:
+            description:
+                - Type of source for the rule. Required if `direction` = `INGRESS`.
+                - " * `CIDR_BLOCK`: If the rule's `source` is an IP address range in CIDR notation."
+                - " * `SERVICE_CIDR_BLOCK`: If the rule's `source` is the `cidrBlock` value for a
+                      L(Service,https://docs.cloud.oracle.com/#/en/iaas/20160918/Service/) (the rule is for traffic coming from a
+                      particular `Service` through a service gateway)."
+                - " * `NETWORK_SECURITY_GROUP`: If the rule's `source` is the OCID of a
+                      L(NetworkSecurityGroup,https://docs.cloud.oracle.com/#/en/iaas/20160918/NetworkSecurityGroup/)."
+            returned: on success
+            type: string
+            sample: CIDR_BLOCK
+        tcp_options:
+            description:
+                - Optional and valid only for TCP. Use to specify particular destination ports for TCP rules.
+                  If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
+            returned: on success
+            type: complex
+            contains:
+                destination_port_range:
+                    description:
+                        - An inclusive range of allowed destination ports. Use the same number for the min and max
+                          to indicate a single port. Defaults to all ports if not specified.
+                    returned: on success
+                    type: complex
+                    contains:
+                        max:
+                            description:
+                                - The maximum port number. Must not be lower than the minimum port number. To specify
+                                  a single port number, set both the min and max to the same value.
+                            returned: on success
+                            type: int
+                            sample: 56
+                        min:
+                            description:
+                                - The minimum port number. Must not be greater than the maximum port number.
+                            returned: on success
+                            type: int
+                            sample: 56
+                source_port_range:
+                    description:
+                        - An inclusive range of allowed source ports. Use the same number for the min and max to
+                          indicate a single port. Defaults to all ports if not specified.
+                    returned: on success
+                    type: complex
+                    contains:
+                        max:
+                            description:
+                                - The maximum port number. Must not be lower than the minimum port number. To specify
+                                  a single port number, set both the min and max to the same value.
+                            returned: on success
+                            type: int
+                            sample: 56
+                        min:
+                            description:
+                                - The minimum port number. Must not be greater than the maximum port number.
+                            returned: on success
+                            type: int
+                            sample: 56
+        time_created:
+            description:
+                - The date and time the security rule was created. Format defined by RFC3339.
+            returned: on success
+            type: string
+            sample: 2013-10-20T19:20:30+01:00
+        udp_options:
+            description:
+                - Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.
+                  If you specify UDP as the protocol but omit this object, then all destination ports are allowed.
+            returned: on success
+            type: complex
+            contains:
+                destination_port_range:
+                    description:
+                        - An inclusive range of allowed destination ports. Use the same number for the min and max
+                          to indicate a single port. Defaults to all ports if not specified.
+                    returned: on success
+                    type: complex
+                    contains:
+                        max:
+                            description:
+                                - The maximum port number. Must not be lower than the minimum port number. To specify
+                                  a single port number, set both the min and max to the same value.
+                            returned: on success
+                            type: int
+                            sample: 56
+                        min:
+                            description:
+                                - The minimum port number. Must not be greater than the maximum port number.
+                            returned: on success
+                            type: int
+                            sample: 56
+                source_port_range:
+                    description:
+                        - An inclusive range of allowed source ports. Use the same number for the min and max to
+                          indicate a single port. Defaults to all ports if not specified.
+                    returned: on success
+                    type: complex
+                    contains:
+                        max:
+                            description:
+                                - The maximum port number. Must not be lower than the minimum port number. To specify
+                                  a single port number, set both the min and max to the same value.
+                            returned: on success
+                            type: int
+                            sample: 56
+                        min:
+                            description:
+                                - The minimum port number. Must not be greater than the maximum port number.
+                            returned: on success
+                            type: int
+                            sample: 56
+    sample: [{
+        "description": "description_example",
+        "destination": "destination_example",
+        "destination_type": "CIDR_BLOCK",
+        "direction": "EGRESS",
+        "icmp_options": {
+            "code": 56,
+            "type": 56
+        },
+        "id": "04ABEC",
+        "is_stateless": true,
+        "is_valid": true,
+        "protocol": "protocol_example",
+        "source": "source_example",
+        "source_type": "CIDR_BLOCK",
+        "tcp_options": {
+            "destination_port_range": {
+                "max": 56,
+                "min": 56
+            },
+            "source_port_range": {
+                "max": 56,
+                "min": 56
+            }
+        },
+        "time_created": "2013-10-20T19:20:30+01:00",
+        "udp_options": {
+            "destination_port_range": {
+                "max": 56,
+                "min": 56
+            },
+            "source_port_range": {
+                "max": 56,
+                "min": 56
+            }
+        }
+    }]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle.oci_resource_utils import (
+    OCIResourceFactsHelperBase,
+    get_custom_class,
+)
+
+try:
+    from oci.core import VirtualNetworkClient
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+class SecurityRuleFactsHelperGen(OCIResourceFactsHelperBase):
+    """Supported operations: list"""
+
+    def get_required_params_for_list(self):
+        return ["network_security_group_id"]
+
+    def list_resources(self):
+        optional_list_method_params = ["direction", "sort_by", "sort_order"]
+        optional_kwargs = dict(
+            (param, self.module.params[param])
+            for param in optional_list_method_params
+            if self.module.params.get(param) is not None
+        )
+        return oci_common_utils.list_all_resources(
+            self.client.list_network_security_group_security_rules,
+            network_security_group_id=self.module.params.get(
+                "network_security_group_id"
+            ),
+            **optional_kwargs
+        )
+
+
+SecurityRuleFactsHelperCustom = get_custom_class("SecurityRuleFactsHelperCustom")
+
+
+class ResourceFactsHelper(SecurityRuleFactsHelperCustom, SecurityRuleFactsHelperGen):
+    pass
+
+
+def main():
+    module_args = oci_common_utils.get_common_arg_spec()
+    module_args.update(
+        dict(
+            network_security_group_id=dict(type="str", required=True),
+            direction=dict(type="str", choices=["EGRESS", "INGRESS"]),
+            sort_by=dict(type="str", choices=["TIMECREATED"]),
+            sort_order=dict(type="str", choices=["ASC", "DESC"]),
+        )
+    )
+
+    module = AnsibleModule(argument_spec=module_args)
+
+    if not HAS_OCI_PY_SDK:
+        module.fail_json(msg="oci python sdk required for this module.")
+
+    resource_facts_helper = ResourceFactsHelper(
+        module=module,
+        resource_type="security_rule",
+        service_client_class=VirtualNetworkClient,
+        namespace="core",
+    )
+
+    result = []
+
+    if resource_facts_helper.is_get():
+        result = [resource_facts_helper.get()]
+    elif resource_facts_helper.is_list():
+        result = resource_facts_helper.list()
+    else:
+        resource_facts_helper.fail()
+
+    module.exit_json(security_rules=result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/oci_vcn.py
+++ b/library/oci_vcn.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -251,7 +252,7 @@ vcn:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -276,6 +277,9 @@ class VcnHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("vcn_id")
+
+    def get_get_fn(self):
+        return self.client.get_vcn
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -310,8 +314,16 @@ class VcnHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.create_vcn, create_vcn_details=create_details
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_vcn,
+            call_fn_args=(),
+            call_fn_kwargs=dict(create_vcn_details=create_details),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def get_update_model_class(self):
@@ -319,15 +331,32 @@ class VcnHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_vcn,
-            vcn_id=self.module.params.get("vcn_id"),
-            update_vcn_details=update_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_vcn,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                vcn_id=self.module.params.get("vcn_id"),
+                update_vcn_details=update_details,
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_active_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_vcn, vcn_id=self.module.params.get("vcn_id")
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_vcn,
+            call_fn_args=(),
+            call_fn_kwargs=dict(vcn_id=self.module.params.get("vcn_id")),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_resource_terminated_states(),
         )
 
 
@@ -361,7 +390,10 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_helper = ResourceHelper(
-        module=module, resource_type="vcn", service_client_class=VirtualNetworkClient
+        module=module,
+        resource_type="vcn",
+        service_client_class=VirtualNetworkClient,
+        namespace="core",
     )
 
     result = dict(changed=False)

--- a/library/oci_vcn_facts.py
+++ b/library/oci_vcn_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -284,13 +285,16 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_facts_helper = ResourceFactsHelper(
-        module=module, resource_type="vcn", service_client_class=VirtualNetworkClient
+        module=module,
+        resource_type="vcn",
+        service_client_class=VirtualNetworkClient,
+        namespace="core",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/library/oci_virtual_circuit.py
+++ b/library/oci_virtual_circuit.py
@@ -569,7 +569,10 @@ def update_virtual_circuit(virtual_network_client, existing_virtual_circuit, mod
     if existing_virtual_circuit.type == "PUBLIC":
         remove_assigned_bgp_peering_ips(existing_cross_connect_mappings)
     if input_cross_connect_mappings is not None:
-        cross_connect_mappings, cross_connect_mappings_changed = oci_utils.check_and_return_component_list_difference(
+        (
+            cross_connect_mappings,
+            cross_connect_mappings_changed,
+        ) = oci_utils.check_and_return_component_list_difference(
             input_cross_connect_mappings,
             existing_cross_connect_mappings,
             purge_cross_connect_mappings,

--- a/library/oci_vnic.py
+++ b/library/oci_vnic.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2017, 2018, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2019, Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
@@ -34,6 +34,11 @@ options:
         description: A user-friendly name for the VNIC. Does not have to be unique, and it is changeable.
         required: false
         aliases: ['display_name']
+  nsg_ids:
+        description: A list of the OCIDs of the network security groups (NSGs) to add the VNIC to.
+                     Setting this as an empty array removes the VNIC from all network security groups.
+                     For more information about NSGs, see
+                     L(NetworkSecurityGroup, https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/NetworkSecurityGroup/).
   skip_source_dest_check:
         description: Determines whether the source/destination check is disabled on the VNIC. Defaults to false, which
                      means the check is performed.
@@ -80,6 +85,7 @@ vnic:
         "is_primary": false,
         "lifecycle_state": "AVAILABLE",
         "mac_address": "00:00:17:00:BC:6A",
+        "nsg_ids": ["ocid1.networksecuritygroup.oc1.iad.aaaaaaaas5tfvdhvt6sfam3wfzarw"],
         "private_ip": "10.0.0.11",
         "public_ip": null,
         "skip_source_dest_check": false,
@@ -125,6 +131,7 @@ def main():
             name=dict(type="str", required=False, aliases=["display_name"]),
             vnic_id=dict(type="str", required=False, aliases=["id"]),
             hostname_label=dict(type="str", required=False),
+            nsg_ids=dict(type="list", required=False),
             skip_source_dest_check=dict(type="bool", required=False, default=False),
             state=dict(
                 type="str", required=False, default="present", choices=["present"]
@@ -160,6 +167,7 @@ def main():
                 uvd.skip_source_dest_check = skip_source_dest_check
                 uvd.hostname_label = hostname_label
                 uvd.display_name = name
+                uvd.nsg_ids = module.params.get("nsg_ids", None)
 
                 oci_utils.call_with_backoff(
                     virtnetwork_client.update_vnic, vnic_id=id, update_vnic_details=uvd

--- a/library/oci_vnic_attachment.py
+++ b/library/oci_vnic_attachment.py
@@ -75,6 +75,10 @@ options:
             display_name:
                 description: A user-friendly name for the VNIC. Does not have to be unique.
                 required: false
+            nsg_ids:
+                description: A list of the OCIDs of the network security groups (NSGs) to add the VNIC to.
+                             For more information about NSGs, see NetworkSecurityGroup L(NetworkSecurityGroup,
+                             https://docs.cloud.oracle.com/iaas/api/#/en/iaas/20160918/NetworkSecurityGroup/).
             private_ip:
                 description: The private IP to assign to the VNIC. Must be an available IP address
                              within the subnet's CIDR. If you don't specify a value, Oracle
@@ -229,6 +233,7 @@ def get_vnic_details(module):
     cvd.subnet_id = vnic_details["subnet_id"]
     cvd.defined_tags = vnic_details.get("defined_tags", None)
     cvd.freeform_tags = vnic_details.get("freeform_tags", None)
+    cvd.nsg_ids = vnic_details.get("nsg_ids", None)
     return cvd
 
 

--- a/library/oci_volume_attachment.py
+++ b/library/oci_volume_attachment.py
@@ -24,40 +24,51 @@ description:
 version_added: "2.5"
 options:
     instance_id:
-        description: The OCID of the instance. Required to attach a volume to an instance with I(state=present).
+        description:
+            - The OCID of the instance. Required to attach a volume to an instance with I(state=present).
         required: false
     is_read_only:
-        description: Whether the attachment was created in read-only mode.
+        description:
+            - Whether the attachment was created in read-only mode.
         required: false
         default: false
         type: bool
     state:
-        description: Use I(state=present) to attach a volume to an instance. Use I(state=absent) to detach a volume from
+        description:
+            - Use I(state=present) to attach a volume to an instance. Use I(state=absent) to detach a volume from
                      an instance.
         required: false
         default: present
         choices: ['present', 'absent']
     type:
-        description: The type of volume. Required to attach a volume to an instance with I(state=present).
+        description:
+            - The type of volume. Required to attach a volume to an instance with I(state=present).
         required: false
         choices: ['iscsi', 'paravirtualized']
     use_chap:
-        description: Whether to use CHAP authentication for the volume attachment.
+        description:
+            - Whether to use CHAP authentication for the volume attachment.
         required: false
         default: false
         type: bool
     volume_id:
-        description: The OCID of the volume. Required to attach a volume to an instance with I(state=present).
+        description:
+            - The OCID of the volume. Required to attach a volume to an instance with I(state=present).
         required: false
     volume_attachment_id:
-        description: The OCID of the volume attachment. Required to detach a volume from an instance with
+        description:
+            - The OCID of the volume attachment. Required to detach a volume from an instance with
                      I(state=absent).
         required: False
         aliases: [ 'id' ]
     display_name:
-        description: A user-friendly name. Does not have to be unique, and it cannot be changed. Avoid entering
+        description:
+            - A user-friendly name. Does not have to be unique, and it cannot be changed. Avoid entering
                      confidential information.
         required: false
+    device:
+        description:
+            - The device name.
 author: "Rohit Chaware (@rohitChaware)"
 extends_documentation_fragment: [ oracle, oracle_wait_options ]
 """
@@ -77,34 +88,160 @@ EXAMPLES = """
 
 RETURN = """
 volume_attachment:
-    description: Information about the volume attachment
-    returned: On successful attach operation
-    type: dict
+    description:
+        - Details of the VolumeAttachment resource acted upon by the current operation
+    returned: on success
+    type: complex
+    contains:
+        attachment_type:
+            description:
+                - The type of volume attachment.
+            returned: on success
+            type: string
+            sample: attachment_type_example
+        availability_domain:
+            description:
+                - The availability domain of an instance.
+                - "Example: `Uocm:PHX-AD-1`"
+            returned: on success
+            type: string
+            sample: Uocm:PHX-AD-1
+        compartment_id:
+            description:
+                - The OCID of the compartment.
+            returned: on success
+            type: string
+            sample: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
+        device:
+            description:
+                - The device name.
+            returned: on success
+            type: string
+            sample: /dev/oracleoci/oraclevdb
+        display_name:
+            description:
+                - A user-friendly name. Does not have to be unique, and it cannot be changed.
+                  Avoid entering confidential information.
+                - "Example: `My volume attachment`"
+            returned: on success
+            type: string
+            sample: My volume attachment
+        id:
+            description:
+                - The OCID of the volume attachment.
+            returned: on success
+            type: string
+            sample: ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx
+        instance_id:
+            description:
+                - The OCID of the instance the volume is attached to.
+            returned: on success
+            type: string
+            sample: ocid1.instance.oc1..xxxxxxEXAMPLExxxxxx
+        is_read_only:
+            description:
+                - Whether the attachment was created in read-only mode.
+            returned: on success
+            type: bool
+            sample: true
+        is_shareable:
+            description:
+                - Whether the attachment should be created in shareable mode. If an attachment is created in shareable mode, then other instances can attach the
+                  same volume, provided that they also create their attachments in shareable mode. Only certain volume types can be attached in shareable mode.
+                  Defaults to false if not specified.
+            returned: on success
+            type: bool
+            sample: true
+        lifecycle_state:
+            description:
+                - The current state of the volume attachment.
+            returned: on success
+            type: string
+            sample: ATTACHING
+        time_created:
+            description:
+                - The date and time the volume was created, in the format defined by RFC3339.
+                - "Example: `2016-08-25T21:10:29.600Z`"
+            returned: on success
+            type: string
+            sample: 2016-08-25T21:10:29.600Z
+        volume_id:
+            description:
+                - The OCID of the volume.
+            returned: on success
+            type: string
+            sample: ocid1.volume.oc1..xxxxxxEXAMPLExxxxxx
+        is_pv_encryption_in_transit_enabled:
+            description:
+                - Whether in-transit encryption for the data volume's paravirtualized attachment is enabled or not.
+            returned: on success
+            type: bool
+            sample: true
+        chap_secret:
+            description:
+                - "The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name.
+                  (Also called the \\"CHAP password\\".)"
+                - "Example: `d6866c0d-298b-48ba-95af-309b4faux45e`"
+            returned: on success
+            type: string
+            sample: d6866c0d-298b-48ba-95af-309b4faux45e
+        chap_username:
+            description:
+                - The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.
+                - "Example: `ocid1.volume.oc1.phx.abyhqljrgvttnlx73nmrwfaux7kcvzfs3s66izvxf2h4lgvyndsdsnoiwr5q`"
+            returned: on success
+            type: string
+            sample: ocid1.volume.oc1.phx.abyhqljrgvttnlx73nmrwfaux7kcvzfs3s66izvxf2h4lgvyndsdsnoiwr5q
+        ipv4:
+            description:
+                - The volume's iSCSI IP address.
+                - "Example: `169.254.0.2`"
+            returned: on success
+            type: string
+            sample: 169.254.0.2
+        iqn:
+            description:
+                - The target volume's iSCSI Qualified Name in the format defined by RFC 3720.
+                - "Example: `iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9`"
+            returned: on success
+            type: string
+            sample: iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9
+        port:
+            description:
+                - The volume's iSCSI port.
+                - "Example: `3260`"
+            returned: on success
+            type: int
+            sample: 3260
     sample: {
-                "attachment_type": "iscsi",
-                "availability_domain": "BnQb:PHX-AD-1",
-                "chap_secret": null,
-                "chap_username": null,
-                "compartment_id": "ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
-                "display_name": "ansible_volume_attachment",
-                "id": "ocid1.volumeattachment.oc1.phx.xxxxxEXAMPLExxxxx",
-                "instance_id": "ocid1.instance.oc1.phx.xxxxxEXAMPLExxxxx",
-                "ipv4": "169.254.2.2",
-                "iqn": "iqn.2015-12.com.oracleiaas:472a085d-41a9-4c18-ae7d-dea5b296dad3",
-                "lifecycle_state": "ATTACHED",
-                "port": 3260,
-                "time_created": "2017-11-23T11:17:50.139000+00:00",
-                "volume_id": "ocid1.volume.oc1.phx.xxxxxEXAMPLExxxxx",
-                "iscsi_attach_commands": [
-                    "sudo iscsiadm -m node -o new -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260",
-                    "sudo iscsiadm -m node -o update -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -n node.startup -v automatic",
-                    "sudo iscsiadm -m node -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260 -l"
-                ],
-                "iscsi_detach_commands": [
-                    "sudo iscsiadm -m node -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260 -u",
-                    "sudo iscsiadm -m node -o delete -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328"
-                ],
-            }
+        "attachment_type": "attachment_type_example",
+        "availability_domain": "Uocm:PHX-AD-1",
+        "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
+        "device": "/dev/oracleoci/oraclevdb",
+        "display_name": "My volume attachment",
+        "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
+        "instance_id": "ocid1.instance.oc1..xxxxxxEXAMPLExxxxxx",
+        "is_read_only": true,
+        "is_shareable": true,
+        "lifecycle_state": "ATTACHING",
+        "time_created": "2016-08-25T21:10:29.600Z",
+        "volume_id": "ocid1.volume.oc1..xxxxxxEXAMPLExxxxxx",
+        "is_pv_encryption_in_transit_enabled": true,
+        "chap_secret": "d6866c0d-298b-48ba-95af-309b4faux45e",
+        "chap_username": "ocid1.volume.oc1.phx.abyhqljrgvttnlx73nmrwfaux7kcvzfs3s66izvxf2h4lgvyndsdsnoiwr5q",
+        "ipv4": "169.254.0.2",
+        "iqn": "iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9",
+        "port": 3260,
+        "iscsi_attach_commands": [
+            "sudo iscsiadm -m node -o new -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260",
+            "sudo iscsiadm -m node -o update -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -n node.startup -v automatic",
+            "sudo iscsiadm -m node -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260 -l"
+        ],
+        "iscsi_detach_commands": [
+            "sudo iscsiadm -m node -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328 -p 169.254.2.2:3260 -u",
+            "sudo iscsiadm -m node -o delete -T iqn.2015-12.com.oracleiaas:1edac499-4d1b-4451-ba52-b803d0fb7328"
+        ],
+    }
 """
 
 from ansible.module_utils.basic import AnsibleModule
@@ -176,6 +313,7 @@ def main():
             volume_id=dict(type="str", required=False),
             volume_attachment_id=dict(type="str", required=False, aliases=["id"]),
             display_name=dict(type="str", required=False),
+            device=dict(type="str"),
         )
     )
 

--- a/library/oci_volume_backup_actions.py
+++ b/library/oci_volume_backup_actions.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -77,12 +78,12 @@ volume_backup:
             sample: ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx
         defined_tags:
             description:
-                - Defined tags for this resource. Each key is predefined and scoped to a namespace.
-                  For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                - Defined tags for this resource. Each key is predefined and scoped to a
+                  namespace. For more information, see L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
                 - "Example: `{\\"Operations\\": {\\"CostCenter\\": \\"42\\"}}`"
             returned: on success
             type: dict
-            sample: {Operations: {CostCenter: US}}
+            sample: {'Operations': {'CostCenter': 'US'}}
         display_name:
             description:
                 - A user-friendly name for the volume backup. Does not have to be unique and it's changeable.
@@ -103,12 +104,12 @@ volume_backup:
         freeform_tags:
             description:
                 - Free-form tags for this resource. Each tag is a simple key-value pair with no
-                  predefined name, type, or namespace. For more information, see
-                  L(Resource Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+                  predefined name, type, or namespace. For more information, see L(Resource
+                  Tags,https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
                 - "Example: `{\\"Department\\": \\"Finance\\"}`"
             returned: on success
             type: dict
-            sample: {Department: Finance}
+            sample: {'Department': 'Finance'}
         id:
             description:
                 - The OCID of the volume backup.
@@ -188,10 +189,10 @@ volume_backup:
             sample: ocid1.volume.oc1..xxxxxxEXAMPLExxxxxx
     sample: {
         "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
-        "defined_tags": {Operations: {CostCenter: US}},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}},
         "display_name": "display_name_example",
         "expiration_time": "2013-10-20T19:20:30+01:00",
-        "freeform_tags": {Department: Finance},
+        "freeform_tags": {'Department': 'Finance'},
         "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
         "lifecycle_state": "CREATING",
         "size_in_gbs": 56,
@@ -208,9 +209,9 @@ volume_backup:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
-    OCIResourceHelperBase,
+    OCIActionsHelperBase,
     get_custom_class,
     convert_input_data_to_model_class,
 )
@@ -224,8 +225,11 @@ except ImportError:
     HAS_OCI_PY_SDK = False
 
 
-class VolumeBackupActionsHelperGen(OCIResourceHelperBase):
-    """Supported actions: copy"""
+class VolumeBackupActionsHelperGen(OCIActionsHelperBase):
+    """
+    Supported actions:
+        copy
+    """
 
     @staticmethod
     def get_module_resource_id_param():
@@ -233,6 +237,9 @@ class VolumeBackupActionsHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("volume_backup_id")
+
+    def get_get_fn(self):
+        return self.client.get_volume_backup
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -244,10 +251,22 @@ class VolumeBackupActionsHelperGen(OCIResourceHelperBase):
         action_details = convert_input_data_to_model_class(
             self.module.params, CopyVolumeBackupDetails
         )
-        return oci_common_utils.call_with_backoff(
-            self.client.copy_volume_backup,
-            volume_backup_id=self.module.params.get("volume_backup_id"),
-            copy_volume_backup_details=action_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.copy_volume_backup,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                volume_backup_id=self.module.params.get("volume_backup_id"),
+                copy_volume_backup_details=action_details,
+            ),
+            waiter_type=oci_wait_utils.LIFECYCLE_STATE_WAITER_KEY,
+            operation="{0}_{1}".format(
+                self.module.params.get("action").upper(),
+                oci_common_utils.ACTION_OPERATION_KEY,
+            ),
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or self.get_action_desired_states(self.module.params.get("action")),
         )
 
 
@@ -280,6 +299,7 @@ def main():
         module=module,
         resource_type="volume_backup",
         service_client_class=BlockstorageClient,
+        namespace="core",
     )
 
     result = resource_helper.perform_action(module.params.get("action"))

--- a/library/oci_volume_backup_policy_facts.py
+++ b/library/oci_volume_backup_policy_facts.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates.
 # This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
+
 
 from __future__ import absolute_import, division, print_function
 
@@ -18,159 +20,184 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: oci_volume_backup_policy_facts
-short_description: Retrieve information of volume backup policies in OCI Block Volume service
+short_description: Fetches details about one or multiple VolumeBackupPolicy resources in Oracle Cloud Infrastructure
 description:
-    - This module retrieves information of the specified volume backup policy or all volume backup policies available
-      to the caller.
+    - Fetches details about one or multiple VolumeBackupPolicy resources in Oracle Cloud Infrastructure
+    - Lists all volume backup policies available to the caller.
+    - If I(policy_id) is specified, the details of a single VolumeBackupPolicy will be returned.
 version_added: "2.5"
 options:
     policy_id:
-        description: The OCID of the volume backup policy.
-        required: false
-        aliases: ['id']
-author: "Rohit Chaware (@rohitChaware)"
+        description:
+            - The OCID of the volume backup policy.
+            - Required to get a specific volume_backup_policy.
+        aliases: ["id"]
+author:
+    - Manoj Meda (@manojmeda)
+    - Mike Ross (@mross22)
+    - Nabeel Al-Saber (@nalsaber)
 extends_documentation_fragment: [ oracle, oracle_display_name_option ]
 """
 
 EXAMPLES = """
-- name: Get information of a volume backup policy
+- name: List volume_backup_policies
   oci_volume_backup_policy_facts:
-    id: ocid1.volumebackuppolicy.oc1..xxxxxEXAMPLExxxxx
 
-- name: Get information of all available volume backup policies
-  oci_volume_backup_policy_assignment_facts:
+- name: Get a specific volume_backup_policy
+  oci_volume_backup_policy_facts:
+    policy_id: ocid1.policy.oc1..xxxxxxEXAMPLExxxxxx
+
 """
 
 RETURN = """
-volume_backup_polices:
-    description: List of volume backup policies
+volume_backup_policies:
+    description:
+        - List of VolumeBackupPolicy resources
     returned: on success
     type: complex
     contains:
         display_name:
-            description: A user-friendly name for the volume backup policy. Does not have to be unique and it's
-                         changeable. Avoid entering confidential information.
-            returned: always
+            description:
+                - A user-friendly name for the volume backup policy. Does not have to be unique and it's changeable.
+                  Avoid entering confidential information.
+            returned: on success
             type: string
-            sample: gold
+            sample: display_name_example
         id:
-            description: The OCID of the volume backup policy.
-            returned: always
+            description:
+                - The OCID of the volume backup policy.
+            returned: on success
             type: string
-            sample: ocid1.volumebackuppolicy.oc1..xxxxxEXAMPLExxxxx
+            sample: ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx
         schedules:
-            description: The collection of schedules that this policy will apply.
-            returned: always
-            type: list
-            sample: [
-                {
-                  "backup-type": "INCREMENTAL",
-                  "offset-seconds": 0,
-                  "period": "ONE_DAY",
-                  "retention-seconds": 604800
-                },
-                {
-                  "backup-type": "INCREMENTAL",
-                  "offset-seconds": 0,
-                  "period": "ONE_WEEK",
-                  "retention-seconds": 2419200
-                },
-                {
-                  "backup-type": "INCREMENTAL",
-                  "offset-seconds": 0,
-                  "period": "ONE_MONTH",
-                  "retention-seconds": 31560000
-                },
-                {
-                  "backup-type": "FULL",
-                  "offset-seconds": 0,
-                  "period": "ONE_YEAR",
-                  "retention-seconds": 157680000
-                }
-            ]
+            description:
+                - The collection of schedules that this policy will apply.
+            returned: on success
+            type: complex
+            contains:
+                backup_type:
+                    description:
+                        - The type of backup to create.
+                    returned: on success
+                    type: string
+                    sample: FULL
+                offset_seconds:
+                    description:
+                        - The number of seconds that the backup time should be shifted from the default interval boundaries specified by the period. Backup time
+                          = Frequency start time + Offset.
+                    returned: on success
+                    type: int
+                    sample: 56
+                period:
+                    description:
+                        - How often the backup should occur.
+                    returned: on success
+                    type: string
+                    sample: ONE_HOUR
+                retention_seconds:
+                    description:
+                        - How long, in seconds, backups created by this schedule should be kept until being automatically deleted.
+                    returned: on success
+                    type: int
+                    sample: 56
         time_created:
-            description: The date and time the volume backup policy was created. Format defined by RFC3339.
-            returned: always
+            description:
+                - The date and time the volume backup policy was created. Format defined by RFC3339.
+            returned: on success
             type: string
-            sample: 2017-12-22T15:40:53.219000+00:00
+            sample: 2013-10-20T19:20:30+01:00
     sample: [{
-                "display_name": "silver",
-                "id": "ocid1.volumebackuppolicy.oc1..xxxxxEXAMPLExxxxx",
-                "schedules": [
-                    {
-                        "backup_type": "INCREMENTAL",
-                        "offset_seconds": 0,
-                        "period": "ONE_WEEK",
-                        "retention_seconds": 2419200
-                    },
-                    {
-                        "backup_type": "INCREMENTAL",
-                        "offset_seconds": 0,
-                        "period": "ONE_MONTH",
-                        "retention_seconds": 31560000
-                    },
-                    {
-                        "backup_type": "FULL",
-                        "offset_seconds": 0,
-                        "period": "ONE_YEAR",
-                        "retention_seconds": 157680000
-                    }
-                ],
-                "time_created": "2017-10-01T00:00:00+00:00"
+        "display_name": "display_name_example",
+        "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
+        "schedules": [{
+            "backup_type": "FULL",
+            "offset_seconds": 56,
+            "period": "ONE_HOUR",
+            "retention_seconds": 56
+        }],
+        "time_created": "2013-10-20T19:20:30+01:00"
     }]
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_utils
+from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle.oci_resource_utils import (
+    OCIResourceFactsHelperBase,
+    get_custom_class,
+)
 
 try:
-    from oci.core.blockstorage_client import BlockstorageClient
-    from oci.util import to_dict
-    from oci.exceptions import ServiceError
+    from oci.core import BlockstorageClient
 
     HAS_OCI_PY_SDK = True
 except ImportError:
     HAS_OCI_PY_SDK = False
 
 
-def main():
-    module_args = oci_utils.get_facts_module_arg_spec()
-    module_args.update(dict(policy_id=dict(type="str", required=False, aliases=["id"])))
+class VolumeBackupPolicyFactsHelperGen(OCIResourceFactsHelperBase):
+    """Supported operations: get, list"""
 
-    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+    def get_required_params_for_get(self):
+        return ["policy_id"]
+
+    def get_required_params_for_list(self):
+        return []
+
+    def get_resource(self):
+        return oci_common_utils.call_with_backoff(
+            self.client.get_volume_backup_policy,
+            policy_id=self.module.params.get("policy_id"),
+        )
+
+    def list_resources(self):
+        optional_list_method_params = ["display_name"]
+        optional_kwargs = dict(
+            (param, self.module.params[param])
+            for param in optional_list_method_params
+            if self.module.params.get(param) is not None
+        )
+        return oci_common_utils.list_all_resources(
+            self.client.list_volume_backup_policies, **optional_kwargs
+        )
+
+
+VolumeBackupPolicyFactsHelperCustom = get_custom_class(
+    "VolumeBackupPolicyFactsHelperCustom"
+)
+
+
+class ResourceFactsHelper(
+    VolumeBackupPolicyFactsHelperCustom, VolumeBackupPolicyFactsHelperGen
+):
+    pass
+
+
+def main():
+    module_args = oci_common_utils.get_common_arg_spec()
+    module_args.update(
+        dict(policy_id=dict(aliases=["id"], type="str"), display_name=dict(type="str"))
+    )
+
+    module = AnsibleModule(argument_spec=module_args)
 
     if not HAS_OCI_PY_SDK:
         module.fail_json(msg="oci python sdk required for this module.")
 
-    block_storage_client = oci_utils.create_service_client(module, BlockstorageClient)
+    resource_facts_helper = ResourceFactsHelper(
+        module=module,
+        resource_type="volume_backup_policy",
+        service_client_class=BlockstorageClient,
+        namespace="core",
+    )
 
-    policy_id = module.params["policy_id"]
+    result = []
 
-    try:
-        if policy_id:
-            result = [
-                to_dict(
-                    oci_utils.call_with_backoff(
-                        block_storage_client.get_volume_backup_policy,
-                        policy_id=policy_id,
-                    ).data
-                )
-            ]
-        else:
-            optional_list_method_params = ["display_name"]
-            optional_kwargs = dict(
-                (param, module.params[param])
-                for param in optional_list_method_params
-                if module.params.get(param) is not None
-            )
-            result = to_dict(
-                oci_utils.call_with_backoff(
-                    block_storage_client.list_volume_backup_policies, **optional_kwargs
-                ).data
-            )
-
-    except ServiceError as ex:
-        module.fail_json(msg=ex.message)
+    if resource_facts_helper.is_get():
+        result = [resource_facts_helper.get()]
+    elif resource_facts_helper.is_list():
+        result = resource_facts_helper.list()
+    else:
+        resource_facts_helper.fail()
 
     module.exit_json(volume_backup_policies=result)
 

--- a/library/oci_waas_policy.py
+++ b/library/oci_waas_policy.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -39,7 +40,6 @@ description:
       Identifiers,https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
     - "**Note:** After sending the POST request, the new object's state will temporarily be `CREATING`. Ensure that the resource's state has changed to `ACTIVE`
       before use."
-    - "This resource has the following action operations in the M(oci_waas_policy_actions) module: accept_recommendations."
 version_added: "2.5"
 options:
     compartment_id:
@@ -1750,13 +1750,13 @@ waas_policy:
                 - A simple key-value pair without any defined schema.
             returned: on success
             type: dict
-            sample: {Department: Finance}
+            sample: {'Department': 'Finance'}
         defined_tags:
             description:
                 - A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
             returned: on success
             type: dict
-            sample: {Operations: {CostCenter: US}}
+            sample: {'Operations': {'CostCenter': 'US'}}
     sample: {
         "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
         "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
@@ -1919,13 +1919,13 @@ waas_policy:
                 "addresses": []
             }]
         },
-        "freeform_tags": {Department: Finance},
-        "defined_tags": {Operations: {CostCenter: US}}
+        "freeform_tags": {'Department': 'Finance'},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}}
     }
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.oracle import oci_common_utils
+from ansible.module_utils.oracle import oci_common_utils, oci_wait_utils
 from ansible.module_utils.oracle.oci_resource_utils import (
     OCIResourceHelperBase,
     get_custom_class,
@@ -1950,6 +1950,9 @@ class WaasPolicyHelperGen(OCIResourceHelperBase):
 
     def get_module_resource_id(self):
         return self.module.params.get("waas_policy_id")
+
+    def get_get_fn(self):
+        return self.client.get_waas_policy
 
     def get_resource(self):
         return oci_common_utils.call_with_backoff(
@@ -1987,8 +1990,16 @@ class WaasPolicyHelperGen(OCIResourceHelperBase):
 
     def create_resource(self):
         create_details = self.get_create_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.create_waas_policy, create_waas_policy_details=create_details
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.create_waas_policy,
+            call_fn_args=(),
+            call_fn_kwargs=dict(create_waas_policy_details=create_details),
+            waiter_type=oci_wait_utils.WORK_REQUEST_WAITER_KEY,
+            operation=oci_common_utils.CREATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_work_request_completed_states(),
         )
 
     def get_update_model_class(self):
@@ -1996,16 +2007,34 @@ class WaasPolicyHelperGen(OCIResourceHelperBase):
 
     def update_resource(self):
         update_details = self.get_update_model()
-        return oci_common_utils.call_with_backoff(
-            self.client.update_waas_policy,
-            waas_policy_id=self.module.params.get("waas_policy_id"),
-            update_waas_policy_details=update_details,
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.update_waas_policy,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                waas_policy_id=self.module.params.get("waas_policy_id"),
+                update_waas_policy_details=update_details,
+            ),
+            waiter_type=oci_wait_utils.WORK_REQUEST_WAITER_KEY,
+            operation=oci_common_utils.UPDATE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_work_request_completed_states(),
         )
 
     def delete_resource(self):
-        return oci_common_utils.call_with_backoff(
-            self.client.delete_waas_policy,
-            waas_policy_id=self.module.params.get("waas_policy_id"),
+        return oci_wait_utils.call_and_wait(
+            call_fn=self.client.delete_waas_policy,
+            call_fn_args=(),
+            call_fn_kwargs=dict(
+                waas_policy_id=self.module.params.get("waas_policy_id")
+            ),
+            waiter_type=oci_wait_utils.WORK_REQUEST_WAITER_KEY,
+            operation=oci_common_utils.DELETE_OPERATION_KEY,
+            waiter_client=self.client,
+            resource_helper=self,
+            wait_for_states=self.module.params.get("wait_until")
+            or oci_common_utils.get_work_request_completed_states(),
         )
 
 
@@ -2326,7 +2355,10 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_helper = ResourceHelper(
-        module=module, resource_type="waas_policy", service_client_class=WaasClient
+        module=module,
+        resource_type="waas_policy",
+        service_client_class=WaasClient,
+        namespace="waas",
     )
 
     result = dict(changed=False)

--- a/library/oci_waas_policy_facts.py
+++ b/library/oci_waas_policy_facts.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Apache License v2.0
 # See LICENSE.TXT for details.
+# GENERATED FILE - DO NOT EDIT - MANUAL CHANGES WILL BE OVERWRITTEN
 
 
 from __future__ import absolute_import, division, print_function
@@ -1046,13 +1047,13 @@ waas_policies:
                 - A simple key-value pair without any defined schema.
             returned: on success
             type: dict
-            sample: {Department: Finance}
+            sample: {'Department': 'Finance'}
         defined_tags:
             description:
                 - A key-value pair with a defined schema that restricts the values of tags. These predefined keys are scoped to namespaces.
             returned: on success
             type: dict
-            sample: {Operations: {CostCenter: US}}
+            sample: {'Operations': {'CostCenter': 'US'}}
     sample: [{
         "id": "ocid1.resource.oc1..xxxxxxEXAMPLExxxxxx",
         "compartment_id": "ocid1.compartment.oc1..xxxxxxEXAMPLExxxxxx",
@@ -1215,8 +1216,8 @@ waas_policies:
                 "addresses": []
             }]
         },
-        "freeform_tags": {Department: Finance},
-        "defined_tags": {Operations: {CostCenter: US}}
+        "freeform_tags": {'Department': 'Finance'},
+        "defined_tags": {'Operations': {'CostCenter': 'US'}}
     }]
 """
 
@@ -1301,13 +1302,16 @@ def main():
         module.fail_json(msg="oci python sdk required for this module.")
 
     resource_facts_helper = ResourceFactsHelper(
-        module=module, resource_type="waas_policy", service_client_class=WaasClient
+        module=module,
+        resource_type="waas_policy",
+        service_client_class=WaasClient,
+        namespace="waas",
     )
 
     result = []
 
     if resource_facts_helper.is_get():
-        result = resource_facts_helper.get()
+        result = [resource_facts_helper.get()]
     elif resource_facts_helper.is_list():
         result = resource_facts_helper.list()
     else:

--- a/module_utils/oracle/actionhelpers/__init__.py
+++ b/module_utils/oracle/actionhelpers/__init__.py
@@ -4,6 +4,4 @@
 # Apache License v2.0
 # See LICENSE.TXT for details.
 
-from ansible.module_utils.oracle.actionhelpers import (
-    oci_object_storage_bucket_actions_helper,
-)
+from ansible.module_utils.oracle.actionhelpers import oci_security_rule_actions_helper

--- a/module_utils/oracle/actionhelpers/oci_security_rule_actions_helper.py
+++ b/module_utils/oracle/actionhelpers/oci_security_rule_actions_helper.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible.module_utils.oracle import oci_common_utils, oci_utils
+
+
+try:
+    import oci
+    from oci.exceptions import ServiceError, MaximumWaitTimeExceeded
+    from oci.util import to_dict
+    from oci.core.models import (
+        AddedNetworkSecurityGroupSecurityRules,
+        UpdatedNetworkSecurityGroupSecurityRules,
+    )
+    import json
+
+    HAS_OCI_PY_SDK = True
+
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+
+class SecurityRuleActionsHelperCustom:
+    def _add_network_security_group_rules_idempotency_check(self):
+        existing_security_rules = self.list_security_rules()
+        provided_security_rules = self.module.params.get("security_rules", [])
+        provided_security_rules_to_add = []
+
+        existing_security_rules_as_dicts = [
+            to_dict(security_rule) for security_rule in existing_security_rules
+        ]
+
+        for provided_security_rule in provided_security_rules:
+            if not oci_common_utils.is_in_list(
+                existing_security_rules_as_dicts, element=provided_security_rule
+            ):
+                provided_security_rules_to_add.append(provided_security_rule)
+
+        if len(provided_security_rules_to_add) == 0:
+            resource = AddedNetworkSecurityGroupSecurityRules(
+                security_rules=self.list_security_rules()
+            )
+            return oci_common_utils.get_result(
+                changed=False,
+                resource_type=self.resource_type,
+                resource=to_dict(resource),
+            )
+        else:
+            self.module.params["security_rules"] = provided_security_rules_to_add
+
+    def _update_network_security_group_rules_idempotency_check(self):
+        existing_security_rules = self.list_security_rules()
+        provided_security_rules = self.module.params.get("security_rules", [])
+
+        existing_security_rules_as_dicts = [
+            to_dict(security_rule) for security_rule in existing_security_rules
+        ]
+
+        all_rules_to_update_already_exist_and_match = True
+        for provided_security_rule in provided_security_rules:
+            if not oci_common_utils.is_in_list(
+                existing_security_rules_as_dicts, element=provided_security_rule
+            ):
+                all_rules_to_update_already_exist_and_match = False
+
+        if all_rules_to_update_already_exist_and_match:
+            resource = UpdatedNetworkSecurityGroupSecurityRules(
+                security_rules=self.list_security_rules()
+            )
+            return oci_common_utils.get_result(
+                changed=False,
+                resource_type=self.resource_type,
+                resource=to_dict(resource),
+            )
+
+    def _remove_network_security_group_rules_idempotency_check(self):
+        existing_security_rules = self.list_security_rules()
+        provided_security_rule_ids_to_delete = self.module.params.get(
+            "security_rule_ids", []
+        )
+        security_rule_ids_to_delete = []
+        for existing_security_rule in existing_security_rules:
+            if existing_security_rule.id in provided_security_rule_ids_to_delete:
+                security_rule_ids_to_delete.append(existing_security_rule.id)
+
+        if len(security_rule_ids_to_delete) == 0:
+            # RemoveNetworkSecurityGroupSecurityRules returns nothing, but in order to keep return type consistent
+            # across add / remove / delete, we choose to return UpdatedNetworkSecurityGroupSecurityRules with an
+            # empty 'security_rules' list
+            resource = UpdatedNetworkSecurityGroupSecurityRules(
+                security_rules=self.list_security_rules()
+            )
+            return oci_common_utils.get_result(
+                changed=False,
+                resource_type=self.resource_type,
+                resource=to_dict(resource),
+            )
+        else:
+            self.module.params["security_rule_ids"] = security_rule_ids_to_delete
+
+    def perform_action(self, action):
+
+        action_fn = self.get_action_fn(action)
+        if not action_fn:
+            self.module.fail_json(msg="{0} not supported by the module.".format(action))
+
+        # the idempotency checks for these actions are custom since we aren't doing the regular
+        # check for existence, we are checking if a requested resource is present within a list
+        if action == "add_network_security_group_security_rules":
+            action_idempotency_checks_fn = (
+                self._add_network_security_group_rules_idempotency_check
+            )
+            check_mode_response_resource = to_dict(
+                AddedNetworkSecurityGroupSecurityRules(security_rules=[])
+            )
+        elif action == "update_network_security_group_security_rules":
+            action_idempotency_checks_fn = (
+                self._update_network_security_group_rules_idempotency_check
+            )
+            check_mode_response_resource = to_dict(
+                UpdatedNetworkSecurityGroupSecurityRules(security_rules=[])
+            )
+        elif action == "remove_network_security_group_security_rules":
+            action_idempotency_checks_fn = (
+                self._remove_network_security_group_rules_idempotency_check
+            )
+            # RemoveNetworkSecurityGroupSecurityRules returns nothing, but in order to keep return type consistent
+            # across add / remove / delete, we choose to return UpdatedNetworkSecurityGroupSecurityRules with an
+            # empty 'security_rules' list
+            check_mode_response_resource = to_dict(
+                UpdatedNetworkSecurityGroupSecurityRules(security_rules=[])
+            )
+        else:
+            self.module.fail_json(
+                msg="Performing action failed for unrecognized action: {0}".format(
+                    action
+                )
+            )
+
+        result = action_idempotency_checks_fn()
+        if result:
+            return result
+
+        if self.check_mode:
+            return oci_common_utils.get_result(
+                changed=True,
+                resource_type=self.resource_type,
+                resource=check_mode_response_resource,
+            )
+
+        try:
+            actioned_resource = action_fn()
+        except MaximumWaitTimeExceeded as mwtex:
+            self.module.fail_json(msg=str(mwtex))
+        except ServiceError as se:
+            self.module.fail_json(
+                msg="Performing action failed with exception: {0}".format(se.message)
+            )
+        else:
+            # - the individual action operations return the rules that were acted on (except REMOVE which returns nothing)
+            #   to keep consistent with patterns in other modules, we override here to return the current set of all rules
+            # - in order to return the same format as the generated docs for actions operations (result.security_rule.security_rules)
+            #    we use AddedNetworkSecurityGroupSecurityRules here as a wrapper
+            resource = AddedNetworkSecurityGroupSecurityRules(
+                security_rules=self.list_security_rules()
+            )
+            return oci_common_utils.get_result(
+                changed=True,
+                resource_type=self.resource_type,
+                resource=to_dict(resource),
+            )
+
+    def list_security_rules(self):
+        optional_list_method_params = ["direction", "sort_by", "sort_order"]
+        optional_kwargs = dict(
+            (param, self.module.params[param])
+            for param in optional_list_method_params
+            if self.module.params.get(param) is not None
+        )
+        return oci_common_utils.list_all_resources(
+            self.client.list_network_security_group_security_rules,
+            network_security_group_id=self.module.params.get(
+                "network_security_group_id"
+            ),
+            **optional_kwargs
+        )

--- a/module_utils/oracle/oci_wait_utils.py
+++ b/module_utils/oracle/oci_wait_utils.py
@@ -1,0 +1,294 @@
+# Copyright (c) 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible.module_utils.oracle import oci_common_utils
+
+try:
+    import oci
+    from oci.util import to_dict
+
+    HAS_OCI_PY_SDK = True
+except ImportError:
+    HAS_OCI_PY_SDK = False
+
+LIFECYCLE_STATE_WAITER_KEY = "LIFECYCLE_STATE_WAITER"
+WORK_REQUEST_WAITER_KEY = "WORK_REQUEST_WAITER"
+NONE_WAITER_KEY = "NONE_WAITER_KEY"
+
+
+class Waiter:
+    """Interface defining wait method"""
+
+    def wait(self):
+        raise NotImplementedError(
+            "Expected to be implemented by the specific waiter classes."
+        )
+
+
+class BaseWaiter(Waiter):
+    """Base class for various waiters"""
+
+    def __init__(self, client, resource_helper, operation_response, wait_for_states):
+        self.client = client
+        self.operation_response = operation_response
+        self.wait_for_states = wait_for_states
+        self.resource_helper = resource_helper
+
+    def get_initial_response(self):
+        raise NotImplementedError(
+            "Expected to be implemented by the specific waiter classes."
+        )
+
+    def get_evaluate_response_lambda(self):
+        raise NotImplementedError(
+            "Expected to be implemented by the specific waiter classes."
+        )
+
+    def wait(self):
+        if not self.resource_helper.module.params.get("wait"):
+            return self.operation_response
+        wait_response = oci.wait_until(
+            self.client,
+            self.get_initial_response(),
+            evaluate_response=self.get_evaluate_response_lambda(),
+            max_wait_seconds=self.resource_helper.module.params.get(
+                "wait_timeout", oci_common_utils.MAX_WAIT_TIMEOUT_IN_SECONDS
+            ),
+        )
+        return self.get_resource_from_wait_response(wait_response)
+
+    def get_resource_from_wait_response(self, wait_response):
+        raise NotImplementedError(
+            "Expected to be implemented by the specific waiter classes."
+        )
+
+
+class LifecycleStateWaiterBase(BaseWaiter):
+    """Base class for various waiters"""
+
+    def __init__(self, client, resource_helper, operation_response, wait_for_states):
+        self.client = client
+        self.operation_response = operation_response
+        self.wait_for_states = wait_for_states
+        self.resource_helper = resource_helper
+
+    def get_initial_response(self):
+        return self.resource_helper.get_resource()
+
+    def get_evaluate_response_lambda(self):
+        lowered_wait_for_states = [state.lower() for state in self.wait_for_states]
+        return (
+            lambda r: getattr(r.data, "lifecycle_state")
+            and getattr(r.data, "lifecycle_state").lower() in lowered_wait_for_states
+        )
+
+    def get_resource_from_wait_response(self, wait_response):
+        return wait_response.data
+
+
+class LifecycleStateWaiter(LifecycleStateWaiterBase):
+    """Waiter which waits on the lifecycle state of the resource"""
+
+    def __init__(self, client, resource_helper, operation_response, wait_for_states):
+        super(LifecycleStateWaiter, self).__init__(
+            client, resource_helper, operation_response, wait_for_states
+        )
+
+
+class CreateOperationLifecycleStateWaiter(LifecycleStateWaiterBase):
+    """Waiter which waits on the lifecycle state of the resource"""
+
+    def __init__(self, client, resource_helper, operation_response, wait_for_states):
+        super(CreateOperationLifecycleStateWaiter, self).__init__(
+            client, resource_helper, operation_response, wait_for_states
+        )
+
+    def get_initial_response(self):
+        identifier = self.operation_response.data.id
+        if not identifier:
+            self.resource_helper.module.fail_json(
+                "Error getting the resource identifier."
+            )
+        try:
+            id_orig = self.resource_helper.module.params[
+                self.resource_helper.get_module_resource_id_param()
+            ]
+        except NotImplementedError:
+            return self.resource_helper.get_resource()
+        self.resource_helper.module.params[
+            self.resource_helper.get_module_resource_id_param()
+        ] = identifier
+        get_response = self.resource_helper.get_resource()
+        self.resource_helper.module.params[
+            self.resource_helper.get_module_resource_id_param()
+        ] = id_orig
+        return get_response
+
+
+class WorkRequestWaiter(BaseWaiter):
+    """Waiter which waits on the work request"""
+
+    def __init__(self, client, resource_helper, operation_response, wait_for_states):
+        self.client = client
+        self.resource_helper = resource_helper
+        self.operation_response = operation_response
+        self.wait_for_states = wait_for_states
+
+    def get_initial_response(self):
+        return self.client.get_work_request(
+            self.operation_response.headers["opc-work-request-id"]
+        )
+
+    def get_evaluate_response_lambda(self):
+        lowered_wait_for_states = [state.lower() for state in self.wait_for_states]
+        return (
+            lambda r: getattr(r.data, "status")
+            and getattr(r.data, "status").lower() in lowered_wait_for_states
+        )
+
+    def get_resource_from_wait_response(self, wait_response):
+        get_response = self.resource_helper.get_resource()
+        return get_response.data
+
+
+class CreateOperationWorkRequestWaiter(WorkRequestWaiter):
+    """Waiter which waits on the work request"""
+
+    def __init__(self, client, resource_helper, operation_response, wait_for_states):
+        super(CreateOperationWorkRequestWaiter, self).__init__(
+            client, resource_helper, operation_response, wait_for_states
+        )
+
+    def get_resource_from_wait_response(self, wait_response):
+        entity_type = oci_common_utils.get_entity_type(
+            self.resource_helper.resource_type
+        )
+        identifier = None
+        for resource in wait_response.data.resources:
+            if (
+                hasattr(resource, "entity_type")
+                and getattr(resource, "entity_type") == entity_type
+            ):
+                identifier = resource.identifier
+        if not identifier:
+            self.resource_helper.module.fail_json(
+                msg="Could not get the resource identifier from work request response {0}".format(
+                    to_dict(wait_response.data)
+                )
+            )
+        get_response = self.resource_helper.get_get_fn()(identifier)
+        return get_response.data
+
+
+class NoneWaiter(Waiter):
+    """Waiter which does not wait"""
+
+    def __init__(self, client, resource_helper, operation_response, wait_for_states):
+        self.client = client
+        self.resource_helper = resource_helper
+        self.operation_response = operation_response
+        self.wait_for_states = wait_for_states
+
+    def wait(self):
+        return self.operation_response.data
+
+
+class AuditConfigurationLifecycleStateWaiter(LifecycleStateWaiter):
+    def __init__(self, client, resource_helper, operation_response, wait_for_states):
+        super(AuditConfigurationLifecycleStateWaiter, self).__init__(
+            client, resource_helper, operation_response, wait_for_states
+        )
+
+    def get_evaluate_response_lambda(self):
+        # The update operation currently returns a work request id but the AuditClient currently does not support
+        # waiting for the work request. So wait until the configuration is updated by checking the value.
+        return (
+            lambda r: r.data.retention_period_days
+            == self.resource_helper.module.params.get("retention_period_days")
+        )
+
+
+# A map specifying the overrides for the default waiters.
+# Key is a tuple consisting spec name, resource type and the operation and the value is the waiter class.
+# For ex: ("waas", "waas_policy", oci_common_utils.UPDATE_OPERATION_KEY) -> CustomWaasWaiterClass
+_WAITER_OVERRIDE_MAP = {
+    # The audit update operation currently returns a work request id but the AuditClient currently does not support
+    # waiting for the work request. So inject NoneWaiter and customize it to manually wait on the update condition.
+    ("audit", "configuration", oci_common_utils.UPDATE_OPERATION_KEY): NoneWaiter
+}
+
+
+def get_waiter_override(namespace, resource_type, operation):
+    """Return the custom waiter class if any for the resource and operation. Else return None."""
+    waiter_override_key = (namespace, resource_type, operation)
+    if waiter_override_key in _WAITER_OVERRIDE_MAP:
+        return _WAITER_OVERRIDE_MAP.get(waiter_override_key)
+    # check if an override exists for ANY_OPERATION_KEY. This is helpful if we need a custom waiter for all(any)
+    # resource operations
+    waiter_override_key = (namespace, resource_type, oci_common_utils.ANY_OPERATION_KEY)
+    if waiter_override_key in _WAITER_OVERRIDE_MAP:
+        return _WAITER_OVERRIDE_MAP.get(waiter_override_key)
+    return None
+
+
+def get_waiter(
+    waiter_type, operation, client, resource_helper, operation_response, wait_for_states
+):
+    """Return appropriate waiter object based on type and the operation."""
+    # First check if there is any custom override for the waiter class. If exists, use it.
+    waiter_override_class = get_waiter_override(
+        resource_helper.namespace, resource_helper.resource_type, operation
+    )
+    if waiter_override_class:
+        return waiter_override_class(
+            client, resource_helper, operation_response, wait_for_states
+        )
+    if waiter_type == LIFECYCLE_STATE_WAITER_KEY:
+        if operation == oci_common_utils.CREATE_OPERATION_KEY:
+            return CreateOperationLifecycleStateWaiter(
+                client, resource_helper, operation_response, wait_for_states
+            )
+        return LifecycleStateWaiter(
+            client, resource_helper, operation_response, wait_for_states
+        )
+    elif waiter_type == WORK_REQUEST_WAITER_KEY:
+        if operation == oci_common_utils.CREATE_OPERATION_KEY:
+            return CreateOperationWorkRequestWaiter(
+                client, resource_helper, operation_response, wait_for_states
+            )
+        return WorkRequestWaiter(
+            client, resource_helper, operation_response, wait_for_states
+        )
+    return NoneWaiter(client, resource_helper, operation_response, wait_for_states)
+
+
+def call_and_wait(
+    call_fn,
+    call_fn_args,
+    call_fn_kwargs,
+    waiter_type,
+    operation,
+    waiter_client,
+    resource_helper,
+    wait_for_states,
+):
+    """Call the given function and wait until the operation is completed and return the resource."""
+    operation_response = oci_common_utils.call_with_backoff(
+        call_fn, *call_fn_args, **call_fn_kwargs
+    )
+    waiter = get_waiter(
+        waiter_type,
+        operation,
+        waiter_client,
+        resource_helper,
+        operation_response=operation_response,
+        wait_for_states=wait_for_states,
+    )
+    return waiter.wait()

--- a/module_utils/oracle/resourcehelpers/__init__.py
+++ b/module_utils/oracle/resourcehelpers/__init__.py
@@ -7,7 +7,6 @@
 from ansible.module_utils.oracle.resourcehelpers import (
     oci_api_key_helper,
     oci_waas_policy_helper,
-    oci_autonomous_data_warehouse_helper,
     oci_object_lifecycle_policy_helper,
     oci_audit_configuration_helper,
     oci_auto_scaling_configuration_helper,

--- a/module_utils/oracle/resourcehelpers/oci_audit_configuration_helper.py
+++ b/module_utils/oracle/resourcehelpers/oci_audit_configuration_helper.py
@@ -27,9 +27,10 @@ class ConfigurationHelperCustom:
     def is_update(self):
         return True
 
-    def update_wait(self, update_response):
+    def update_resource(self):
         ## The update operation currently returns a work request id but the AuditClient currently does not support
         ## waiting for the work request. So wait until the configuration is updated by checking the value.
+        super(ConfigurationHelperCustom, self).update_resource()
         get_response = self.get_resource()
         waiter_response = oci.wait_until(
             self.client,

--- a/module_utils/oracle/resourcehelpers/oci_object_lifecycle_policy_helper.py
+++ b/module_utils/oracle/resourcehelpers/oci_object_lifecycle_policy_helper.py
@@ -50,7 +50,5 @@ class ObjectLifecyclePolicyHelperCustom:
 
     # override UPDATE to use CREATE underneath because there may be no existing
     # resource to fetch which is fine for CREATE but causes UPDATE to fail
-    def update(self, check_applicable=True, wait_applicable=True):
-        return self.create(
-            check_applicable=check_applicable, wait_applicable=wait_applicable
-        )
+    def update(self):
+        return self.create()

--- a/module_utils/oracle/resourcehelpers/oci_waas_policy_helper.py
+++ b/module_utils/oracle/resourcehelpers/oci_waas_policy_helper.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils.oracle import oci_common_utils, oci_waas_utils
+from ansible.module_utils.oracle import oci_common_utils
 
 
 try:
@@ -30,33 +30,3 @@ class WaasPolicyHelperCustom:
                 WaasPolicyHelperCustom, self
             ).list_resources()
         ]
-
-    def create_wait(self, create_response):
-        work_request_response = self.wait_for_work_request(
-            create_response, oci_common_utils.WORK_REQUEST_COMPLETED_STATES
-        )
-        for work_request_resource in work_request_response.data.resources:
-            if (
-                work_request_resource.entity_type == "waas"
-                and work_request_resource.action_type == "CREATED"
-            ):
-                waas_policy_id = work_request_resource.identifier
-                break
-        if not waas_policy_id:
-            self.module.fail_json(
-                msg="Cound not get the waas policy id from the work request."
-            )
-        waas_policy = oci_common_utils.call_with_backoff(
-            self.client.get_waas_policy, waas_policy_id=waas_policy_id
-        ).data
-        if not waas_policy:
-            self.module.fail_json(
-                "Could not get the waas policy resource after creation."
-            )
-        if waas_policy.lifecycle_state in oci_common_utils.DEAD_STATES:
-            self.module.fail_json(
-                msg="WAAS policy created but in {0} state.".format(
-                    waas_policy.lifecycle_state
-                )
-            )
-        return waas_policy

--- a/samples/compute/always_free_launch_compute_instance/README.md
+++ b/samples/compute/always_free_launch_compute_instance/README.md
@@ -1,0 +1,15 @@
+# Overview
+
+This sample shows how an [Always Free](https://www.oracle.com/cloud/free/) public compute instance can be [launched](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/Tasks/launchinginstance.htm) and [accessed](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/Tasks/accessinginstance.htm) from the internet using SSH, through OCI ansible cloud modules.
+
+The sample 
+- generates a temporary host-specific SSH key-pair
+- specifies the public key from that key-pair to connect to the instance during instance launch and 
+- demonstrates how the newly launched instance can be connected to using SSH.
+
+# Instructions
+
+To run the sample, after ensuring that you have the pre-requisites for OCI ansible cloud modules, please provide values (that are specific to your tenancy) for the following variables in the `vars` section of `sample.yaml`:
+- instance_ad
+- instance_compartment
+- instance_image  # provide an OL image

--- a/samples/compute/always_free_launch_compute_instance/sample.yaml
+++ b/samples/compute/always_free_launch_compute_instance/sample.yaml
@@ -1,0 +1,141 @@
+---
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+- name: Launch a compute instance and connect to it using SSH
+  hosts: localhost
+  vars:
+    # common networking definitions
+    quad_zero_route: "0.0.0.0/0"
+    TCP_protocol: "6"
+    SSH_port: "22"
+
+    vcn_name: "myalwaysfreetestvcn"
+    vcn_cidr_block: "10.0.0.0/16"
+    vcn_dns_label: "alwaysfreevcn"
+
+    ig_name: "myalwaysfreeinternetgatewayformytestvcn"
+
+    route_table_name: "myalwaysfreeroutetable"
+    # route all internet access to our Internet Gateway
+    route_table_rules:
+        - cidr_block: "{{ quad_zero_route }}"
+          network_entity_id: "{{ ig_id }}"
+
+
+    subnet_cidr: "10.0.0.48/28"
+    subnet_name: "myalwaysfreetestsubnet"
+    subnet_dns_label: "myfreesubnet"
+
+    securitylist_name: "myalwaysfreesecuritylist"
+
+    # always free shape
+    instance_shape: "VM.Standard.E2.1.Micro"
+    instance_hostname: "myalwaysfreetestinstance"
+
+    #########################################
+    # Tenancy specific configuration
+    # *Note* - Override the following variables based on your tenancy
+    # or set a valid value for the corresponding environment variable
+    #########################################
+    instance_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
+    # provide an "OL" image
+    # find OL image ocids per region here: https://docs.cloud.oracle.com/iaas/images/image/501c6e22-4dc6-4e99-b045-cae47aae343f/
+    instance_image: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
+
+  tasks:
+    - import_tasks: setup.yaml
+
+    - name: Launch an instance
+      oci_instance:
+        availability_domain: "{{ instance_ad }}"
+        compartment_id: "{{ instance_compartment }}"
+        name: "my_always_free_test_instance"
+        source_details:
+          source_type: image
+          image_id: "{{ instance_image }}"
+        shape: "{{ instance_shape }}"
+        vnic:
+            assign_public_ip: True
+            hostname_label: "{{ instance_hostname }}"
+            subnet_id: "{{ instance_subnet_id }}"
+        metadata:
+            ssh_authorized_keys: "{{ lookup('file',  my_test_public_key ) }}"
+      register: result
+
+    - name: Print instance details
+      debug:
+        msg: "Launched a new instance {{ result }}"
+    - set_fact:
+        instance_id: "{{result.instance.id }}"
+
+    - name: Create a volume
+      oci_volume:
+        availability_domain: "{{ instance_ad }}"
+        compartment_id: "{{ instance_compartment }}"
+        name: my_always_free_test_volume
+        size_in_gbs: 50
+      register: result
+
+    - name: Print volume details
+      debug:
+        msg: "Created a new volume {{ result }}"
+    - set_fact:
+        volume_id: "{{result.volume.id }}"
+
+    - name: Attach volume to new instance
+      oci_volume_attachment:
+        instance_id: "{{ instance_id }}"
+        type: paravirtualized
+        volume_id: "{{ volume_id }}"
+      register: result
+
+    - name: Print volume attachment details
+      debug:
+        msg: "Attached volume to instance {{ result }}"
+    - set_fact:
+        volume_attachment_id: "{{result.volume_attachment.id }}"
+
+    - name: Get the VNIC attachment details of instance
+      oci_vnic_attachment_facts:
+        compartment_id: "{{ instance_compartment }}"
+        instance_id: "{{ instance_id }}"
+      register: result
+
+    - name: Get details of the VNIC
+      oci_vnic_facts:
+        id: "{{ result.vnic_attachments[0].vnic_id }}"
+      register: result
+    - set_fact:
+        instance_public_ip: "{{result.vnic.public_ip}}"
+
+    - name: Print the public ip of the newly launched instance
+      debug:
+        msg: "Public IP of launched instance {{ instance_public_ip }}"
+
+    - name: Wait (upto 5 minutes) for port 22 to become open
+      wait_for:
+        port: 22
+        host: '{{ instance_public_ip }}'
+        state: started
+        delay: 10
+      vars:
+        ansible_connection: local
+
+    - name: Attempt a ssh connection to the newly launced instance
+      # Use "opc" user as this is an OL image
+      # Disable SSH's strict host key checking just for this one command invocation
+      command: ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i {{ temp_certificates_path }}/private_key.pem opc@{{ instance_public_ip }} uname -a
+      retries: 3
+      delay: 5
+      register: result
+      until: result.rc == 0
+
+    - name: Print SSH response from launched instance
+      debug:
+        msg: "SSH response from instance -> {{ result.stdout_lines }}"
+
+    - import_tasks: teardown.yaml

--- a/samples/compute/always_free_launch_compute_instance/setup.yaml
+++ b/samples/compute/always_free_launch_compute_instance/setup.yaml
@@ -1,0 +1,165 @@
+---
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+- name: Check pre-requisites
+  fail:
+    msg: "Environment variable {{item}} not set. Please declare an environment variable with an appropriate value for the sample to work."
+  when: item not in ansible_env
+  with_items:
+    - "SAMPLE_COMPARTMENT_OCID"
+    - "SAMPLE_IMAGE_OCID"
+
+# find the availability domain that is Always Free eligible in this tenancy
+- name: List availbility domains
+  oci_ad_facts:
+    compartment_id: "{{ instance_compartment }}"
+  register: result
+
+- set_fact:
+    availability_domains: "{{ result.availability_domains }}"
+
+- debug:
+    msg: "{{ availability_domains }}"
+
+- name: List shapes in first AD
+  oci_shape_facts:
+    compartment_id: "{{ instance_compartment }}"
+    image_id: "{{ instance_image }}"
+    availability_domain: "{{ availability_domains[0].name }}"
+  register: result
+  when: availability_domains | length > 0
+
+- set_fact:
+    instance_ad: "{{ availability_domains[0].name }}"
+  loop: "{{ result.shapes.shapes }}"
+  when: item.shape == instance_shape and availability_domains | length > 0
+
+- name: List shapes in second AD
+  oci_shape_facts:
+    compartment_id: "{{ instance_compartment }}"
+    image_id: "{{ instance_image }}"
+    availability_domain: "{{ availability_domains[1].name }}"
+  register: result
+  when: availability_domains | length > 1
+
+- set_fact:
+    instance_ad: "{{ availability_domains[1].name }}"
+  loop: "{{ result.shapes.shapes }}"
+  when: item.shape == instance_shape and availability_domains | length > 1
+
+- name: List shapes in third AD
+  oci_shape_facts:
+    compartment_id: "{{ instance_compartment }}"
+    image_id: "{{ instance_image }}"
+    availability_domain: "{{ availability_domains[2].name }}"
+  register: result
+  when: availability_domains | length > 2
+
+- set_fact:
+    instance_ad: "{{ availability_domains[2].name }}"
+  loop: "{{ result.shapes.shapes }}"
+  when: item.shape == instance_shape and availability_domains | length > 2
+
+- name: Create a temporary directory to house a temporary SSH keypair we will later use to connect to instance
+  tempfile:
+    state: directory
+    suffix: cert
+  register: result
+- set_fact:
+    temp_certificates_path: "{{ result.path }}"
+- name: Generate a Private Key
+  openssl_privatekey:
+    path: "{{ temp_certificates_path }}/private_key.pem"
+    type: RSA
+    size: 2048
+- set_fact:
+    my_test_public_key: "{{ temp_certificates_path }}/public_key.pem"
+- name: Generate a Public Key
+  openssl_publickey:
+    path: "{{ my_test_public_key }}"
+    privatekey_path: "{{ temp_certificates_path }}/private_key.pem"
+    format: OpenSSH
+
+- name: Create a VCN
+  oci_vcn:
+    compartment_id: "{{ instance_compartment }}"
+    display_name: "{{ vcn_name }}"
+    cidr_block: "{{ vcn_cidr_block }}"
+    dns_label: "{{ vcn_dns_label }}"
+  register: result
+- set_fact:
+    vcn_id: "{{ result.vcn.id }}"
+
+- name: Create a new Internet Gateway
+  oci_internet_gateway:
+    compartment_id: "{{ instance_compartment }}"
+    vcn_id: "{{ vcn_id }}"
+    name: "{{ ig_name }}"
+    enabled: 'yes'
+    state: 'present'
+  register: result
+- set_fact:
+    ig_id: "{{ result.internet_gateway.id }}"
+
+- name: Create route table to connect internet gateway to the VCN
+  oci_route_table:
+    compartment_id: "{{ instance_compartment }}"
+    vcn_id: "{{ vcn_id }}"
+    name: "{{ route_table_name }}"
+    route_rules: "{{ route_table_rules }}"
+    state: 'present'
+  register: result
+- set_fact:
+    rt_id: "{{ result.route_table.id }}"
+
+# Create a security list for allowing access to public instance
+# Use a jinja2 template of the ingress and egress security rules to generate
+# a templated version of the final rules.
+- name: create ingress rules yaml body
+  template: src=./templates/ingress_security_rules.yaml.j2 dest=/tmp/instance_ingress_security_rules.yaml
+- name: create egress yaml body
+  template: src=./templates/egress_security_rules.yaml.j2 dest=/tmp/instance_egress_security_rules.yaml
+# Load the variables defined in the generated files
+- name: load the variables defined in the ingress rules yaml body
+  include_vars:
+    file: /tmp/instance_ingress_security_rules.yaml
+    name: loaded_ingress
+- name: print loaded_ingress
+  debug:
+    msg: "loaded ingress is {{loaded_ingress}}"
+- name: load the variables defined in the egress rules yaml body
+  include_vars:
+    file: /tmp/instance_egress_security_rules.yaml
+    name: loaded_egress
+- name: print loaded_egress
+  debug:
+    msg: "loaded egress is {{loaded_egress}}"
+- name: Create a security list for allowing access to public instance
+  oci_security_list:
+    name: "{{ securitylist_name }}"
+    compartment_id: "{{ instance_compartment }}"
+    vcn_id: '{{ vcn_id }}'
+    ingress_security_rules: "{{ loaded_ingress.instance_ingress_security_rules }}"
+    egress_security_rules:  "{{ loaded_egress.instance_egress_security_rules }}"
+  register: result
+- set_fact:
+    instance_security_list_ocid: "{{ result.security_list.id }}"
+
+- name: Create a subnet to host the public instance. Link security_list and route_table.
+  oci_subnet:
+    availability_domain: "{{ instance_ad }}"
+    cidr_block: "{{ subnet_cidr }}"
+    compartment_id: "{{ instance_compartment }}"
+    display_name: "{{ subnet_name }}"
+    prohibit_public_ip_on_vnic: false
+    route_table_id: "{{ rt_id }}"
+    security_list_ids: [ "{{ instance_security_list_ocid }}" ]
+    vcn_id: '{{ vcn_id }}'
+    dns_label: "{{ subnet_dns_label }}"
+  register: result
+- set_fact:
+    instance_subnet_id: "{{ result.subnet.id }}"

--- a/samples/compute/always_free_launch_compute_instance/teardown.yaml
+++ b/samples/compute/always_free_launch_compute_instance/teardown.yaml
@@ -1,0 +1,46 @@
+---
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+- name: Detach the block volume
+  oci_volume_attachment:
+    id: "{{volume_attachment_id}}"
+    state: absent
+
+- name: Terminate the block volume
+  oci_volume:
+    id: "{{volume_id}}"
+    state: absent
+
+- name: Terminate the instance
+  oci_instance:
+    id: "{{ instance_id }}"
+    state: absent
+
+- name: Delete the subnet
+  oci_subnet:
+    id: "{{ instance_subnet_id }}"
+    state: absent
+
+- name: Delete the security list
+  oci_security_list:
+    id: "{{ instance_security_list_ocid }}"
+    state: absent
+
+- name: Delete the route table
+  oci_route_table:
+    id: "{{ rt_id }}"
+    state: absent
+
+- name: Delete the Internet Gateway
+  oci_internet_gateway:
+    id: "{{ ig_id }}"
+    state: absent
+
+- name: Delete the VCN
+  oci_vcn:
+    vcn_id: "{{ vcn_id }}"
+    state: absent

--- a/samples/compute/always_free_launch_compute_instance/templates/egress_security_rules.yaml.j2
+++ b/samples/compute/always_free_launch_compute_instance/templates/egress_security_rules.yaml.j2
@@ -1,0 +1,15 @@
+---
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+instance_egress_security_rules:
+  # Allow ssh connections outside
+  - destination: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ SSH_port }}
+        max: {{ SSH_port }}
+

--- a/samples/compute/always_free_launch_compute_instance/templates/ingress_security_rules.yaml.j2
+++ b/samples/compute/always_free_launch_compute_instance/templates/ingress_security_rules.yaml.j2
@@ -1,0 +1,15 @@
+---
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+instance_ingress_security_rules:
+  # Allow incoming SSH connections
+  - source: "{{ quad_zero_route }}"
+    protocol: "{{ TCP_protocol }}"
+    tcp_options:
+      destination_port_range:
+        min: {{ SSH_port }}
+        max: {{ SSH_port }}
+

--- a/samples/compute/launch_compute_instance/sample.yaml
+++ b/samples/compute/launch_compute_instance/sample.yaml
@@ -43,6 +43,7 @@
     instance_ad: "{{ lookup('env', 'SAMPLE_AD_NAME') }}"
     instance_compartment: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
     # provide an "OL" image
+    # find OL image ocids per region here: https://docs.cloud.oracle.com/iaas/images/image/501c6e22-4dc6-4e99-b045-cae47aae343f/
     instance_image: "{{ lookup('env', 'SAMPLE_IMAGE_OCID') }}"
 
   tasks:

--- a/samples/database/always_free_autonomous_database/README.md
+++ b/samples/database/always_free_autonomous_database/README.md
@@ -1,0 +1,27 @@
+# Overview
+
+This sample shows how to create an Always Free [Autonomous Transaction Processing Database](https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/adbfreeoverview.htm). To explore more about
+Oracle Cloud Infrastructure's Autonomous Transaction Processing Cloud Service, please visit
+[here](https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/atpoverview.htm).
+
+The sample
+
+- sets up an Autonomous Transaction Processing Database.
+- List all the Autonomous Transaction Processing Databases available in the compartment filtered by display name.
+- Get facts of a specific database.
+- Stops and starts an Autonomous Transaction Processing Database.
+- Deletes an Autonomous Transaction Processing Database.
+
+# Instructions
+
+To run the sample, after ensuring that you have the pre-requisites for OCI
+ansible cloud modules, please provide values (that are specific to your tenancy)
+for the following variables in the `vars` section of `sample.yaml`:
+
+- compartment_ocid
+- admin_password
+
+Note: The sample, by default, sets up an Autonomous Transaction Processing Database, prints an information message,
+runs a few tests to show that it is working, and tears down the Autonomous Transaction Processing Database. If you want
+to experiment with the Autonomous Transaction Processing Database after it is setup, comment out the invocation
+to `teardown.yaml` at the end of `sample.yaml`.

--- a/samples/database/always_free_autonomous_database/sample.yaml
+++ b/samples/database/always_free_autonomous_database/sample.yaml
@@ -1,0 +1,116 @@
+---
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+- name: Autonomous Database usage example
+  hosts: localhost
+  connection: local
+  vars:
+    display_name: "always_free_adb"
+    db_name: "alwaysfreeadb" # (Maximum 14 alphanumeric characters)
+   
+    # the following settings are inherent to Always Free ADBs and cannot be scaled
+    data_storage_size_in_tbs: 1  # always free ADB will have 0.02 TB (20 GB) of storage but API requires value of >= 1 TB
+    cpu_core_count: 1
+
+    #########################################
+    # *Note* - Override the following variables based on your tenancy
+    # or set a valid value for the corresponding environment variable
+    # Please refer to module documentation for sample values for
+    # variables
+    #########################################
+    compartment_ocid: "{{ lookup('env', 'SAMPLE_COMPARTMENT_OCID') }}"
+    admin_password: "{{ lookup('env', 'SAMPLE_ADMIN_PASSWORD') }}" # sample value, admin_password: 'BEstr0ng_#11'
+
+  tasks:
+    - block:
+
+        - name: Check pre-requisites
+          fail:
+            msg: "Environment variable {{item}} not set. Please declare an environment variable with an appropriate value for the sample to work."
+          when: item not in ansible_env
+          with_items:
+            - "SAMPLE_COMPARTMENT_OCID"
+            - "SAMPLE_ADMIN_PASSWORD"
+
+        - name: Create a new Always Free Autonomous Database
+          oci_autonomous_database:
+              compartment_id: "{{ compartment_ocid }}"
+              cpu_core_count: "{{ cpu_core_count }}"
+              display_name: "{{ display_name }}"
+              admin_password: "{{ admin_password }}"
+              db_name: "{{ db_name }}"
+              data_storage_size_in_tbs: "{{ data_storage_size_in_tbs }}"
+              is_free_tier: true
+              state: 'present'
+          register: result
+
+        - set_fact:
+             autonomous_database_id: "{{ result.autonomous_database.id }}"
+
+        - assert:
+            that:
+              - result.autonomous_database.lifecycle_state == "AVAILABLE"
+
+    # List Autonomous Databases filtered by Display Name
+        - name: List All Autonomous Databases in a compartment, filtered by Display Name
+          oci_autonomous_database_facts:
+             compartment_id: "{{ compartment_ocid }}"
+             display_name: '{{ display_name }}'
+          register: result
+
+        - name: Assert that specified Autonomous Database is listed
+          assert:
+             that:
+                - result.autonomous_databases[0].display_name == display_name
+
+    # Stop Autonomous Databases
+        - name: Stop an Autonomous Database
+          oci_autonomous_database:
+             autonomous_database_id: "{{ autonomous_database_id }}"
+             state: 'stop'
+          register: result
+
+        - name: Assert that specified Autonomous Database is stopped
+          assert:
+             that:
+                - result.autonomous_database.lifecycle_state == 'STOPPED'
+
+    # Start Autonomous Databases
+        - name: Start Autonomous Database
+          oci_autonomous_database:
+             autonomous_database_id: "{{ autonomous_database_id }}"
+             state: 'start'
+          register: result
+
+        - name: Assert that specified Autonomous Database is started and available
+          assert:
+             that:
+                - result.autonomous_database.lifecycle_state == 'AVAILABLE'
+
+    # Get a specific Autonomous Database
+        - name: Get a specific Autonomous Database's facts
+          oci_autonomous_database_facts:
+             autonomous_database_id: "{{ autonomous_database_id }}"
+          register: result
+        - debug: # print facts retrieved about the Autonomous Database
+              msg: "{{result}}"
+        - name: Assert that specified Autonomous Database is listed
+          assert:
+             that:
+                - result.autonomous_databases[0].display_name == display_name
+
+        - import_tasks: teardown.yaml
+
+      rescue:
+
+        - import_tasks: teardown.yaml
+          ignore_errors: yes
+
+        - fail:
+            msg: "The sample execution failed."
+
+

--- a/samples/database/always_free_autonomous_database/teardown.yaml
+++ b/samples/database/always_free_autonomous_database/teardown.yaml
@@ -1,0 +1,19 @@
+---
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates.
+# This software is made available to you under the terms of the GPL 3.0 license or the Apache 2.0 license.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License v2.0
+# See LICENSE.TXT for details.
+
+# Delete Autonomous Database
+- name: Delete Autonomous Database
+  oci_autonomous_database:
+     autonomous_database_id: "{{ autonomous_database_id }}"
+     state: 'absent'
+  register: result
+
+- name: Assert that specified Autonomous Database is deleted
+  assert:
+         that:
+            - result.changed == True
+            - result.autonomous_database.display_name == display_name

--- a/samples/database/autonomous_database/README.md
+++ b/samples/database/autonomous_database/README.md
@@ -1,14 +1,15 @@
 # Overview
 
-This sample shows how to crete an Autonomous Transaction Processing Database. To explore more about
+This sample shows how to create an [Autonomous Transaction Processing Database](https://www.oracle.com/database/autonomous-transaction-processing.html). To explore more about
 Oracle Cloud Infrastructure's Autonomous Transaction Processing Cloud Service, please visit
 [here](https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/atpoverview.htm).
 
 The sample
+
 - sets up an Autonomous Transaction Processing Database.
 - List all the Autonomous Transaction Processing Databases available in the compartment filtered by display name.
 - Get facts of a specific database.
-- Stops and starts n Autonomous Transaction Processing Database.
+- Stops and starts an Autonomous Transaction Processing Database.
 - Deletes an Autonomous Transaction Processing Database.
 
 # Instructions
@@ -16,6 +17,7 @@ The sample
 To run the sample, after ensuring that you have the pre-requisites for OCI
 ansible cloud modules, please provide values (that are specific to your tenancy)
 for the following variables in the `vars` section of `sample.yaml`:
+
 - compartment_ocid
 - cpu_core_count
 - display_name

--- a/test/units/test_oci_common_utils.py
+++ b/test/units/test_oci_common_utils.py
@@ -42,19 +42,31 @@ def test_is_dict_subset_when_source_and_target_are_empty():
 def test_is_dict_subset_when_source_has_more_keys():
     s = {"key1": "val1"}
     t = {}
-    assert oci_common_utils.is_dict_subset(s, t) is True
+    assert oci_common_utils.is_dict_subset(s, t) is False
+    assert (
+        oci_common_utils.is_dict_subset(s, t, ignore_attr_if_not_in_target=True) is True
+    )
 
     s = {"key1": "val1", "key2": "val2"}
     t = {"key1": "val1"}
-    assert oci_common_utils.is_dict_subset(s, t) is True
+    assert oci_common_utils.is_dict_subset(s, t) is False
+    assert (
+        oci_common_utils.is_dict_subset(s, t, ignore_attr_if_not_in_target=True) is True
+    )
 
     s = {"key1": "val1", "key2": {"subkey1": "subval1", "subkey2": "subval2"}}
     t = {"key1": "val1", "key2": {"subkey1": "subval1"}}
-    assert oci_common_utils.is_dict_subset(s, t) is True
+    assert oci_common_utils.is_dict_subset(s, t) is False
+    assert (
+        oci_common_utils.is_dict_subset(s, t, ignore_attr_if_not_in_target=True) is True
+    )
 
     s = {"key1": "val1", "key2": {"subkey1": "subval1", "subkey3": "subval3"}}
     t = {"key1": "val1", "key2": {"subkey1": "subval1", "subkey2": "subval2"}}
-    assert oci_common_utils.is_dict_subset(s, t) is True
+    assert oci_common_utils.is_dict_subset(s, t) is False
+    assert (
+        oci_common_utils.is_dict_subset(s, t, ignore_attr_if_not_in_target=True) is True
+    )
 
 
 def test_is_dict_subset_when_source_has_less_keys():
@@ -229,7 +241,10 @@ def test_is_dict_subset_when_dicts_have_dict_values():
         "key1": "val1",
         "key2": {"subkey1": {"subkey2": "subval2"}, "subkey3": {"subkey4": "subval4"}},
     }
-    assert oci_common_utils.is_dict_subset(s, t) is True
+    assert oci_common_utils.is_dict_subset(s, t) is False
+    assert (
+        oci_common_utils.is_dict_subset(s, t, ignore_attr_if_not_in_target=True) is True
+    )
 
 
 def test_is_dict_subset_returns_False_when_dicts_are_different():
@@ -275,11 +290,17 @@ def test_are_dicts_equal_when_source_and_target_are_empty():
 def test_are_dicts_equal_when_source_has_more_keys():
     s = {"key1": "val1"}
     t = {}
-    assert oci_common_utils.are_dicts_equal(s, t) is True
+    assert oci_common_utils.are_dicts_equal(s, t) is False
+    assert (
+        oci_common_utils.is_dict_subset(s, t, ignore_attr_if_not_in_target=True) is True
+    )
 
     s = {"key1": "val1", "key2": "val2"}
     t = {"key1": "val1"}
-    assert oci_common_utils.are_dicts_equal(s, t) is True
+    assert oci_common_utils.are_dicts_equal(s, t) is False
+    assert (
+        oci_common_utils.is_dict_subset(s, t, ignore_attr_if_not_in_target=True) is True
+    )
 
     s = {"key1": "val1", "key2": {"subkey1": "subval1", "subkey2": "subval2"}}
     t = {"key1": "val1", "key2": {"subkey1": "subval1"}}

--- a/test/units/test_oci_instance.py
+++ b/test/units/test_oci_instance.py
@@ -210,7 +210,7 @@ def test_create_instance_source_via_image_when_boot_volume_size_in_gbs_is_passed
 
 
 def test_get_source_details_from_module_ignores_image_id_top_level_module_parameter_when_source_details_exists(
-    create_instance_source_via_image_patch
+    create_instance_source_via_image_patch,
 ):
     module = get_module(set_top_level_image_id=True)
     create_instance_source_via_image_patch.return_value = InstanceSourceViaImageDetails(
@@ -224,7 +224,7 @@ def test_get_source_details_from_module_ignores_image_id_top_level_module_parame
 
 
 def test_get_source_details_from_module_use_image_id_top_level_module_parameter_when_source_details_does_not_exist(
-    create_instance_source_via_image_patch
+    create_instance_source_via_image_patch,
 ):
     module = get_module(set_top_level_image_id=True)
     del module.params["source_details"]
@@ -239,7 +239,7 @@ def test_get_source_details_from_module_use_image_id_top_level_module_parameter_
 
 
 def test_get_source_details_from_module_when_image_id_is_passed_as_source_details(
-    create_instance_source_via_image_patch
+    create_instance_source_via_image_patch,
 ):
     module = get_module()
     create_instance_source_via_image_patch.return_value = InstanceSourceViaImageDetails(
@@ -253,7 +253,7 @@ def test_get_source_details_from_module_when_image_id_is_passed_as_source_detail
 
 
 def test_get_source_details_from_module_when_image_id_is_passed_as_source_details_with_boot_volume_size(
-    create_instance_source_via_image_patch
+    create_instance_source_via_image_patch,
 ):
     custom_boot_volume_size_in_gbs = 100
     module = get_module(custom_boot_volume_size_in_gbs=custom_boot_volume_size_in_gbs)
@@ -275,7 +275,7 @@ def test_get_source_details_from_module_when_image_id_is_passed_as_source_detail
 
 
 def test_get_source_details_from_module_fails_for_unknown_source_type(
-    create_instance_source_via_image_patch
+    create_instance_source_via_image_patch,
 ):
     module = get_module(source_type="unknownSourceType")
     create_instance_source_via_image_patch.return_value = None
@@ -285,7 +285,7 @@ def test_get_source_details_from_module_fails_for_unknown_source_type(
 
 
 def test_get_launch_instance_details_calls_get_source_details_from_module(
-    get_source_details_from_module_patch
+    get_source_details_from_module_patch,
 ):
     custom_boot_volume_size_in_gbs = 100
     module = get_module(custom_boot_volume_size_in_gbs=custom_boot_volume_size_in_gbs)


### PR DESCRIPTION
### Added
- Support for [Free Tier](https://www.oracle.com/cloud/free/) resources
  - Compute [sample](https://github.com/oracle/oci-ansible-modules/tree/master/samples/compute/always_free_launch_compute_instance)
  - Autonomous Database [sample](https://github.com/oracle/oci-ansible-modules/tree/master/samples/database/always_free_autonomous_database)
- Support for associating [Network Security Groups](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/networksecuritygroups.htm) with vnics
  - `oci_instance`
  - `oci_vnic`
  - `oci_vnic_attachment`
- Support for associating [Security Rules](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/securityrules.htm) with [Network Security Groups](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/networksecuritygroups.htm)
  - `oci_security_rule_actions`
  - `oci_security_rule_facts`
- Support for specifying device path for volume attachments
  - `oci_volume_attachment`

### Changed
   - Minimum supported OCI Python SDK to 2.5.0

Co-authored-by: Manoj Meda <manoj.meda@oracle.com>
Co-authored-by: Nabeel Al Saber <nabeel.al.saber@oracle.com>
Co-authored-by: Mike Ross <mike.c.ross@oracle.com>