### PR TITLE
New release of v1.14.0 of OCI Ansible Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2019-12-23
+
+### Added
+- db_workload parameter to oci_autonomous_database module
+  - Allows specifying whether to create an Autonomous Transaction Processing database or an Autonomous Data Warehouse
+
+### Fixed:
+- oci_db_home module patch apply error [issue](https://github.com/oracle/oci-ansible-modules/issues/89)
+- oci_db_system module update and patch apply error [issue](https://github.com/oracle/oci-ansible-modules/issues/86)
+
 ## [1.13.0] - 2019-12-12
 
 ### Added

--- a/docs/modules/oci_autonomous_database_module.rst
+++ b/docs/modules/oci_autonomous_database_module.rst
@@ -221,6 +221,23 @@ Parameters
             </tr>
                                 <tr>
                                                                 <td colspan="1">
+                    <b>db_workload</b>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>OLTP</li>
+                                                                                                                                                                                                <li>DW</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                                                        <div>The Autonomous Database workload type. OLTP indicates an Autonomous Transaction Processing database and DW indicates an Autonomous Data Warehouse. The default is OLTP.</div>
+                                                                                </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
                     <b>defined_tags</b>
                     <div style="font-size: small">
                         <span style="color: purple">dictionary</span>
@@ -570,7 +587,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                             <div>Attributes of the launched/updated Autonomous Database. For delete, deleted Autonomous Database description will be returned.</div>
                                         <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
-                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;lifecycle_state&#x27;: &#x27;AVAILABLE&#x27;, &#x27;display_name&#x27;: &#x27;ansible-autonomous-database-955&#x27;, &#x27;cpu_core_count&#x27;: 1, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;defined_tags&#x27;: {&#x27;ansible_tag_namespace_integration_test_1&#x27;: {&#x27;ansible_tag_1&#x27;: &#x27;initial&#x27;}}, &#x27;is_free_tier&#x27;: False, &#x27;freeform_tags&#x27;: {&#x27;system_license&#x27;: &#x27;trial&#x27;}, &#x27;time_created&#x27;: &#x27;2018-09-22T15:06:55.426000+00:00&#x27;, &#x27;db_name&#x27;: &#x27;autodbbackup&#x27;, &#x27;license_model&#x27;: &#x27;LICENSE_INCLUDED&#x27;, &#x27;connection_strings&#x27;: {&#x27;high&#x27;: &#x27;adwc.EXAMPLE1.oraclecloud.com:1522/EXAMPLE1_autodb_high.atp.oraclecloud.com&#x27;, &#x27;medium&#x27;: &#x27;adwc.EXAMPLE3.oraclecloud.com:1522/EXAMPLE3_autodb_medium.atp.oraclecloud.com&#x27;, &#x27;low&#x27;: &#x27;adwc.EXAMPLE2.oraclecloud.com:1522/EXAMPLE2_autodb_low.atp.oraclecloud.com&#x27;}, &#x27;lifecycle_details&#x27;: None, &#x27;data_storage_size_in_tbs&#x27;: 1, &#x27;id&#x27;: &#x27;ocid1.autonomousdatabase.oc1.iad.xxxxxEXAMPLExxxxx&#x27;, &#x27;service_console_url&#x27;: &#x27;https://example1.oraclecloud.com/console/index.html? tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx &amp;database_name=ANSIBLEAUTODB&amp;service_type=ATP&#x27;}</div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;is_free_tier&#x27;: False, &#x27;time_created&#x27;: &#x27;2018-09-22T15:06:55.426000+00:00&#x27;, &#x27;db_workload&#x27;: &#x27;DW&#x27;, &#x27;db_name&#x27;: &#x27;autodbbackup&#x27;, &#x27;license_model&#x27;: &#x27;LICENSE_INCLUDED&#x27;, &#x27;data_storage_size_in_tbs&#x27;: 1, &#x27;id&#x27;: &#x27;ocid1.autonomousdatabase.oc1.iad.xxxxxEXAMPLExxxxx&#x27;, &#x27;service_console_url&#x27;: &#x27;https://example1.oraclecloud.com/console/index.html? tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx &amp;database_name=ANSIBLEAUTODB&amp;service_type=ATP&#x27;, &#x27;lifecycle_state&#x27;: &#x27;AVAILABLE&#x27;, &#x27;display_name&#x27;: &#x27;ansible-autonomous-database-955&#x27;, &#x27;compartment_id&#x27;: &#x27;ocid1.compartment.oc1..xxxxxEXAMPLExxxxx&#x27;, &#x27;defined_tags&#x27;: {&#x27;ansible_tag_namespace_integration_test_1&#x27;: {&#x27;ansible_tag_1&#x27;: &#x27;initial&#x27;}}, &#x27;freeform_tags&#x27;: {&#x27;system_license&#x27;: &#x27;trial&#x27;}, &#x27;cpu_core_count&#x27;: 1, &#x27;connection_strings&#x27;: {&#x27;high&#x27;: &#x27;adwc.EXAMPLE1.oraclecloud.com:1522/EXAMPLE1_autodb_high.atp.oraclecloud.com&#x27;, &#x27;medium&#x27;: &#x27;adwc.EXAMPLE3.oraclecloud.com:1522/EXAMPLE3_autodb_medium.atp.oraclecloud.com&#x27;, &#x27;low&#x27;: &#x27;adwc.EXAMPLE2.oraclecloud.com:1522/EXAMPLE2_autodb_low.atp.oraclecloud.com&#x27;}, &#x27;lifecycle_details&#x27;: None}</div>
                                     </td>
             </tr>
                                                             <tr>
@@ -641,6 +658,20 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                                         <br/>
                                             <div style="font-size: smaller"><b>Sample:</b></div>
                                                 <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ansibleautodb</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <b>db_workload</b>
+                    <div style="font-size: small; color: purple">string</div>
+                                    </td>
+                <td>on success</td>
+                <td>
+                                                                        <div>The Autonomous Database workload type.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">OLTP</div>
                                     </td>
             </tr>
                                 <tr>

--- a/docs/modules/oci_security_rule_actions_module.rst
+++ b/docs/modules/oci_security_rule_actions_module.rst
@@ -681,8 +681,8 @@ Examples
           direction: INGRESS
           protocol: all
         - description: Example egress security rule
-          source_type: CIDR_BLOCK
-          source: 10.0.0.0/16
+          destination_type: CIDR_BLOCK
+          destination: 10.0.0.0/16
           direction: EGRESS
           protocol: all
         action: add_network_security_group_security_rules
@@ -706,10 +706,10 @@ Examples
           direction: INGRESS
           protocol: all
         - description: Example egress security rule - updated
-          id: 880233
-          source_type: CIDR_BLOCK
-          source: 10.0.0.0/24
+          destination_type: CIDR_BLOCK
+          destination: 10.0.0.0/24
           direction: EGRESS
+          id: 880233
           protocol: all
         action: update_network_security_group_security_rules
 

--- a/inventory-script/oci_inventory.py
+++ b/inventory-script/oci_inventory.py
@@ -226,7 +226,7 @@ try:
 except ImportError:
     HAS_OCI_PY_SDK = False
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"
 inventory_agent_name = "Oracle-Ansible-Inv/"
 
 

--- a/library/oci_autonomous_database.py
+++ b/library/oci_autonomous_database.py
@@ -80,6 +80,13 @@ options:
                      Autonomous Databases have 1 CPU and 20GB of memory. For Always Free databases, memory and CPU
                      cannot be scaled.
         required: false
+    db_workload:
+        description:
+            - The Autonomous Database workload type. OLTP indicates an Autonomous Transaction Processing database and
+              DW indicates an Autonomous Data Warehouse. The default is OLTP.
+        choices:
+            - "OLTP"
+            - "DW"
     force:
         description: Force overwriting existing wallet file when downloading wallet.
         required: false
@@ -242,6 +249,12 @@ RETURN = """
                 returned: always
                 type: bool
                 sample: false
+            db_workload:
+                description:
+                    - The Autonomous Database workload type.
+                returned: on success
+                type: string
+                sample: OLTP
 
         sample: {
                   "compartment_id":"ocid1.compartment.oc1..xxxxxEXAMPLExxxxx",
@@ -270,7 +283,8 @@ RETURN = """
                         tenant_name=OCID1.TENANCY.OC1..xxxxxEXAMPLExxxxx
                         &database_name=ANSIBLEAUTODB&service_type=ATP",
                   "time_created":"2018-09-22T15:06:55.426000+00:00",
-                  "is_free_tier": false
+                  "is_free_tier": false,
+                  "db_workload": "DW"
               }
 """
 
@@ -312,6 +326,7 @@ def create_or_update_autonomous_database(db_client, module):
                 kwargs_list={"compartment_id": module.params.get("compartment_id")},
                 module=module,
                 model=CreateAutonomousDatabaseDetails(),
+                default_attribute_values={"db_workload": "OLTP"},
             )
     except ServiceError as ex:
         get_logger().error(
@@ -536,6 +551,7 @@ def main():
             timestamp=dict(type="str", required=False),
             wallet_file=dict(type="str", required=False),
             is_free_tier=dict(type="bool", required=False),
+            db_workload=dict(type="str", choices=["OLTP", "DW"]),
             force=dict(
                 type="bool", required=False, default=True, aliases=["overwrite"]
             ),

--- a/library/oci_db_system.py
+++ b/library/oci_db_system.py
@@ -673,20 +673,21 @@ def update_db_system(db_client, module, db_system_id):
         raise ClientError(
             Exception("No DB System with id " + db_system_id + " is found for update")
         )
-    primitive_attributes = [
-        "cpu_core_count",
-        "data_storage_size_in_gbs",
-        "freeform_tags",
-        "defined_tags",
-    ]
+
     existing_ssh_public_keys = db_system.ssh_public_keys
     last_patch_history_entry_id = db_system.last_patch_history_entry_id
     purge_ssh_public_keys = module.params.get("purge_ssh_public_keys")
     delete_ssh_public_keys = module.params.get("delete_ssh_public_keys")
     update_db_system_details = UpdateDbSystemDetails()
 
+    primitive_attributes = [
+        "cpu_core_count",
+        "data_storage_size_in_gbs",
+        "freeform_tags",
+        "defined_tags",
+    ]
     for attribute in primitive_attributes:
-        changed = oci_utils.check_and_update_attributes(
+        changed = oci_utils.check_and_update_attributes_if_changed(
             update_db_system_details,
             attribute,
             module.params.get(attribute, None),

--- a/library/oci_security_rule_actions.py
+++ b/library/oci_security_rule_actions.py
@@ -250,8 +250,8 @@ EXAMPLES = """
       direction: INGRESS
       protocol: all
     - description: Example egress security rule
-      source_type: CIDR_BLOCK
-      source: 10.0.0.0/16
+      destination_type: CIDR_BLOCK
+      destination: 10.0.0.0/16
       direction: EGRESS
       protocol: all
     action: add_network_security_group_security_rules
@@ -275,10 +275,10 @@ EXAMPLES = """
       direction: INGRESS
       protocol: all
     - description: Example egress security rule - updated
-      id: 880233
-      source_type: CIDR_BLOCK
-      source: 10.0.0.0/24
+      destination_type: CIDR_BLOCK
+      destination: 10.0.0.0/24
       direction: EGRESS
+      id: 880233
       protocol: all
     action: update_network_security_group_security_rules
 

--- a/module_utils/oracle/oci_common_utils.py
+++ b/module_utils/oracle/oci_common_utils.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     HAS_OCI_PY_SDK = False
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"
 MAX_WAIT_TIMEOUT_IN_SECONDS = 1200
 DEAD_STATES = [
     "TERMINATING",

--- a/module_utils/oracle/oci_db_utils.py
+++ b/module_utils/oracle/oci_db_utils.py
@@ -48,17 +48,19 @@ def is_version_changed(
         patch_details = get_patch_details_from_version(input_version_dict)
         return True, patch_details
     else:
-        input_action = input_version_dict.get("action")
-        if (
-            not (
-                last_patch_history.action == "APPLY"
-                and last_patch_history.lifecycle_state == "SUCCEEDED"
-            )
-            and last_patch_history.action != input_action
-            or last_patch_history.lifecycle_state != "SUCCEEDED"
-        ):
-            patch_details = get_patch_details_from_version(input_version_dict)
-            return True, patch_details
+        # Don't check history, depend on server error
+        # This will cause errors if running the precheck after success
+        # input_action = input_version_dict.get("action")
+        # if (
+        #     not (
+        #         last_patch_history.action == "APPLY"
+        #         and last_patch_history.lifecycle_state == "SUCCEEDED"
+        #     )
+        #     and last_patch_history.action != input_action
+        #     or last_patch_history.lifecycle_state != "SUCCEEDED"
+        # ):
+        patch_details = get_patch_details_from_version(input_version_dict)
+        return True, patch_details
 
     return version_changed, patch_details
 

--- a/module_utils/oracle/oci_utils.py
+++ b/module_utils/oracle/oci_utils.py
@@ -277,6 +277,19 @@ def check_and_update_attributes(
     return changed
 
 
+def check_and_update_attributes_if_changed(
+    target_instance, attr_name, input_value, existing_value, changed
+):
+    """
+    This function checks the difference between two resource attributes of literal types and sets the attribute
+    value in the target instance type holding the attribute if the value changed.
+    """
+    if input_value is not None and not eq(input_value, existing_value):
+        changed = True
+        target_instance.__setattr__(attr_name, input_value)
+    return changed
+
+
 def check_and_update_resource(
     resource_type,
     get_fn,


### PR DESCRIPTION
### Added
- db_workload parameter to oci_autonomous_database module
  - Allows specifying whether to create an Autonomous Transaction Processing database or an Autonomous Data Warehouse

### Fixed
- oci_db_home module patch apply error [issue](https://github.com/oracle/oci-ansible-modules/issues/89)
- oci_db_system module update and patch apply error [issue](https://github.com/oracle/oci-ansible-modules/issues/86)